### PR TITLE
fix(trim): resolve age display and prompt signal handling

### DIFF
--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -1,13 +1,17 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/lost-in-the/grove/internal/cli"
+	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/git"
 	"github.com/lost-in-the/grove/internal/log"
@@ -30,6 +34,7 @@ type CleanCandidate struct {
 	Branch        string
 	LastAccess    time.Time
 	DaysSince     int
+	DaysUnknown   bool // True when age cannot be determined from state or filesystem
 	IsDirty       bool
 	ExcludeReason string // If set, worktree cannot be cleaned
 }
@@ -101,8 +106,14 @@ Examples:
 				candidate.LastAccess = ws.LastAccessedAt
 				candidate.DaysSince = int(now.Sub(ws.LastAccessedAt).Hours() / 24)
 			} else {
-				// If not in state, assume very old
-				candidate.DaysSince = 9999
+				// Not in state: try filesystem fallback to derive age
+				if t, err := worktreeLastModified(tree.Path, now); err == nil {
+					candidate.LastAccess = t
+					candidate.DaysSince = int(now.Sub(t).Hours() / 24)
+				} else {
+					// Age is truly unknown — treat as eligible but display "unknown age"
+					candidate.DaysUnknown = true
+				}
 			}
 
 			// Check exclusions
@@ -116,7 +127,7 @@ Examples:
 				candidate.ExcludeReason = "environment worktree"
 			} else if tree.IsDirty && !cleanIncludeDirty {
 				candidate.ExcludeReason = "dirty (use --include-dirty)"
-			} else if candidate.DaysSince < cleanOlderThan {
+			} else if !candidate.DaysUnknown && candidate.DaysSince < cleanOlderThan {
 				candidate.ExcludeReason = fmt.Sprintf("accessed %d days ago (threshold: %d)", candidate.DaysSince, cleanOlderThan)
 			}
 
@@ -153,7 +164,11 @@ Examples:
 				dirtyMark = " [dirty]"
 			}
 			_, _ = fmt.Fprintf(w, "  %s ", c.Name)
-			cli.Faint(w, "  (%s) - %d days since last access%s", c.Branch, c.DaysSince, dirtyMark)
+			if c.DaysUnknown {
+				cli.Faint(w, "  (%s) - unknown age%s", c.Branch, dirtyMark)
+			} else {
+				cli.Faint(w, "  (%s) - %d days since last access%s", c.Branch, c.DaysSince, dirtyMark)
+			}
 		}
 
 		if cleanDryRun {
@@ -164,13 +179,28 @@ Examples:
 
 		// ALWAYS prompt - mandatory confirmation
 		_, _ = fmt.Fprintln(w)
-		cli.Warning(w, "This will permanently remove %d worktree(s) and their associated tmux sessions.", len(cleanable))
-		fmt.Print("Type 'yes' to confirm: ")
-
-		var response string
-		_, _ = fmt.Scanln(&response)
-		if response != "yes" {
-			fmt.Println("Canceled")
+		confirmDetails := make([]string, 0, len(cleanable))
+		for _, c := range cleanable {
+			if c.DaysUnknown {
+				confirmDetails = append(confirmDetails, fmt.Sprintf("%s (%s) - unknown age", c.Name, c.Branch))
+			} else {
+				confirmDetails = append(confirmDetails, fmt.Sprintf("%s (%s) - %d days", c.Name, c.Branch, c.DaysSince))
+			}
+		}
+		confirmed, err := cli.ConfirmWithDetails(
+			w,
+			fmt.Sprintf("This will permanently remove %d worktree(s) and their associated tmux sessions.", len(cleanable)),
+			confirmDetails,
+			"Proceed?",
+			false,
+		)
+		if err != nil {
+			// Ctrl+C, ESC, or non-interactive — treat as cancellation
+			fmt.Fprintln(os.Stderr, "Canceled")
+			os.Exit(exitcode.UserCancelled)
+		}
+		if !confirmed {
+			fmt.Fprintln(os.Stderr, "Canceled")
 			os.Exit(exitcode.UserCancelled)
 		}
 
@@ -333,6 +363,42 @@ func handleBatchBranchDeletion(repoPath string, branches []string, forceDelete b
 	}
 
 	return nil
+}
+
+// worktreeLastModified returns the best available timestamp for a worktree's
+// last activity. It tries two approaches in order:
+//
+//  1. git log -1 --format=%ct on the worktree path, which gives the commit
+//     timestamp of the most recent commit checked out in that worktree.
+//  2. Stat of the worktree's .git file (a plain file for linked worktrees),
+//     which reflects the last time git touched the worktree metadata.
+//
+// Returns an error when neither source is available.
+func worktreeLastModified(worktreePath string, _ time.Time) (time.Time, error) {
+	// Attempt 1: git log on the worktree
+	out, err := cmdexec.Output(
+		context.Background(),
+		"git",
+		[]string{"log", "-1", "--format=%ct"},
+		worktreePath,
+		cmdexec.GitLocal,
+	)
+	if err == nil {
+		ts := strings.TrimSpace(string(out))
+		if ts != "" {
+			if sec, err := strconv.ParseInt(ts, 10, 64); err == nil && sec > 0 {
+				return time.Unix(sec, 0), nil
+			}
+		}
+	}
+
+	// Attempt 2: mtime of the .git file (linked worktree pointer)
+	gitFile := worktreePath + "/.git"
+	if info, err := os.Stat(gitFile); err == nil {
+		return info.ModTime(), nil
+	}
+
+	return time.Time{}, fmt.Errorf("could not determine age for worktree at %s", worktreePath)
 }
 
 func init() {

--- a/cmd/grove/commands/clean_test.go
+++ b/cmd/grove/commands/clean_test.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCleanCandidateDaysUnknown(t *testing.T) {
+	c := CleanCandidate{DaysUnknown: true}
+	if c.DaysSince != 0 {
+		t.Errorf("DaysSince should be zero-value when DaysUnknown is set, got %d", c.DaysSince)
+	}
+	if !c.DaysUnknown {
+		t.Error("DaysUnknown should be true")
+	}
+}
+
+func TestWorktreeLastModified_GitFile(t *testing.T) {
+	// Create a temporary directory simulating a linked worktree
+	dir := t.TempDir()
+
+	// Write a fake .git file (linked worktrees have a plain .git file, not a directory)
+	gitFile := filepath.Join(dir, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: ../.git/worktrees/test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := time.Now().Add(-time.Second)
+	result, err := worktreeLastModified(dir, time.Now())
+	after := time.Now().Add(time.Second)
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if result.Before(before) || result.After(after) {
+		t.Errorf("mtime %v not in expected range [%v, %v]", result, before, after)
+	}
+}
+
+func TestWorktreeLastModified_NoGitFile(t *testing.T) {
+	// A directory with no .git file and no git history — should return an error
+	dir := t.TempDir()
+
+	_, err := worktreeLastModified(dir, time.Now())
+	if err == nil {
+		t.Error("expected error for directory without .git file or git history")
+	}
+}
+
+func TestWorktreeLastModified_GitLog(t *testing.T) {
+	// Use the grove repo itself (has git history) — git log should succeed
+	dir := findRepoRoot(t)
+	if dir == "" {
+		t.Skip("could not find git repo root")
+	}
+
+	result, err := worktreeLastModified(dir, time.Now())
+	if err != nil {
+		t.Fatalf("expected no error for repo with git history, got: %v", err)
+	}
+	if result.IsZero() {
+		t.Error("expected non-zero time from git log")
+	}
+	// Sanity check: commit time should be in the past
+	if result.After(time.Now()) {
+		t.Errorf("git log timestamp %v is in the future", result)
+	}
+}
+
+// findRepoRoot walks up from the current working directory to find a .git directory.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil && info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/cmd/grove/commands/init.go
+++ b/cmd/grove/commands/init.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -175,10 +176,13 @@ func initializeState(groveDir, cwd, projectName string) error {
 	}
 
 	mainBranch := detectMainBranch(cwd)
+	now := time.Now()
 	mainState := &state.WorktreeState{
-		Path:   cwd,
-		Branch: mainBranch,
-		Root:   true,
+		Path:           cwd,
+		Branch:         mainBranch,
+		Root:           true,
+		CreatedAt:      now,
+		LastAccessedAt: now,
 	}
 	return stateMgr.AddWorktree("main", mainState)
 }

--- a/cmd/grove/commands/repair.go
+++ b/cmd/grove/commands/repair.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/state"
 	"github.com/lost-in-the/grove/internal/tmux"
@@ -138,16 +139,18 @@ Examples:
 			return nil
 		}
 
-		// Prompt for confirmation
-		if !isInteractive() {
-			fmt.Fprintln(os.Stderr, "Non-interactive mode: use --dry-run to preview or run interactively to repair")
-			return nil
+		// Prompt for confirmation — cli.Confirm handles non-interactive detection
+		confirmed, err := cli.Confirm("Proceed with repairs?", false)
+		if err != nil {
+			if !cli.IsInteractive() {
+				fmt.Fprintln(os.Stderr, "Non-interactive mode: use --dry-run to preview or run interactively to repair")
+				return nil
+			}
+			// Ctrl+C, ESC, or other cancellation
+			fmt.Fprintln(os.Stderr, "Canceled")
+			os.Exit(exitcode.UserCancelled)
 		}
-
-		fmt.Fprint(os.Stderr, "Proceed with repairs? [y/N]: ")
-		var response string
-		_, _ = fmt.Scanln(&response)
-		if response != "y" && response != "Y" {
+		if !confirmed {
 			fmt.Fprintln(os.Stderr, "Canceled")
 			os.Exit(exitcode.UserCancelled)
 		}


### PR DESCRIPTION
## Summary
- Fix worktree ages showing "9999 days" when state is missing by using filesystem fallback (#9)
- Set timestamps on main worktree during `grove init` (#9)
- Migrate `trim` and `repair` prompts from raw `fmt.Scanln` to signal-aware `cli.Confirm`/`cli.ConfirmWithDetails` (#17)

Closes #9
Closes #17

## Test plan
- [ ] `grove trim` shows accurate ages for worktrees not in state
- [ ] `grove init` creates main worktree with timestamps
- [ ] Ctrl+C and ESC cancel `grove trim` confirmation prompt
- [ ] Ctrl+C and ESC cancel `grove repair` confirmation prompt
- [ ] `make lint test` passes