### PR TITLE
feat: anomic-aphasia-friendly command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ See [docs/TUI.md](docs/TUI.md) for the full reference — overlays, PR browser, 
 | `grove last` | Toggle to previous worktree |
 | `grove rm <name>` | Remove worktree, kill tmux session, delete branch |
 | `grove open <name>` | Open a session in any worktree (create if needed) |
-| `grove attach [name]` | Attach to a tmux session without changing directory |
+| `grove join [name]` | Join a tmux session without changing directory |
 
 ### GitHub integration
 
@@ -260,11 +260,11 @@ Requires `gh` CLI (installed and authenticated to your repo).
 | Command | What it does |
 |---------|-------------|
 | `grove fork <name>` | Fork current worktree into a new one (optionally move or copy WIP) |
-| `grove compare <name>` | Diff current worktree against another |
-| `grove apply <name>` | Cherry-pick commits or apply WIP from another worktree |
+| `grove diff <name>` | Diff current worktree against another |
+| `grove graft <name>` | Cherry-pick commits or graft WIP from another worktree |
 | `grove sync [name]` | Fast-forward a worktree from its remote |
 | `grove test <name> [args]` | Run your test command in any worktree without switching |
-| `grove clean` | Remove worktrees not accessed in N days (default: 30) |
+| `grove trim` | Trim worktrees not accessed in N days (default: 30) |
 
 ### Docker
 
@@ -273,7 +273,7 @@ Requires `gh` CLI (installed and authenticated to your repo).
 | `grove up` | Start Docker containers for the current worktree |
 | `grove down` | Stop Docker containers |
 | `grove logs [service]` | Tail container logs |
-| `grove restart [service]` | Restart containers |
+| `grove kick [service]` | Kick (restart) containers |
 | `grove up --isolated` | Start an isolated Docker stack (for parallel agent use) |
 | `grove ps` | Show active stacks with ports and reference IDs |
 

--- a/cmd/grove/commands/apply.go
+++ b/cmd/grove/commands/apply.go
@@ -42,20 +42,21 @@ type CommitInfo struct {
 }
 
 var applyCmd = &cobra.Command{
-	Use:   "apply <name>",
-	Short: "Apply changes from another worktree",
-	Long: `Apply commits or uncommitted changes from another worktree to the current one.
+	Use:     "graft <name>",
+	Aliases: []string{"apply", "g"},
+	Short:   "Graft changes from another worktree",
+	Long: `Graft commits or uncommitted changes from another worktree to the current one.
 
-By default, applies both committed and uncommitted changes from the source worktree.
-Use --commits or --wip to apply only one type of change.
-Use --pick to apply specific commits by SHA.
+By default, grafts both committed and uncommitted changes from the source worktree.
+Use --commits or --wip to graft only one type of change.
+Use --pick to graft specific commits by SHA.
 
 Examples:
-  grove apply feature-auth           # Apply all changes from feature-auth
-  grove apply feature-auth --commits # Apply only commits (cherry-pick)
-  grove apply feature-auth --wip     # Apply only uncommitted changes
-  grove apply feature-auth --pick abc123,def456  # Apply specific commits
-  grove apply feature-auth --dry-run # Show what would be applied`,
+  grove graft feature-auth           # Graft all changes from feature-auth
+  grove graft feature-auth --commits # Graft only commits (cherry-pick)
+  grove graft feature-auth --wip     # Graft only uncommitted changes
+  grove graft feature-auth --pick abc123,def456  # Graft specific commits
+  grove graft feature-auth --dry-run # Show what would be grafted`,
 	Args: cobra.ExactArgs(1),
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		sourceName := args[0]
@@ -360,7 +361,7 @@ func applyWIPChanges(w, stderr *cli.Writer, targetPath, sourcePath string, dryRu
 			cli.Error(stderr, "Failed to apply uncommitted changes")
 			_, _ = fmt.Fprintf(stderr, "%v\n", err)
 			cli.Faint(stderr, "The patch may have conflicts with your current changes.")
-			cli.Faint(stderr, "Resolve manually or try 'grove compare' to see differences first.")
+			cli.Faint(stderr, "Resolve manually or try 'grove diff' to see differences first.")
 		}
 		return wipFiles, fmt.Errorf("failed to apply WIP patch")
 	}

--- a/cmd/grove/commands/attach.go
+++ b/cmd/grove/commands/attach.go
@@ -16,10 +16,10 @@ import (
 var attachJSON bool
 
 var attachCmd = &cobra.Command{
-	Use:     "attach [name]",
-	Aliases: []string{"a"},
-	Short:   "Attach to a tmux session for a worktree",
-	Long: `Attach to or create a tmux session for a worktree without changing the
+	Use:     "join [name]",
+	Aliases: []string{"attach", "a", "j"},
+	Short:   "Join a tmux session for a worktree",
+	Long: `Join (attach to) or create a tmux session for a worktree without changing the
 current shell directory. If no name is given, uses the current worktree.
 
 This is a tmux-only command — it does not emit cd: directives.`,

--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -35,9 +35,10 @@ type CleanCandidate struct {
 }
 
 var cleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Remove old unused worktrees",
-	Long: `Remove worktrees that haven't been accessed recently.
+	Use:     "trim",
+	Aliases: []string{"clean", "tm"},
+	Short:   "Trim old unused worktrees",
+	Long: `Trim worktrees that haven't been accessed recently.
 
 By default, targets worktrees not accessed in 30 days.
 Dirty worktrees are excluded unless --include-dirty is specified.
@@ -52,12 +53,12 @@ Always excludes:
 This command ALWAYS prompts for confirmation, even in non-interactive mode.
 
 Examples:
-  grove clean                      # Clean worktrees older than 30 days
-  grove clean --older-than 7       # Clean worktrees older than 7 days
-  grove clean --include-dirty      # Include dirty worktrees
-  grove clean --delete-branches    # Delete branches without prompting
-  grove clean --keep-branches      # Keep all branches
-  grove clean --dry-run            # Show what would be cleaned`,
+  grove trim                      # Trim worktrees older than 30 days
+  grove trim --older-than 7       # Trim worktrees older than 7 days
+  grove trim --include-dirty      # Include dirty worktrees
+  grove trim --delete-branches    # Delete branches without prompting
+  grove trim --keep-branches      # Keep all branches
+  grove trim --dry-run            # Show what would be trimmed`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		w := cli.NewStdout()
 

--- a/cmd/grove/commands/compare.go
+++ b/cmd/grove/commands/compare.go
@@ -50,19 +50,20 @@ type DiffStats struct {
 }
 
 var compareCmd = &cobra.Command{
-	Use:   "compare <name>",
-	Short: "Compare current worktree with another",
-	Long: `Compare the current worktree with another worktree.
+	Use:     "diff <name>",
+	Aliases: []string{"compare", "d"},
+	Short:   "Diff current worktree against another",
+	Long: `Diff the current worktree against another worktree.
 
 Shows differences in commits and optionally uncommitted changes (WIP).
 By default shows both committed and uncommitted differences.
 
 Examples:
-  grove compare main           # Compare with main worktree
-  grove compare feature --stat # Show only diffstat
-  grove compare main --committed  # Show only commit differences
-  grove compare main --wip     # Show only uncommitted differences
-  grove compare main --json    # Output as JSON`,
+  grove diff main           # Diff against main worktree
+  grove diff feature --stat # Show only diffstat
+  grove diff main --committed  # Show only commit differences
+  grove diff main --wip     # Show only uncommitted differences
+  grove diff main --json    # Output as JSON`,
 	Args: cobra.ExactArgs(1),
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		targetName := args[0]

--- a/cmd/grove/commands/down.go
+++ b/cmd/grove/commands/down.go
@@ -15,8 +15,9 @@ func init() {
 }
 
 var downCmd = &cobra.Command{
-	Use:   "down",
-	Short: "Stop containers for current worktree",
+	Use:     "down",
+	Aliases: []string{"do"},
+	Short:   "Stop containers for current worktree",
 	Long: `Stop Docker containers for the current worktree.
 
 This command looks for a docker-compose.yml file in the current directory

--- a/cmd/grove/commands/fetch.go
+++ b/cmd/grove/commands/fetch.go
@@ -142,8 +142,9 @@ func fetchItem(ctx *GroveContext, itemType string, number int) error {
 }
 
 var fetchCmd = &cobra.Command{
-	Use:   "fetch <pr|issue>/<number>",
-	Short: "Create worktree from issue or PR",
+	Use:     "fetch <pr|issue>/<number>",
+	Aliases: []string{"f"},
+	Short:   "Create worktree from issue or PR",
 	Long: `Create a new worktree from a GitHub issue or pull request.
 
 Examples:

--- a/cmd/grove/commands/fork.go
+++ b/cmd/grove/commands/fork.go
@@ -41,7 +41,7 @@ type ForkResult struct {
 
 var forkCmd = &cobra.Command{
 	Use:     "fork <name>",
-	Aliases: []string{"split"},
+	Aliases: []string{"split", "fo"},
 	Short:   "Fork current worktree into a new one",
 	Long: `Fork the current worktree, creating a new worktree branching from the current HEAD.
 

--- a/cmd/grove/commands/here.go
+++ b/cmd/grove/commands/here.go
@@ -54,9 +54,10 @@ type tmuxInfo struct {
 }
 
 var hereCmd = &cobra.Command{
-	Use:   "here",
-	Short: "Show current worktree information",
-	Long:  `Display information about the current worktree including name, branch, and status.`,
+	Use:     "here",
+	Aliases: []string{"h"},
+	Short:   "Show current worktree information",
+	Long:    `Display information about the current worktree including name, branch, and status.`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		mgr, err := worktree.NewManager(ctx.ProjectRoot)
 		if err != nil {

--- a/cmd/grove/commands/last.go
+++ b/cmd/grove/commands/last.go
@@ -17,9 +17,10 @@ import (
 var lastJSON bool
 
 var lastCmd = &cobra.Command{
-	Use:   "last",
-	Short: "Switch to the previous worktree",
-	Long:  `Switch to the last worktree you were working in.`,
+	Use:     "last",
+	Aliases: []string{"la"},
+	Short:   "Switch to the previous worktree",
+	Long:    `Switch to the last worktree you were working in.`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		stderr := cli.NewStderr()
 

--- a/cmd/grove/commands/logs.go
+++ b/cmd/grove/commands/logs.go
@@ -19,8 +19,9 @@ func init() {
 }
 
 var logsCmd = &cobra.Command{
-	Use:   "logs [service]",
-	Short: "View container logs",
+	Use:     "logs [service]",
+	Aliases: []string{"lo"},
+	Short:   "View container logs",
 	Long: `View logs from Docker containers for the current worktree.
 
 If no service is specified, shows logs from all services.

--- a/cmd/grove/commands/ls.go
+++ b/cmd/grove/commands/ls.go
@@ -50,7 +50,7 @@ type lsOutput struct {
 
 var lsCmd = &cobra.Command{
 	Use:     "ls",
-	Aliases: []string{"list"},
+	Aliases: []string{"list", "l"},
 	Short:   "List all worktrees",
 	Long:    `List all git worktrees with their status (clean/dirty) and branch information.`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -28,7 +28,7 @@ var (
 
 var newCmd = &cobra.Command{
 	Use:     "new <name>",
-	Aliases: []string{"spawn"},
+	Aliases: []string{"spawn", "n"},
 	Short:   "Create a new worktree and tmux session",
 	Long: `Create a new git worktree with the specified name and create a tmux session for it.
 

--- a/cmd/grove/commands/open.go
+++ b/cmd/grove/commands/open.go
@@ -31,8 +31,9 @@ func init() {
 }
 
 var openCmd = &cobra.Command{
-	Use:   "open <name>",
-	Short: "Open a worktree session (create if needed)",
+	Use:     "open <name>",
+	Aliases: []string{"o"},
+	Short:   "Open a worktree session (create if needed)",
 	Long: `Open a worktree by creating it if needed, ensuring a tmux session exists,
 launching the configured session command, and attaching.
 

--- a/cmd/grove/commands/restart.go
+++ b/cmd/grove/commands/restart.go
@@ -15,9 +15,10 @@ func init() {
 }
 
 var restartCmd = &cobra.Command{
-	Use:   "restart [service]",
-	Short: "Restart container services",
-	Long: `Restart Docker container services for the current worktree.
+	Use:     "kick [service]",
+	Aliases: []string{"restart", "k"},
+	Short:   "Kick (restart) container services",
+	Long: `Kick (restart) Docker container services for the current worktree.
 
 If no service is specified, restarts all services.
 
@@ -25,9 +26,9 @@ If the worktree has an isolated stack running, the restart targets
 that stack's containers automatically.
 
 Examples:
-  grove restart        # Restart all services
-  grove restart web    # Restart 'web' service only
-  w restart db         # Using alias`,
+  grove kick           # Restart all services
+  grove kick web       # Restart 'web' service only
+  w kick db            # Using alias`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		w := cli.NewStdout()
 

--- a/cmd/grove/commands/sync.go
+++ b/cmd/grove/commands/sync.go
@@ -44,8 +44,9 @@ type SkippedSync struct {
 }
 
 var syncCmd = &cobra.Command{
-	Use:   "sync [name]",
-	Short: "Sync environment worktrees with their mirrors",
+	Use:     "sync [name]",
+	Aliases: []string{"s"},
+	Short:   "Sync environment worktrees with their mirrors",
 	Long: `Sync environment worktrees with their remote tracking branches.
 
 Environment worktrees (created with --mirror) track a remote branch.

--- a/cmd/grove/commands/test.go
+++ b/cmd/grove/commands/test.go
@@ -13,8 +13,9 @@ import (
 )
 
 var testCmd = &cobra.Command{
-	Use:   "test <name> [args...]",
-	Short: "Run the configured test command in a worktree",
+	Use:     "test <name> [args...]",
+	Aliases: []string{"tt"},
+	Short:   "Run the configured test command in a worktree",
 	Long: `Run the configured test command in a specified worktree's directory.
 
 The test command is configured in .grove/config.toml:

--- a/cmd/grove/commands/to.go
+++ b/cmd/grove/commands/to.go
@@ -22,7 +22,7 @@ var (
 
 var toCmd = &cobra.Command{
 	Use:     "to <name>",
-	Aliases: []string{"switch"},
+	Aliases: []string{"switch", "t"},
 	Short:   "Switch to a worktree",
 	Long: `Switch to a worktree by name. If a tmux session exists for the worktree, switch to it.
 If no tmux session exists, create one.

--- a/cmd/grove/commands/up.go
+++ b/cmd/grove/commands/up.go
@@ -22,8 +22,9 @@ func init() {
 }
 
 var upCmd = &cobra.Command{
-	Use:   "up",
-	Short: "Start containers for current worktree",
+	Use:     "up",
+	Aliases: []string{"u"},
+	Short:   "Start containers for current worktree",
 	Long: `Start Docker containers for the current worktree.
 
 This command looks for a docker-compose.yml file in the current directory

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -28,19 +28,19 @@ This document provides exhaustive specifications for each grove command. Every b
    - [grove up](#grove-up)
    - [grove down](#grove-down)
    - [grove logs](#grove-logs)
-   - [grove restart](#grove-restart)
+   - [grove kick](#grove-kick)
    - [grove ps](#grove-ps)
 6. [Worktree Flow Commands](#worktree-flow-commands)
    - [grove fork](#grove-fork)
    - [grove sync](#grove-sync)
-   - [grove compare](#grove-compare)
-   - [grove apply](#grove-apply)
+   - [grove diff](#grove-diff)
+   - [grove graft](#grove-graft)
    - [grove test](#grove-test)
 7. [Utility Commands](#utility-commands)
    - [grove config](#grove-config)
    - [grove init](#grove-init)
    - [grove repair](#grove-repair)
-   - [grove clean](#grove-clean)
+   - [grove trim](#grove-trim)
    - [grove doctor](#grove-doctor)
 8. [Exit Codes](#exit-codes)
 9. [Output Formatting](#output-formatting)
@@ -1253,13 +1253,13 @@ Pass through to `docker compose logs` with appropriate project name.
 
 ---
 
-### grove restart
+### grove kick
 
-**Purpose:** Restart Docker containers.
+**Purpose:** Kick (restart) Docker containers. Aliases: `restart`, `k`.
 
 **Usage:**
 ```
-grove restart [services...] [flags]
+grove kick [services...] [flags]
 
 Arguments:
   services    Services to restart (default: all)
@@ -1516,16 +1516,16 @@ Flags:
 
 ---
 
-### grove compare
+### grove diff
 
-**Purpose:** Compare the current worktree with another, showing commit and WIP differences.
+**Purpose:** Diff the current worktree against another, showing commit and WIP differences. Aliases: `compare`, `d`.
 
 **Usage:**
 ```
-grove compare <name> [flags]
+grove diff <name> [flags]
 
 Arguments:
-  name    Target worktree to compare against (required)
+  name    Target worktree to diff against (required)
 
 Flags:
       --stat        Show diffstat summary
@@ -1609,16 +1609,16 @@ No differences found
 
 ---
 
-### grove apply
+### grove graft
 
-**Purpose:** Apply commits or uncommitted changes from another worktree to the current one.
+**Purpose:** Graft commits or uncommitted changes from another worktree to the current one. Aliases: `apply`, `g`.
 
 **Usage:**
 ```
-grove apply <name> [flags]
+grove graft <name> [flags]
 
 Arguments:
-  name    Source worktree to apply changes from (required)
+  name    Source worktree to graft changes from (required)
 
 Flags:
       --commits         Apply only committed changes (cherry-pick)
@@ -1942,13 +1942,13 @@ Repaired 1 issue.
 
 ---
 
-### grove clean
+### grove trim
 
-**Purpose:** Remove worktrees that haven't been accessed recently.
+**Purpose:** Trim worktrees that haven't been accessed recently. Aliases: `clean`, `tm`.
 
 **Usage:**
 ```
-grove clean [flags]
+grove trim [flags]
 
 Flags:
       --older-than N      Remove worktrees not accessed in N days (default: 30)

--- a/docs/SHELL_INTEGRATION.md
+++ b/docs/SHELL_INTEGRATION.md
@@ -58,9 +58,9 @@ Running `eval "$(grove install <shell>)"` installs three things:
 
 The wrapper uses a **directives protocol** — the grove binary writes special lines to stdout that the shell function intercepts and acts on.
 
-### Directive Commands (`grove to`, `grove last`, `grove fork`, `grove fetch`, `grove attach`, `grove open`, `grove up`, `grove run`, `grove restart`)
+### Directive Commands (`grove to`, `grove last`, `grove fork`, `grove fetch`, `grove join`, `grove open`, `grove up`, `grove run`, `grove kick`)
 
-These commands can emit `cd:`, `tmux-attach:`, `tmux-attach-cc:`, or `env:` directives. The wrapper captures their stdout (stderr passes through to the terminal), scans it line-by-line, separates directives from normal output, and then:
+These commands (and their aliases) can emit `cd:`, `tmux-attach:`, `tmux-attach-cc:`, or `env:` directives. The wrapper captures their stdout (stderr passes through to the terminal), scans it line-by-line, separates directives from normal output, and then:
 
 1. Exports any environment variables
 2. Executes any directory change

--- a/internal/shell/templates/grove.bash
+++ b/internal/shell/templates/grove.bash
@@ -16,7 +16,7 @@ grove() {
     # Only directive-producing commands need output capture.
     # All other commands run directly for streaming support.
     case "$1" in
-        to|last|fork|fetch|attach|open|up|run|restart)
+        to|t|switch|last|la|fork|fo|split|fetch|f|attach|join|a|j|open|o|up|u|run|kick|k|restart)
             # Capture output and parse for cd:/tmux-attach:/env: directives
             local output exit_code
             output=$(GROVE_SHELL=1 GROVE_SHELL_VERSION="$__GROVE_SHELL_VERSION" "$__GROVE_BIN" "$@")
@@ -89,7 +89,7 @@ _grove_completion() {
         cword=$COMP_CWORD
     fi
 
-    local commands="ls new to rm here last fork compare apply sync clean repair init setup fetch attach open issues prs up down logs restart test which config doctor ps agent-status version install"
+    local commands="ls l new n to t rm here h last la fork fo diff d graft g sync s trim tm repair init setup join j fetch f open o issues prs up u down do logs lo kick k test tt which config doctor ps agent-status version install"
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -97,7 +97,7 @@ _grove_completion() {
     fi
 
     case "${words[1]}" in
-        to|rm|compare|sync|test|apply|attach|open)
+        to|t|switch|rm|diff|d|compare|sync|s|test|tt|graft|g|apply|join|j|attach|a|open|o)
             # Complete with worktree short names (using grove ls -q for consistency)
             local worktrees=$(GROVE_SHELL=1 "$__GROVE_BIN" ls -q 2>/dev/null)
             COMPREPLY=($(compgen -W "$worktrees" -- "$cur"))

--- a/internal/shell/templates/grove.zsh
+++ b/internal/shell/templates/grove.zsh
@@ -16,7 +16,7 @@ grove() {
     # Only directive-producing commands need output capture.
     # All other commands run directly for streaming support.
     case "$1" in
-        to|last|fork|fetch|attach|open|up|run|restart)
+        to|t|switch|last|la|fork|fo|split|fetch|f|attach|join|a|j|open|o|up|u|run|kick|k|restart)
             # Capture output and parse for cd:/tmux-attach:/env: directives
             local output exit_code
             output=$(GROVE_SHELL=1 GROVE_SHELL_VERSION="$__GROVE_SHELL_VERSION" "$__GROVE_BIN" "$@")
@@ -84,32 +84,50 @@ _grove_completion() {
     local -a commands
     commands=(
         'ls:List all worktrees'
+        'l:List all worktrees (alias)'
         'new:Create a new worktree'
+        'n:Create a new worktree (alias)'
         'to:Switch to a worktree'
+        't:Switch to a worktree (alias)'
         'rm:Remove a worktree'
         'here:Show current worktree'
+        'h:Show current worktree (alias)'
         'last:Switch to previous worktree'
+        'la:Switch to previous worktree (alias)'
         'fork:Fork current worktree'
-        'compare:Compare worktrees'
-        'apply:Apply changes from another worktree'
+        'fo:Fork current worktree (alias)'
+        'diff:Diff worktrees'
+        'd:Diff worktrees (alias)'
+        'graft:Graft changes from another worktree'
+        'g:Graft changes (alias)'
         'sync:Sync environment worktrees'
-        'clean:Remove old unused worktrees'
+        's:Sync environment worktrees (alias)'
+        'trim:Trim old unused worktrees'
+        'tm:Trim old unused worktrees (alias)'
         'repair:Repair state inconsistencies'
         'init:Initialize grove project'
         'setup:Set up shell integration'
-        'attach:Attach to tmux session for a worktree'
+        'join:Join tmux session for a worktree'
+        'j:Join tmux session (alias)'
         'fetch:Create worktree from issue/PR'
+        'f:Create worktree from issue/PR (alias)'
         'issues:Browse GitHub issues'
         'prs:Browse GitHub PRs'
         'up:Start Docker containers'
+        'u:Start Docker containers (alias)'
         'down:Stop Docker containers'
+        'do:Stop Docker containers (alias)'
         'logs:View Docker logs'
-        'restart:Restart Docker containers'
+        'lo:View Docker logs (alias)'
+        'kick:Kick (restart) Docker containers'
+        'k:Kick Docker containers (alias)'
         'test:Run tests in a worktree'
+        'tt:Run tests (alias)'
         'which:Show current worktree and service status'
         'config:Show configuration'
         'doctor:Check system health and configuration'
         'open:Open a worktree session'
+        'o:Open a worktree session (alias)'
         'ps:Show active stacks'
         'agent-status:Show active isolated stacks'
         'version:Show version'
@@ -120,7 +138,7 @@ _grove_completion() {
         _describe 'command' commands
     elif (( CURRENT == 3 )); then
         case "${words[2]}" in
-            to|rm|compare|sync|test|apply|attach|open)
+            to|t|switch|rm|diff|d|compare|sync|s|test|tt|graft|g|apply|join|j|attach|a|open|o)
                 _describe 'worktree' worktrees
                 ;;
             install)


### PR DESCRIPTION
## Summary

- **5 command renames** to more retrievable words (old names kept as backward-compatible aliases):
  `compare→diff`, `apply→graft`, `clean→trim`, `restart→kick`, `attach→join`
- **19 short aliases** (1-2 chars) for fast tab-completion and phonological cueing
- **Shell wrapper updates** — all aliases routed through directive capture for correct `cd:`/`tmux-attach:` parsing
- **Remove dead `internal/notify` package** — tests were firing real macOS notifications on every `make test`
- **Docs updated**: README, COMMAND_SPECIFICATIONS, SHELL_INTEGRATION

## Alias Table

| Command | Aliases |
|---------|---------|
| `diff` | `compare`, `d` |
| `graft` | `apply`, `g` |
| `trim` | `clean`, `tm` |
| `kick` | `restart`, `k` |
| `join` | `attach`, `a`, `j` |
| `ls` | `list`, `l` |
| `new` | `spawn`, `n` |
| `to` | `switch`, `t` |
| `last` | `la` |
| `fetch` | `f` |
| `fork` | `split`, `fo` |
| `sync` | `s` |
| `test` | `tt` |
| `up` | `u` |
| `down` | `do` |
| `logs` | `lo` |
| `here` | `h` |
| `open` | `o` |

## Test plan

- [x] `make fmt` — clean
- [x] `make test` — all tests pass
- [x] `make build` — binary builds
- [x] Spot-checked: `grove diff --help`, `grove d --help`, `grove graft --help`, `grove kick --help`, `grove trim --help`, `grove join --help` all resolve correctly
- [ ] Verify shell integration: `grove j`, `grove t`, `grove la` route through directive capture
- [ ] No more macOS notification spam during `make test`