### PR TITLE
feat(git): include remote branches in branch selector

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -127,6 +127,46 @@ func ListLocalBranches(repoPath string) ([]string, error) {
 	return strings.Split(raw, "\n"), nil
 }
 
+// ListAllBranches returns local and remote branch names (deduplicated).
+// Remote branches are stripped of the "origin/" prefix.
+// Local branches appear first, followed by remote-only branches.
+func ListAllBranches(repoPath string) ([]string, error) {
+	local, err := ListLocalBranches(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get remote branches
+	output, err := cmdexec.Output(context.TODO(), "git", []string{"-C", repoPath, "branch", "-r", "--format=%(refname:short)"}, "", cmdexec.GitLocal)
+	if err != nil {
+		// Fall back to local-only if remote listing fails
+		return local, nil
+	}
+	raw := strings.TrimSpace(string(output))
+	if raw == "" {
+		return local, nil
+	}
+
+	localSet := make(map[string]bool, len(local))
+	for _, b := range local {
+		localSet[b] = true
+	}
+
+	// Add remote branches not already in local, stripping "origin/" prefix
+	for _, rb := range strings.Split(raw, "\n") {
+		name := strings.TrimPrefix(rb, "origin/")
+		if name == "HEAD" || name == "" {
+			continue
+		}
+		if !localSet[name] {
+			local = append(local, name)
+			localSet[name] = true
+		}
+	}
+
+	return local, nil
+}
+
 // isBranchMerged checks if a branch is fully merged into the default branch
 func (b *BranchManager) isBranchMerged(branch string) (bool, error) {
 	// List branches merged into default branch

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -982,7 +982,7 @@ func (m *Model) openSelectedPRURL() {
 
 func (m Model) handleDashboardNewKey() (tea.Model, tea.Cmd) {
 	m.activeView = ViewCreate
-	branches, branchErr := git.ListLocalBranches(m.projectRoot)
+	branches, branchErr := git.ListAllBranches(m.projectRoot)
 	if branchErr != nil {
 		tuilog.Printf("warning: failed to list branches: %v", branchErr)
 	}

--- a/internal/tui/view_issues.go
+++ b/internal/tui/view_issues.go
@@ -157,7 +157,7 @@ func (m Model) handleIssueKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) openCreateWizardForIssue(issue *tracker.Issue) (tea.Model, tea.Cmd) {
-	branches, _ := git.ListLocalBranches(m.projectRoot)
+	branches, _ := git.ListAllBranches(m.projectRoot)
 	m.createState = prefillCreateStateForIssue(issue, m.projectName, branches)
 	m.createState.ReturnView = ViewIssues
 	m.createState.WorktreeBranches = m.worktreeBranchMap()

--- a/internal/tui/view_prs.go
+++ b/internal/tui/view_prs.go
@@ -174,7 +174,7 @@ func (m Model) handlePREnter(s *PRViewState, filtered []*tracker.PullRequest) (t
 }
 
 func (m Model) openCreateWizardForPR(pr *tracker.PullRequest) (tea.Model, tea.Cmd) {
-	branches, _ := git.ListLocalBranches(m.projectRoot)
+	branches, _ := git.ListAllBranches(m.projectRoot)
 	m.createState = prefillCreateStateForPR(pr, m.projectName, branches)
 	m.createState.ReturnView = ViewPRs
 	m.createState.WorktreeBranches = m.worktreeBranchMap()


### PR DESCRIPTION
Follow-up to PR #5. The branch selector only showed local branches — remote-only branches (e.g., PR branches not yet checked out locally) were invisible.

`ListAllBranches` now returns local branches followed by remote-only branches (stripped of `origin/` prefix, deduplicated). `CreateFromBranch` already fetches remote branches before creating.