### PR TITLE
Improve worktree cleanup with better age detection and safety

### DIFF
--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -95,14 +95,16 @@ Examples:
 				IsDirty: tree.IsDirty,
 			}
 
-			// Get last access time from state
+			// Get last access time from state, falling back to filesystem mtime
+			// if the worktree is missing from state or has zero-value timestamps.
 			ws, _ := ctx.State.GetWorktree(tree.ShortName)
-			if ws != nil {
+			candidate.DaysSince = -1 // sentinel meaning "unknown"
+			if ws != nil && !ws.LastAccessedAt.IsZero() {
 				candidate.LastAccess = ws.LastAccessedAt
 				candidate.DaysSince = int(now.Sub(ws.LastAccessedAt).Hours() / 24)
-			} else {
-				// If not in state, assume very old
-				candidate.DaysSince = 9999
+			} else if info, err := os.Stat(tree.Path); err == nil {
+				candidate.LastAccess = info.ModTime()
+				candidate.DaysSince = int(now.Sub(info.ModTime()).Hours() / 24)
 			}
 
 			// Check exclusions
@@ -116,7 +118,7 @@ Examples:
 				candidate.ExcludeReason = "environment worktree"
 			} else if tree.IsDirty && !cleanIncludeDirty {
 				candidate.ExcludeReason = "dirty (use --include-dirty)"
-			} else if candidate.DaysSince < cleanOlderThan {
+			} else if candidate.DaysSince >= 0 && candidate.DaysSince < cleanOlderThan {
 				candidate.ExcludeReason = fmt.Sprintf("accessed %d days ago (threshold: %d)", candidate.DaysSince, cleanOlderThan)
 			}
 
@@ -153,7 +155,11 @@ Examples:
 				dirtyMark = " [dirty]"
 			}
 			_, _ = fmt.Fprintf(w, "  %s ", c.Name)
-			cli.Faint(w, "  (%s) - %d days since last access%s", c.Branch, c.DaysSince, dirtyMark)
+			ageStr := fmt.Sprintf("%d days since last access", c.DaysSince)
+			if c.DaysSince < 0 {
+				ageStr = "last access unknown"
+			}
+			cli.Faint(w, "  (%s) - %s%s", c.Branch, ageStr, dirtyMark)
 		}
 
 		if cleanDryRun {

--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -171,11 +172,13 @@ Examples:
 		// ALWAYS prompt - mandatory confirmation
 		_, _ = fmt.Fprintln(w)
 		cli.Warning(w, "This will permanently remove %d worktree(s) and their associated tmux sessions.", len(cleanable))
-		fmt.Print("Type 'yes' to confirm: ")
 
-		var response string
-		_, _ = fmt.Scanln(&response)
-		if response != "yes" {
+		question := fmt.Sprintf("Remove %d worktree(s)?", len(cleanable))
+		confirmed, err := cli.Confirm(question, false)
+		if err != nil || !confirmed {
+			if err != nil && !errors.Is(err, cli.ErrPromptCanceled) {
+				cli.Error(w, "%v", err)
+			}
 			fmt.Println("Canceled")
 			os.Exit(exitcode.UserCancelled)
 		}

--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -1,14 +1,18 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/lost-in-the/grove/internal/cli"
+	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/git"
 	"github.com/lost-in-the/grove/internal/log"
@@ -96,16 +100,18 @@ Examples:
 				IsDirty: tree.IsDirty,
 			}
 
-			// Get last access time from state, falling back to filesystem mtime
-			// if the worktree is missing from state or has zero-value timestamps.
+			// Get last access time from state, falling back to the worktree's
+			// HEAD commit time when state is missing or has zero-value timestamps.
+			// Commit time is a more honest "last activity" proxy than directory
+			// mtime, which gets bumped by routine churn (e.g. `npm install`).
 			ws, _ := ctx.State.GetWorktree(tree.ShortName)
 			candidate.DaysSince = -1 // sentinel meaning "unknown"
 			if ws != nil && !ws.LastAccessedAt.IsZero() {
 				candidate.LastAccess = ws.LastAccessedAt
 				candidate.DaysSince = int(now.Sub(ws.LastAccessedAt).Hours() / 24)
-			} else if info, err := os.Stat(tree.Path); err == nil {
-				candidate.LastAccess = info.ModTime()
-				candidate.DaysSince = int(now.Sub(info.ModTime()).Hours() / 24)
+			} else if t, ok := worktreeHeadTime(tree.Path); ok {
+				candidate.LastAccess = t
+				candidate.DaysSince = int(now.Sub(t).Hours() / 24)
 			}
 
 			// Check exclusions
@@ -244,6 +250,21 @@ type BranchInfo struct {
 	Status        *git.BranchStatus
 	SafeToDelete  bool
 	StatusSummary string
+}
+
+// worktreeHeadTime returns the commit time of HEAD in the given worktree,
+// used as a fallback "last activity" proxy when state has no timestamp.
+// Returns ok=false if the path is unreadable as a git worktree.
+func worktreeHeadTime(path string) (time.Time, bool) {
+	out, err := cmdexec.Output(context.TODO(), "git", []string{"log", "-1", "--format=%ct", "HEAD"}, path, cmdexec.GitLocal)
+	if err != nil {
+		return time.Time{}, false
+	}
+	secs, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return time.Unix(secs, 0), true
 }
 
 func collectBranchInfos(branchMgr *git.BranchManager, branches []string) []BranchInfo {

--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -169,13 +169,17 @@ Examples:
 			return nil
 		}
 
-		// ALWAYS prompt - mandatory confirmation
+		// ALWAYS prompt - mandatory confirmation. Require typing the literal
+		// word "yes" rather than using cli.Confirm: the operation is permanently
+		// destructive (worktree + tmux removal, no undo), and the trim spec
+		// requires this confirmation to work in non-interactive mode too.
+		// cli.ReadLine handles Ctrl+C/ESC and falls back to cooked-mode read for
+		// piped stdin, so scripted `echo yes | grove trim` still works.
 		_, _ = fmt.Fprintln(w)
 		cli.Warning(w, "This will permanently remove %d worktree(s) and their associated tmux sessions.", len(cleanable))
 
-		question := fmt.Sprintf("Remove %d worktree(s)?", len(cleanable))
-		confirmed, err := cli.Confirm(question, false)
-		if err != nil || !confirmed {
+		response, err := cli.ReadLine("Type 'yes' to confirm: ")
+		if err != nil || response != "yes" {
 			if err != nil && !errors.Is(err, cli.ErrPromptCanceled) {
 				cli.Error(w, "%v", err)
 			}

--- a/cmd/grove/commands/init.go
+++ b/cmd/grove/commands/init.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -189,10 +190,13 @@ func initializeState(groveDir, cwd, projectName string) error {
 	}
 
 	mainBranch := detectMainBranch(cwd)
+	now := time.Now()
 	mainState := &state.WorktreeState{
-		Path:   cwd,
-		Branch: mainBranch,
-		Root:   true,
+		Path:           cwd,
+		Branch:         mainBranch,
+		Root:           true,
+		CreatedAt:      now,
+		LastAccessedAt: now,
 	}
 	return stateMgr.AddWorktree("main", mainState)
 }

--- a/cmd/grove/commands/repair.go
+++ b/cmd/grove/commands/repair.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/state"
 	"github.com/lost-in-the/grove/internal/tmux"
@@ -144,10 +146,11 @@ Examples:
 			return nil
 		}
 
-		fmt.Fprint(os.Stderr, "Proceed with repairs? [y/N]: ")
-		var response string
-		_, _ = fmt.Scanln(&response)
-		if response != "y" && response != "Y" {
+		confirmed, err := cli.Confirm("Proceed with repairs?", false)
+		if err != nil || !confirmed {
+			if err != nil && !errors.Is(err, cli.ErrPromptCanceled) {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+			}
 			fmt.Fprintln(os.Stderr, "Canceled")
 			os.Exit(exitcode.UserCancelled)
 		}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -301,13 +301,27 @@ func (m *Manager) Remove(name string) error {
 	}
 
 	// Remove the worktree normally
-	_, err = cmdexec.CombinedOutput(context.TODO(), "git", []string{"worktree", "remove", targetTree.Path}, m.repoRoot, cmdexec.GitLocal)
-	if err != nil {
-		// Try force remove if regular remove fails
-		output, err := cmdexec.CombinedOutput(context.TODO(), "git", []string{"worktree", "remove", "--force", targetTree.Path}, m.repoRoot, cmdexec.GitLocal)
-		if err != nil {
-			return fmt.Errorf("failed to remove worktree: %s: %w", string(output), err)
-		}
+	if _, err := cmdexec.CombinedOutput(context.TODO(), "git", []string{"worktree", "remove", targetTree.Path}, m.repoRoot, cmdexec.GitLocal); err == nil {
+		return nil
+	}
+
+	// Try git's own --force first
+	forceOutput, forceErr := cmdexec.CombinedOutput(context.TODO(), "git", []string{"worktree", "remove", "--force", targetTree.Path}, m.repoRoot, cmdexec.GitLocal)
+	if forceErr == nil {
+		return nil
+	}
+
+	// Final fallback: nuke the directory ourselves and prune git's metadata.
+	// `git worktree remove --force` refuses to delete non-empty untracked
+	// directories (e.g. node_modules left behind by a post-create hook),
+	// so when git has already given up we tear the directory down directly.
+	// targetTree.Path comes from `git worktree list`, so it is bounded to a
+	// known worktree path rather than user input.
+	if rmErr := os.RemoveAll(targetTree.Path); rmErr != nil {
+		return fmt.Errorf("failed to remove worktree: %s: %w", string(forceOutput), forceErr)
+	}
+	if pruneOutput, pruneErr := cmdexec.CombinedOutput(context.TODO(), "git", []string{"worktree", "prune"}, m.repoRoot, cmdexec.GitLocal); pruneErr != nil {
+		return fmt.Errorf("removed worktree directory but failed to prune git metadata: %s: %w", string(pruneOutput), pruneErr)
 	}
 
 	return nil

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -291,6 +291,13 @@ func (m *Manager) Remove(name string) error {
 		return fmt.Errorf("worktree '%s' not found", name)
 	}
 
+	// Defense in depth: refuse to remove the main worktree. Callers (rm/clean/TUI)
+	// already filter this out, but our os.RemoveAll fallback below would happily
+	// wipe the main checkout if a future caller forgot the guard.
+	if targetTree.IsMain {
+		return fmt.Errorf("cannot remove main worktree '%s'", name)
+	}
+
 	// If the worktree is prunable (directory missing), use git worktree prune
 	if targetTree.IsPrunable {
 		output, err := cmdexec.CombinedOutput(context.TODO(), "git", []string{"worktree", "prune"}, m.repoRoot, cmdexec.GitLocal)


### PR DESCRIPTION
## Summary

This PR enhances the `clean` and `repair` commands with more robust worktree age detection, improved user confirmation handling, and additional safety guards for worktree removal.

Key improvements:
- **Better age detection**: Falls back to git HEAD commit time when state timestamps are missing, providing a more honest "last activity" proxy than directory mtime
- **Improved confirmation UX**: Replaces `fmt.Scanln` with proper CLI prompt handling that supports piped input and graceful cancellation
- **Safety enhancements**: Adds defense-in-depth check to prevent accidental removal of the main worktree, and implements a three-tier fallback strategy for stubborn worktree removal
- **State initialization**: Ensures newly created main worktree state includes proper timestamps

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactoring (no functional change)

## Details

### clean.go
- Added `worktreeHeadTime()` helper to query git commit timestamps as fallback for age detection
- Changed age sentinel from `9999` to `-1` with explicit "unknown" display handling
- Improved confirmation prompt using `cli.ReadLine()` instead of `fmt.Scanln()` for better stdin handling
- Enhanced comments explaining the rationale for commit-time-based age detection
- Fixed age comparison logic to skip unknown ages (`DaysSince < 0`)

### worktree/worktree.go
- Added guard to prevent removal of main worktree (defense in depth)
- Refactored `Remove()` to use three-tier fallback strategy:
  1. Normal `git worktree remove`
  2. Force remove with `--force` flag
  3. Direct filesystem removal + `git worktree prune` (handles cases where git gives up on non-empty untracked directories)
- Improved error messages to distinguish between different failure modes

### repair.go
- Replaced `fmt.Scanln()` with `cli.Confirm()` for consistent confirmation handling
- Added proper error handling for prompt cancellation

### init.go
- Initialize main worktree state with `CreatedAt` and `LastAccessedAt` timestamps to avoid relying on fallback detection

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter is clean (`make lint`)
- [x] Commit messages follow conventional commits

https://claude.ai/code/session_01Qb4rmLwdgf2vRwo9ciSarw