### PR TITLE
fix(docker): resolve external compose paths against project root

### DIFF
--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -251,7 +251,15 @@ Required when `mode = "external"`. Configures the shared compose setup.
 ```toml
 [plugins.docker.external]
 # Path to the external Docker Compose directory (the one with docker-compose.yml).
-# Supports ~ expansion. Required.
+# Accepts:
+#   - absolute paths (`/home/user/code/orchestrator`)
+#   - ~ expansion (`~/work/compose-dev`)
+#   - relative paths, resolved against the project root — i.e., the directory
+#     containing `.grove/`. For example, `path = "../"` in
+#     `~/code/orchestrator/app/.grove/config.toml` resolves to
+#     `~/code/orchestrator/`. This makes a committed config portable across
+#     teammates with different parent directory layouts.
+# Required.
 path = "~/work/compose-dev"        # string (required)
 
 # Environment variable name that grove sets to the worktree path.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,9 @@ func loadFromPaths(cfg *Config, globalPath, projectPath string) (*Config, error)
 		return nil, err
 	}
 	if globalCfg != nil {
+		if err := resolveProjectPaths(globalCfg, projectRootFor(globalPath)); err != nil {
+			return nil, err
+		}
 		cfg = mergeConfigs(cfg, globalCfg)
 	}
 
@@ -203,6 +206,9 @@ func loadFromPaths(cfg *Config, globalPath, projectPath string) (*Config, error)
 		return nil, err
 	}
 	if projectCfg != nil {
+		if err := resolveProjectPaths(projectCfg, projectRootFor(projectPath)); err != nil {
+			return nil, err
+		}
 		cfg = mergeConfigs(cfg, projectCfg)
 	}
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveProjectPaths normalizes any path-valued fields in cfg to absolute
+// paths. Relative paths resolve against projectRoot (the directory containing
+// .grove/, i.e., where a developer would `cd` into the project). ~/-prefixed
+// paths expand against $HOME. Absolute and empty paths are unchanged.
+//
+// This is called once per config file at load time so downstream consumers
+// always see absolute paths regardless of where grove is invoked from.
+func resolveProjectPaths(cfg *Config, projectRoot string) error {
+	if cfg == nil || cfg.Plugins.Docker.External == nil {
+		return nil
+	}
+
+	resolved, err := expandConfigPath(cfg.Plugins.Docker.External.Path, projectRoot)
+	if err != nil {
+		return fmt.Errorf("plugins.docker.external.path: %w", err)
+	}
+	cfg.Plugins.Docker.External.Path = resolved
+	return nil
+}
+
+// expandConfigPath converts p into a cleaned absolute path. Empty strings pass
+// through unchanged (validation will reject them where required). ~/-prefixed
+// paths expand against $HOME. Absolute paths are cleaned. Relative paths are
+// joined to baseDir; if baseDir is empty, they are cleaned as-is.
+func expandConfigPath(p, baseDir string) (string, error) {
+	if p == "" {
+		return p, nil
+	}
+	if p == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand ~: %w", err)
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to expand ~: %w", err)
+		}
+		return filepath.Join(home, p[2:]), nil
+	}
+	if filepath.IsAbs(p) {
+		return filepath.Clean(p), nil
+	}
+	if baseDir == "" {
+		return filepath.Clean(p), nil
+	}
+	return filepath.Clean(filepath.Join(baseDir, p)), nil
+}
+
+// projectRootFor returns the directory that should anchor relative paths in a
+// config file at configPath. By convention .grove/config.toml lives one level
+// below the project root, so the root is the parent of the config file's
+// directory.
+func projectRootFor(configPath string) string {
+	if configPath == "" {
+		return ""
+	}
+	return filepath.Dir(filepath.Dir(configPath))
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandConfigPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		baseDir string
+		want    string
+	}{
+		{"empty unchanged", "", "/anywhere", ""},
+		{"absolute cleaned", "/tmp//foo/../bar", "/ignored", "/tmp/bar"},
+		{"tilde expands", "~/projects/orchestrator", "/ignored", filepath.Join(home, "projects", "orchestrator")},
+		{"bare tilde expands", "~", "/ignored", home},
+		{"relative joins baseDir", "../orchestrator", "/home/user/code/app", "/home/user/code/orchestrator"},
+		{"dot relative joins baseDir", "./shared-infra", "/home/user/code/app", "/home/user/code/app/shared-infra"},
+		{"plain relative joins baseDir", "shared-infra", "/home/user/code/app", "/home/user/code/app/shared-infra"},
+		{"relative without baseDir cleaned", "../orchestrator", "", "../orchestrator"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandConfigPath(tt.path, tt.baseDir)
+			if err != nil {
+				t.Fatalf("expandConfigPath(%q, %q) error = %v", tt.path, tt.baseDir, err)
+			}
+			if got != tt.want {
+				t.Errorf("expandConfigPath(%q, %q) = %q, want %q", tt.path, tt.baseDir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectRootFor(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"project config", "/home/user/code/app/.grove/config.toml", "/home/user/code/app"},
+		{"global config", "/home/user/.config/grove/config.toml", "/home/user/.config"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := projectRootFor(tt.path)
+			if got != tt.want {
+				t.Errorf("projectRootFor(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveProjectPaths_RelativeExternalPath(t *testing.T) {
+	cfg := &Config{
+		Plugins: PluginsConfig{
+			Docker: DockerPluginConfig{
+				External: &ExternalComposeConfig{
+					Path: "../orchestrator",
+				},
+			},
+		},
+	}
+
+	if err := resolveProjectPaths(cfg, "/home/user/code/app"); err != nil {
+		t.Fatalf("resolveProjectPaths() error = %v", err)
+	}
+
+	got := cfg.Plugins.Docker.External.Path
+	want := "/home/user/code/orchestrator"
+	if got != want {
+		t.Errorf("External.Path = %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectPaths_AbsolutePathUnchanged(t *testing.T) {
+	cfg := &Config{
+		Plugins: PluginsConfig{
+			Docker: DockerPluginConfig{
+				External: &ExternalComposeConfig{
+					Path: "/abs/path/to/orchestrator",
+				},
+			},
+		},
+	}
+
+	if err := resolveProjectPaths(cfg, "/home/user/code/app"); err != nil {
+		t.Fatalf("resolveProjectPaths() error = %v", err)
+	}
+
+	got := cfg.Plugins.Docker.External.Path
+	want := "/abs/path/to/orchestrator"
+	if got != want {
+		t.Errorf("External.Path = %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectPaths_NoExternal(t *testing.T) {
+	cfg := &Config{}
+	if err := resolveProjectPaths(cfg, "/anywhere"); err != nil {
+		t.Errorf("resolveProjectPaths() with no external should succeed, got %v", err)
+	}
+}
+
+// TestLoadConfigFromPaths_RelativeExternalPath end-to-end tests that a project
+// config with a relative external.path resolves against the project root
+// (parent of .grove/) when loaded via the normal config loading flow.
+func TestLoadConfigFromPaths_RelativeExternalPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	orchestratorDir := filepath.Join(tmpDir, "orchestrator")
+	appDir := filepath.Join(orchestratorDir, "app")
+	groveDir := filepath.Join(appDir, ".grove")
+
+	if err := os.MkdirAll(orchestratorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(groveDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `
+[plugins.docker]
+mode = "external"
+
+[plugins.docker.external]
+path = "../"
+env_var = "APP_DIR"
+services = ["app"]
+`
+	configPath := filepath.Join(groveDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadFromPaths(LoadDefaults(), "/nonexistent/global.toml", configPath)
+	if err != nil {
+		t.Fatalf("loadFromPaths() error = %v", err)
+	}
+
+	got := cfg.Plugins.Docker.External.Path
+	want, err := filepath.EvalSymlinks(orchestratorDir)
+	if err != nil {
+		want = orchestratorDir
+	}
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		gotResolved = got
+	}
+	if gotResolved != want {
+		t.Errorf("External.Path = %q (resolved %q), want %q", got, gotResolved, want)
+	}
+}

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -196,7 +196,10 @@ auto_stop = true
 mode = "external"
 
 [plugins.docker.external]
-# Path to the shared compose directory
+# Path to the shared compose directory. Absolute, ~/-prefixed, or relative
+# to the project root (parent of .grove/). Use a relative path like "../"
+# when the orchestrator lives one level above the app, so the same config
+# works for teammates with different parent directory layouts.
 path = "~/projects/shared-infra"
 
 # Environment variable that the compose YAML reads to find this app
@@ -232,7 +235,7 @@ symlink_dirs = [
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `path` | Yes | Absolute path to the external compose directory (supports `~`) |
+| `path` | Yes | Path to the external compose directory. Accepts absolute paths, `~/`-prefixed paths (expanded against `$HOME`), and relative paths (resolved against the project root — i.e., the parent of `.grove/`). For example, `path = "../"` in `<app>/.grove/config.toml` points to the directory containing the app — useful for committed configs shared across teammates with different parent layouts. |
 | `env_var` | Yes | Environment variable name the compose YAML reads |
 | `env_file` | No | Filename in the compose directory where grove writes the `env_var` value (default: `.env`). For example, with `env_var = "APP_DIR"` and `env_file = ".env.local"`, grove writes `APP_DIR=/abs/path/to/worktree` to `.env.local` and passes `--env-file .env.local` to compose. Set to `.env.local` to avoid dirtying a git-tracked `.env`. See [Env File Loaders](#env-file-loaders-direnv--mise) for optional loader setup. |
 | `services` | Yes | List of service names to manage |

--- a/plugins/docker/agent_external.go
+++ b/plugins/docker/agent_external.go
@@ -278,7 +278,10 @@ func (s *agentExternalStrategy) agentEnv(worktreePath string, slot int) []string
 	return env
 }
 
-// resolveComposePath resolves ~ in a compose directory path.
+// resolveComposePath resolves ~ in a compose directory path. Paths loaded
+// through internal/config are already absolute (relative paths in
+// .grove/config.toml resolve against the project root at load time), so this
+// is a defensive fallback for callers that construct configs by hand.
 func resolveComposePath(path string) string {
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()


### PR DESCRIPTION
Relative paths in plugins.docker.external.path (e.g. "../") now resolve
against the directory containing .grove/, so a committed .grove/config.toml
can point at a sibling orchestrator directory regardless of where each
teammate keeps the project on disk. Previously only absolute and ~/-prefixed
paths worked reliably; relative paths were resolved against grove's CWD at
exec time and broke as soon as the user invoked grove from anywhere other
than the project root.

Resolution happens once at config load time, so all downstream consumers
(validation, exec.Cmd.Dir, filepath.Rel) see absolute paths.