### PR TITLE
test(init,doctor): cover gaps surfaced in #38

### DIFF
--- a/cmd/grove/commands/doctor_test.go
+++ b/cmd/grove/commands/doctor_test.go
@@ -257,6 +257,240 @@ command = "bundle install"`
 	})
 }
 
+// TestRewriteHostInstallsToCompose_FurtherEdgeCases pins the *current*
+// regex-based behavior on TOML shapes the rewriter doesn't formally
+// understand. Each subtest documents the limitation so that the
+// companion `refactor(doctor): use TOML parser for hook rewrites
+// instead of regex` issue can update the assertions when it lands.
+func TestRewriteHostInstallsToCompose_FurtherEdgeCases(t *testing.T) {
+	t.Run("indented header is currently treated as a header", func(t *testing.T) {
+		// TODO(toml-refactor): a TOML parser would either treat indented
+		// headers as syntax errors or normalize indentation on output.
+		// Today: strings.TrimSpace strips the indent so the header IS
+		// matched, but the injected `service` / `mode` lines come out
+		// unindented while the surrounding `command =` line keeps its
+		// original indent. Asserting the count here so a future change
+		// in either direction surfaces the regression.
+		src := "  [[hooks.post_create]]\n  type = \"command\"\n  command = \"bundle install\"\n"
+		_, n := rewriteHostInstallsToCompose(src, "web")
+		if n != 1 {
+			t.Errorf("indented header: expected n=1 under current behavior, got %d", n)
+		}
+	})
+
+	t.Run("multi-line triple-quoted command is not detected", func(t *testing.T) {
+		// TODO(toml-refactor): a real TOML parser would resolve the
+		// multi-line value to "bundle install" and trigger the rewrite.
+		// Today: the regex extracts the value between the first pair of
+		// `"`, which is empty, so isLikelyHostInstallCommand("") is false.
+		src := "[[hooks.post_create]]\ntype = \"command\"\ncommand = \"\"\"\nbundle install\n\"\"\"\n"
+		got, n := rewriteHostInstallsToCompose(src, "web")
+		if n != 0 {
+			t.Errorf("multi-line command: expected n=0 under current behavior, got %d", n)
+		}
+		if !strings.Contains(got, "bundle install") {
+			t.Errorf("multi-line command should be preserved verbatim, got:\n%s", got)
+		}
+	})
+
+	t.Run("quoted key form \"type\" = \"command\" is not detected", func(t *testing.T) {
+		// TODO(toml-refactor): TOML allows quoted keys; the regex requires
+		// the literal prefix `type` so it misses this shape.
+		src := "[[hooks.post_create]]\n\"type\" = \"command\"\ncommand = \"bundle install\"\n"
+		got, n := rewriteHostInstallsToCompose(src, "web")
+		if n != 0 {
+			t.Errorf("quoted key: expected n=0 under current behavior, got %d", n)
+		}
+		if strings.Contains(got, "docker:compose") {
+			t.Errorf("quoted-key block should not be rewritten, got:\n%s", got)
+		}
+	})
+
+	t.Run("inline-table form is not detected", func(t *testing.T) {
+		// TODO(toml-refactor): inline tables (`hooks = [{...}]`) are valid
+		// TOML; the regex only knows about array-of-tables headers.
+		src := "hooks = [{ type = \"command\", command = \"bundle install\" }]\n"
+		got, n := rewriteHostInstallsToCompose(src, "web")
+		if n != 0 {
+			t.Errorf("inline table: expected n=0 under current behavior, got %d", n)
+		}
+		if got != src {
+			t.Errorf("inline table should be passed through verbatim:\nwant: %q\ngot:  %q", src, got)
+		}
+	})
+}
+
+// projectOpts configures a synthetic project root materialized by
+// testProject. Each string field is the file body; empty means "don't
+// create that file".
+type projectOpts struct {
+	Dockerfile    string
+	Compose       string // written as docker-compose.yml
+	HooksToml     string
+	ReadOnlyGrove bool // chmod 0555 .grove after writing — exercises write failures
+}
+
+// testProject materializes a temporary project root + .grove dir under
+// t.TempDir(). It centralizes the t.TempDir() + os.WriteFile pattern that
+// existed inline in TestCheckHooksDockerRouting_* so doctor tests can
+// declare project shape declaratively.
+func testProject(t *testing.T, opts projectOpts) (root, groveDir string) {
+	t.Helper()
+	root = t.TempDir()
+	groveDir = filepath.Join(root, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatalf("mkdir .grove: %v", err)
+	}
+	if opts.Dockerfile != "" {
+		if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte(opts.Dockerfile), 0644); err != nil {
+			t.Fatalf("write Dockerfile: %v", err)
+		}
+	}
+	if opts.Compose != "" {
+		if err := os.WriteFile(filepath.Join(root, "docker-compose.yml"), []byte(opts.Compose), 0644); err != nil {
+			t.Fatalf("write compose: %v", err)
+		}
+	}
+	if opts.HooksToml != "" {
+		if err := os.WriteFile(filepath.Join(groveDir, "hooks.toml"), []byte(opts.HooksToml), 0644); err != nil {
+			t.Fatalf("write hooks.toml: %v", err)
+		}
+	}
+	if opts.ReadOnlyGrove {
+		if err := os.Chmod(groveDir, 0555); err != nil {
+			t.Fatalf("chmod readonly: %v", err)
+		}
+		// Restore writable perms so t.TempDir's auto-cleanup can rm -r.
+		t.Cleanup(func() { _ = os.Chmod(groveDir, 0755) })
+	}
+	return root, groveDir
+}
+
+// TestFixHostInstallsInDockerProject covers the early-return and error
+// paths that the inline t.TempDir() pattern in
+// TestCheckHooksDockerRouting_* didn't reach.
+func TestFixHostInstallsInDockerProject(t *testing.T) {
+	t.Run("not a docker project returns (0, nil)", func(t *testing.T) {
+		root, groveDir := testProject(t, projectOpts{
+			HooksToml: `[[hooks.post_create]]` + "\n" + `type = "command"` + "\n" + `command = "bundle install"` + "\n",
+		})
+		n, err := fixHostInstallsInDockerProject(root, groveDir)
+		if err != nil {
+			t.Errorf("expected nil error in non-docker dir, got %v", err)
+		}
+		if n != 0 {
+			t.Errorf("expected 0 rewrites in non-docker dir, got %d", n)
+		}
+	})
+
+	t.Run("dockerfile present but no compose file returns (0, nil)", func(t *testing.T) {
+		root, groveDir := testProject(t, projectOpts{
+			Dockerfile: "FROM ruby",
+			HooksToml:  `[[hooks.post_create]]` + "\n" + `type = "command"` + "\n" + `command = "bundle install"` + "\n",
+		})
+		n, err := fixHostInstallsInDockerProject(root, groveDir)
+		if err != nil {
+			t.Errorf("expected nil error when no compose file, got %v", err)
+		}
+		if n != 0 {
+			t.Errorf("expected 0 rewrites when no compose, got %d", n)
+		}
+	})
+
+	t.Run("compose with only infra services can't infer app, returns error", func(t *testing.T) {
+		// All services in infraServiceNames → pickAppService returns
+		// ("", false), so InferAppService fails.
+		compose := `services:
+  postgres:
+    image: postgres:15
+  redis:
+    image: redis:7
+`
+		root, groveDir := testProject(t, projectOpts{
+			Dockerfile: "FROM ruby",
+			Compose:    compose,
+			HooksToml:  `[[hooks.post_create]]` + "\n" + `type = "command"` + "\n" + `command = "bundle install"` + "\n",
+		})
+		_, err := fixHostInstallsInDockerProject(root, groveDir)
+		if err == nil {
+			t.Fatal("expected error when no app service can be inferred")
+		}
+		if !strings.Contains(err.Error(), "can't infer app service") {
+			t.Errorf("error should mention inference failure, got %v", err)
+		}
+	})
+
+	t.Run("missing hooks.toml returns wrapped read error", func(t *testing.T) {
+		compose := "services:\n  web:\n    image: ruby\n"
+		root, groveDir := testProject(t, projectOpts{
+			Dockerfile: "FROM ruby",
+			Compose:    compose,
+			// HooksToml intentionally omitted.
+		})
+		_, err := fixHostInstallsInDockerProject(root, groveDir)
+		if err == nil {
+			t.Fatal("expected error for missing hooks.toml")
+		}
+		if !strings.Contains(err.Error(), "read hooks.toml") {
+			t.Errorf("error should be wrapped as read failure, got %v", err)
+		}
+	})
+
+	t.Run("read-only .grove returns wrapped write error", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("chmod 0555 is bypassed when running as root")
+		}
+		compose := "services:\n  web:\n    image: ruby\n"
+		hooks := `[[hooks.post_create]]
+type = "command"
+command = "bundle install"
+`
+		root, groveDir := testProject(t, projectOpts{
+			Dockerfile:    "FROM ruby",
+			Compose:       compose,
+			HooksToml:     hooks,
+			ReadOnlyGrove: true,
+		})
+		_, err := fixHostInstallsInDockerProject(root, groveDir)
+		if err == nil {
+			t.Fatal("expected write error on read-only .grove")
+		}
+		if !strings.Contains(err.Error(), "write hooks.toml") {
+			t.Errorf("error should be wrapped as write failure, got %v", err)
+		}
+	})
+
+	t.Run("happy path rewrites and reports count", func(t *testing.T) {
+		compose := "services:\n  web:\n    image: ruby\n"
+		hooks := `[[hooks.post_create]]
+type = "command"
+command = "bundle install --quiet"
+`
+		root, groveDir := testProject(t, projectOpts{
+			Dockerfile: "FROM ruby",
+			Compose:    compose,
+			HooksToml:  hooks,
+		})
+		n, err := fixHostInstallsInDockerProject(root, groveDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("expected 1 rewrite, got %d", n)
+		}
+		got, err := os.ReadFile(filepath.Join(groveDir, "hooks.toml"))
+		if err != nil {
+			t.Fatalf("read back hooks.toml: %v", err)
+		}
+		if !strings.Contains(string(got), `type = "docker:compose"`) {
+			t.Errorf("hooks.toml not rewritten:\n%s", got)
+		}
+		if !strings.Contains(string(got), `service = "web"`) {
+			t.Errorf("hooks.toml missing service=web:\n%s", got)
+		}
+	})
+}
+
 func TestCheckEnvFileConfig_NonDefault(t *testing.T) {
 	direnvFound := func(name string) (string, error) {
 		if name == "direnv" {

--- a/cmd/grove/commands/doctor_test.go
+++ b/cmd/grove/commands/doctor_test.go
@@ -324,10 +324,10 @@ func TestRewriteHostInstallsToCompose_FurtherEdgeCases(t *testing.T) {
 // testProject. Each string field is the file body; empty means "don't
 // create that file".
 type projectOpts struct {
-	Dockerfile    string
-	Compose       string // written as docker-compose.yml
-	HooksToml     string
-	ReadOnlyGrove bool // chmod 0555 .grove after writing — exercises write failures
+	Dockerfile        string
+	Compose           string // written as docker-compose.yml
+	HooksToml         string
+	ReadOnlyHooksFile bool // chmod 0444 hooks.toml after writing — exercises write failures
 }
 
 // testProject materializes a temporary project root + .grove dir under
@@ -356,12 +356,17 @@ func testProject(t *testing.T, opts projectOpts) (root, groveDir string) {
 			t.Fatalf("write hooks.toml: %v", err)
 		}
 	}
-	if opts.ReadOnlyGrove {
-		if err := os.Chmod(groveDir, 0555); err != nil {
+	if opts.ReadOnlyHooksFile {
+		// chmod the file (not the dir): Linux file write needs write perm
+		// on the file itself + execute on path components, NOT write on
+		// the parent dir. Chmod'ing the dir to 0555 still lets OpenFile
+		// open and truncate an existing file inside it.
+		hooksPath := filepath.Join(groveDir, "hooks.toml")
+		if err := os.Chmod(hooksPath, 0444); err != nil {
 			t.Fatalf("chmod readonly: %v", err)
 		}
 		// Restore writable perms so t.TempDir's auto-cleanup can rm -r.
-		t.Cleanup(func() { _ = os.Chmod(groveDir, 0755) })
+		t.Cleanup(func() { _ = os.Chmod(hooksPath, 0644) })
 	}
 	return root, groveDir
 }
@@ -436,9 +441,9 @@ func TestFixHostInstallsInDockerProject(t *testing.T) {
 		}
 	})
 
-	t.Run("read-only .grove returns wrapped write error", func(t *testing.T) {
+	t.Run("read-only hooks.toml returns wrapped write error", func(t *testing.T) {
 		if os.Geteuid() == 0 {
-			t.Skip("chmod 0555 is bypassed when running as root")
+			t.Skip("chmod 0444 is bypassed when running as root")
 		}
 		compose := "services:\n  web:\n    image: ruby\n"
 		hooks := `[[hooks.post_create]]
@@ -446,10 +451,10 @@ type = "command"
 command = "bundle install"
 `
 		root, groveDir := testProject(t, projectOpts{
-			Dockerfile:    "FROM ruby",
-			Compose:       compose,
-			HooksToml:     hooks,
-			ReadOnlyGrove: true,
+			Dockerfile:        "FROM ruby",
+			Compose:           compose,
+			HooksToml:         hooks,
+			ReadOnlyHooksFile: true,
 		})
 		_, err := fixHostInstallsInDockerProject(root, groveDir)
 		if err == nil {

--- a/cmd/grove/commands/init.go
+++ b/cmd/grove/commands/init.go
@@ -113,7 +113,7 @@ func runInit() error {
 	fmt.Printf("  Config: %s\n", configPath)
 
 	if !initNoHooks {
-		generateAndWriteHooks(groveDir, cwd)
+		generateAndWriteHooks(groveDir, cwd, cli.StdPrompter{})
 	}
 
 	createInitialWorktrees(cwd, projectName)
@@ -212,7 +212,7 @@ export GROVE_PROJECT="` + projectName + `"
 	}
 }
 
-func generateAndWriteHooks(groveDir, cwd string) {
+func generateAndWriteHooks(groveDir, cwd string, prompter cli.Prompter) {
 	hooksPath := filepath.Join(groveDir, "hooks.toml")
 	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
 		return
@@ -228,23 +228,23 @@ func generateAndWriteHooks(groveDir, cwd string) {
 		return
 	}
 
-	decision := resolveInitMode()
+	decision := resolveInitMode(prompter)
 	switch decision.Mode {
 	case initModeSkip:
 		fmt.Println("\nSkipped hooks.toml generation (per --skip / user choice).")
 		return
 	case initModeWalkthrough:
-		profile = walkthroughProfile(profile)
+		profile = walkthroughProfile(profile, prompter)
 	}
 
 	hooksContent := generateHooksToml(profile)
 
-	if decision.Mode == initModeAuto && !decision.SkipConfirm && cli.IsInteractive() {
+	if decision.Mode == initModeAuto && !decision.SkipConfirm && prompter.IsInteractive() {
 		// Show preview, confirm.
 		fmt.Println("\nProposed .grove/hooks.toml:")
 		fmt.Println(strings.TrimRight(indentLines(hooksContent, "  "), "\n"))
 		fmt.Println()
-		ok, err := cli.Confirm("Write this to .grove/hooks.toml?", true)
+		ok, err := prompter.Confirm("Write this to .grove/hooks.toml?", true)
 		if err != nil || !ok {
 			fmt.Println("Skipped hooks.toml generation.")
 			return
@@ -276,7 +276,7 @@ type initModeDecision struct {
 // resolveInitMode picks how init should generate hooks based on flags + TTY.
 // Precedence: explicit flag > interactive prompt > non-TTY default (auto+yes).
 // Reads package-level flag globals (set by cobra) but does NOT write them.
-func resolveInitMode() initModeDecision {
+func resolveInitMode(prompter cli.Prompter) initModeDecision {
 	switch {
 	case initWalkthrough:
 		return initModeDecision{Mode: initModeWalkthrough, SkipConfirm: initYes}
@@ -286,7 +286,7 @@ func resolveInitMode() initModeDecision {
 		// --yes alone implies --auto without confirm.
 		return initModeDecision{Mode: initModeAuto, SkipConfirm: true}
 	}
-	if !cli.IsInteractive() {
+	if !prompter.IsInteractive() {
 		// Non-TTY (CI, pipes): preserve historical zero-prompt behavior.
 		return initModeDecision{Mode: initModeAuto, SkipConfirm: true}
 	}
@@ -297,7 +297,7 @@ func resolveInitMode() initModeDecision {
 		idxWalkthrough
 		idxSkip
 	)
-	idx, err := cli.ChooseIndex(
+	idx, err := prompter.ChooseIndex(
 		"How would you like to configure hooks.toml?",
 		[]string{
 			"auto (generate from detection, with preview)",
@@ -331,20 +331,20 @@ const (
 // walkthroughProfile prompts the user about each detected item so they can
 // keep, route to a different runner, or drop it. Returns a new profile —
 // does not mutate the input.
-func walkthroughProfile(p *detect.ProjectProfile) *detect.ProjectProfile {
+func walkthroughProfile(p *detect.ProjectProfile, prompter cli.Prompter) *detect.ProjectProfile {
 	out := *p
 
 	// Copy/symlink prompts: just keep/skip. filterByPrompt allocates a fresh
 	// slice so the input profile's backing array isn't shared.
-	out.Copy = filterByPrompt(p.Copy, "Copy file from main worktree?")
-	out.Symlinks = filterByPrompt(p.Symlinks, "Symlink dir from main worktree?")
+	out.Copy = filterByPrompt(p.Copy, "Copy file from main worktree?", prompter)
+	out.Symlinks = filterByPrompt(p.Symlinks, "Symlink dir from main worktree?", prompter)
 
 	// Host commands: route host/container/skip.
 	if len(p.Commands) > 0 {
 		keptHost := make([]string, 0, len(p.Commands))
 		var routedToContainer []detect.ContainerCommand
 		for _, cmd := range p.Commands {
-			switch promptCommandRouting(cmd, p.HasDocker, p.DockerService) {
+			switch promptCommandRouting(cmd, p.HasDocker, p.DockerService, prompter) {
 			case routeHost:
 				keptHost = append(keptHost, cmd)
 			case routeContainer:
@@ -370,7 +370,7 @@ func walkthroughProfile(p *detect.ProjectProfile) *detect.ProjectProfile {
 		keptContainer := make([]detect.ContainerCommand, 0, len(p.ContainerCommands))
 		var demoted []string
 		for _, cc := range p.ContainerCommands {
-			switch promptCommandRouting(cc.Command, true, cc.Service) {
+			switch promptCommandRouting(cc.Command, true, cc.Service, prompter) {
 			case routeHost:
 				demoted = append(demoted, cc.Command)
 			case routeContainer:
@@ -389,13 +389,13 @@ func walkthroughProfile(p *detect.ProjectProfile) *detect.ProjectProfile {
 	return &out
 }
 
-func filterByPrompt(items []string, q string) []string {
+func filterByPrompt(items []string, q string, prompter cli.Prompter) []string {
 	if len(items) == 0 {
 		return items
 	}
 	kept := make([]string, 0, len(items))
 	for _, item := range items {
-		ok, err := cli.Confirm(fmt.Sprintf("%s %q", q, item), true)
+		ok, err := prompter.Confirm(fmt.Sprintf("%s %q", q, item), true)
 		if err == nil && ok {
 			kept = append(kept, item)
 		}
@@ -403,7 +403,7 @@ func filterByPrompt(items []string, q string) []string {
 	return kept
 }
 
-func promptCommandRouting(cmd string, hasDocker bool, service string) commandRouting {
+func promptCommandRouting(cmd string, hasDocker bool, service string, prompter cli.Prompter) commandRouting {
 	// Build options + parallel routing slice so dispatch is index-keyed,
 	// not label-text-keyed (label copy can change without breaking dispatch).
 	options := []string{"host (run on host machine)"}
@@ -419,7 +419,7 @@ func promptCommandRouting(cmd string, hasDocker bool, service string) commandRou
 	options = append(options, "skip (don't run this command)")
 	routings = append(routings, routeSkip)
 
-	idx, err := cli.ChooseIndex(fmt.Sprintf("How to run %q?", cmd), options)
+	idx, err := prompter.ChooseIndex(fmt.Sprintf("How to run %q?", cmd), options)
 	if err != nil || idx < 0 || idx >= len(routings) {
 		return routeSkip
 	}

--- a/cmd/grove/commands/init_test.go
+++ b/cmd/grove/commands/init_test.go
@@ -1,12 +1,71 @@
 package commands
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/config"
 	"github.com/lost-in-the/grove/internal/detect"
 )
+
+// fakePrompter is a scripted cli.Prompter used by tests that need to drive
+// the interactive code paths without raw-TTY stdin. ChooseIndex pops from
+// chooseQueue; Confirm pops from confirmQueue. Calls beyond the queue
+// length panic, so each test case is forced to declare exactly the prompts
+// it expects.
+type fakePrompter struct {
+	interactive  bool
+	chooseQueue  []chooseResult
+	confirmQueue []confirmResult
+	chooseLog    []chooseCall
+	confirmLog   []confirmCall
+}
+
+type chooseResult struct {
+	idx int
+	err error
+}
+
+type confirmResult struct {
+	ok  bool
+	err error
+}
+
+type chooseCall struct {
+	title   string
+	options []string
+}
+
+type confirmCall struct {
+	question   string
+	defaultYes bool
+}
+
+func (p *fakePrompter) IsInteractive() bool { return p.interactive }
+
+func (p *fakePrompter) ChooseIndex(title string, options []string) (int, error) {
+	p.chooseLog = append(p.chooseLog, chooseCall{title: title, options: append([]string{}, options...)})
+	if len(p.chooseQueue) == 0 {
+		panic(fmt.Sprintf("fakePrompter.ChooseIndex called more times than scripted (title=%q)", title))
+	}
+	r := p.chooseQueue[0]
+	p.chooseQueue = p.chooseQueue[1:]
+	return r.idx, r.err
+}
+
+func (p *fakePrompter) Confirm(question string, defaultYes bool) (bool, error) {
+	p.confirmLog = append(p.confirmLog, confirmCall{question: question, defaultYes: defaultYes})
+	if len(p.confirmQueue) == 0 {
+		panic(fmt.Sprintf("fakePrompter.Confirm called more times than scripted (question=%q)", question))
+	}
+	r := p.confirmQueue[0]
+	p.confirmQueue = p.confirmQueue[1:]
+	return r.ok, r.err
+}
 
 func TestGenerateHooksToml_HostCommand(t *testing.T) {
 	p := &detect.ProjectProfile{
@@ -139,8 +198,7 @@ func TestResolveInitMode_FlagPrecedence(t *testing.T) {
 			wantSkipConfirm: true,
 		},
 		{
-			// In `go test`, stdin is not a TTY, so this falls through to
-			// the non-TTY default rather than the interactive prompt.
+			// Non-interactive prompter triggers the non-TTY default branch.
 			name:            "no flags in non-TTY defaults to auto+skipconfirm",
 			wantMode:        initModeAuto,
 			wantSkipConfirm: true,
@@ -149,40 +207,360 @@ func TestResolveInitMode_FlagPrecedence(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			initAuto, initWalkthrough, initYes = c.auto, c.walkthrough, c.yes
-			got := resolveInitMode()
+			p := &fakePrompter{interactive: false}
+			got := resolveInitMode(p)
 			if got.Mode != c.wantMode {
 				t.Errorf("Mode = %q, want %q", got.Mode, c.wantMode)
 			}
 			if got.SkipConfirm != c.wantSkipConfirm {
 				t.Errorf("SkipConfirm = %v, want %v", got.SkipConfirm, c.wantSkipConfirm)
 			}
+			if len(p.chooseLog) != 0 {
+				t.Errorf("non-TTY/flag path should not call ChooseIndex; got %d calls", len(p.chooseLog))
+			}
 		})
 	}
 }
 
-func TestFilterProfileForExternalDocker_StripsContainerCommands(t *testing.T) {
-	// When vendor/bundle is symlinked from external compose, the matching
-	// container `bundle install` should also be skipped.
-	p := &detect.ProjectProfile{
-		HasDocker: true,
-		ContainerCommands: []detect.ContainerCommand{
-			{Service: "app", Command: "bundle install --quiet"},
-			{Service: "app", Command: "rails db:setup"},
-		},
-		Commands: []string{"npm install"},
-		Symlinks: []string{"vendor/bundle"},
-	}
-	ext := &config.ExternalComposeConfig{
-		SymlinkDirs: []string{"vendor/bundle", "node_modules"},
-	}
-	filterProfileForExternalDocker(p, ext)
+// TestResolveInitMode_Interactive covers the prompt branch that was
+// previously unreachable in tests because cli.IsInteractive() reads
+// os.Stdin.Fd() directly. With the cli.Prompter seam, we can drive it.
+func TestResolveInitMode_Interactive(t *testing.T) {
+	// Save and restore flag globals so the cases land on the prompt branch.
+	origAuto, origWalkthrough, origYes := initAuto, initWalkthrough, initYes
+	t.Cleanup(func() {
+		initAuto, initWalkthrough, initYes = origAuto, origWalkthrough, origYes
+	})
+	initAuto, initWalkthrough, initYes = false, false, false
 
-	for _, cc := range p.ContainerCommands {
-		if strings.Contains(cc.Command, "bundle install") {
-			t.Errorf("expected bundle install removed from container commands, got %v", p.ContainerCommands)
-		}
+	cases := []struct {
+		name            string
+		choose          chooseResult
+		wantMode        string
+		wantSkipConfirm bool
+	}{
+		{name: "user picks auto", choose: chooseResult{idx: 0}, wantMode: initModeAuto},
+		{name: "user picks walkthrough", choose: chooseResult{idx: 1}, wantMode: initModeWalkthrough},
+		{name: "user picks skip", choose: chooseResult{idx: 2}, wantMode: initModeSkip},
+		{
+			// Cancel / unknown index falls through the switch default to skip.
+			name: "out-of-range index falls back to skip", choose: chooseResult{idx: 99}, wantMode: initModeSkip,
+		},
+		{
+			// Errors (Ctrl+C, EOF) → safest path is skip.
+			name: "ChooseIndex error returns skip", choose: chooseResult{err: errors.New("canceled")}, wantMode: initModeSkip,
+		},
 	}
-	if len(p.Commands) != 0 {
-		t.Errorf("expected npm install host command stripped (node_modules symlinked), got %v", p.Commands)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := &fakePrompter{
+				interactive: true,
+				chooseQueue: []chooseResult{c.choose},
+			}
+			got := resolveInitMode(p)
+			if got.Mode != c.wantMode {
+				t.Errorf("Mode = %q, want %q", got.Mode, c.wantMode)
+			}
+			if got.SkipConfirm != c.wantSkipConfirm {
+				t.Errorf("SkipConfirm = %v, want %v", got.SkipConfirm, c.wantSkipConfirm)
+			}
+			if len(p.chooseLog) != 1 {
+				t.Fatalf("expected exactly 1 ChooseIndex call, got %d", len(p.chooseLog))
+			}
+			// Sanity: the prompt copy still offers three options in stable order.
+			if n := len(p.chooseLog[0].options); n != 3 {
+				t.Errorf("expected 3 options in prompt, got %d", n)
+			}
+		})
 	}
 }
+
+func TestFilterProfileForExternalDocker(t *testing.T) {
+	cases := []struct {
+		name              string
+		profile           detect.ProjectProfile
+		ext               config.ExternalComposeConfig
+		wantSymlinks      []string
+		wantCopy          []string
+		wantCommands      []string
+		wantContainerCmds []detect.ContainerCommand
+	}{
+		{
+			// Regression: original case from #38 e7ea728.
+			name: "strips container bundle install when vendor/bundle symlinked",
+			profile: detect.ProjectProfile{
+				HasDocker: true,
+				ContainerCommands: []detect.ContainerCommand{
+					{Service: "app", Command: "bundle install --quiet"},
+					{Service: "app", Command: "rails db:setup"},
+				},
+				Commands: []string{"npm install"},
+				Symlinks: []string{"vendor/bundle"},
+			},
+			ext:               config.ExternalComposeConfig{SymlinkDirs: []string{"vendor/bundle", "node_modules"}},
+			wantSymlinks:      []string{},
+			wantCopy:          nil,
+			wantCommands:      []string{},
+			wantContainerCmds: []detect.ContainerCommand{{Service: "app", Command: "rails db:setup"}},
+		},
+		{
+			name: "empty ext is a no-op",
+			profile: detect.ProjectProfile{
+				Symlinks:          []string{"node_modules"},
+				Copy:              []string{".env"},
+				Commands:          []string{"npm install"},
+				ContainerCommands: []detect.ContainerCommand{{Service: "app", Command: "bundle install"}},
+			},
+			ext:               config.ExternalComposeConfig{},
+			wantSymlinks:      []string{"node_modules"},
+			wantCopy:          []string{".env"},
+			wantCommands:      []string{"npm install"},
+			wantContainerCmds: []detect.ContainerCommand{{Service: "app", Command: "bundle install"}},
+		},
+		{
+			// Same path appears in both CopyFiles and SymlinkFiles (e.g., user
+			// migrated config). Filtering must dedupe transparently — the file
+			// is removed once and there are no panics.
+			name: "overlapping CopyFiles and SymlinkFiles both contribute to copy filter",
+			profile: detect.ProjectProfile{
+				Copy: []string{".env", "config/master.key"},
+			},
+			ext: config.ExternalComposeConfig{
+				CopyFiles:    []string{".env"},
+				SymlinkFiles: []string{".env"}, // overlap
+			},
+			wantCopy:     []string{"config/master.key"},
+			wantSymlinks: nil,
+		},
+		{
+			// Mirrors the bundle/npm coverage at shouldSkipCommand: pip+.venv.
+			name: "pip install stripped when .venv symlinked",
+			profile: detect.ProjectProfile{
+				Commands:          []string{"pip install -r requirements.txt", "django-admin migrate"},
+				ContainerCommands: []detect.ContainerCommand{{Service: "web", Command: "pip install -r requirements.txt"}},
+			},
+			ext:               config.ExternalComposeConfig{SymlinkDirs: []string{".venv"}},
+			wantCommands:      []string{"django-admin migrate"},
+			wantContainerCmds: []detect.ContainerCommand{},
+			wantSymlinks:      nil,
+			wantCopy:          nil,
+		},
+		{
+			// Nil ContainerCommands must not panic; field stays nil/empty.
+			name: "nil ContainerCommands is safe",
+			profile: detect.ProjectProfile{
+				Symlinks: []string{"node_modules"},
+				Commands: []string{"npm install"},
+				// ContainerCommands intentionally nil.
+			},
+			ext:               config.ExternalComposeConfig{SymlinkDirs: []string{"node_modules"}},
+			wantSymlinks:      []string{},
+			wantCommands:      []string{},
+			wantContainerCmds: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := c.profile // copy so the table entry isn't mutated across runs
+			filterProfileForExternalDocker(&p, &c.ext)
+
+			if !reflect.DeepEqual(p.Symlinks, c.wantSymlinks) {
+				t.Errorf("Symlinks = %#v, want %#v", p.Symlinks, c.wantSymlinks)
+			}
+			if !reflect.DeepEqual(p.Copy, c.wantCopy) {
+				t.Errorf("Copy = %#v, want %#v", p.Copy, c.wantCopy)
+			}
+			if !reflect.DeepEqual(p.Commands, c.wantCommands) {
+				t.Errorf("Commands = %#v, want %#v", p.Commands, c.wantCommands)
+			}
+			if !reflect.DeepEqual(p.ContainerCommands, c.wantContainerCmds) {
+				t.Errorf("ContainerCommands = %#v, want %#v", p.ContainerCommands, c.wantContainerCmds)
+			}
+		})
+	}
+}
+
+// TestWalkthroughProfile exercises the per-item routing loop. The body was
+// previously unreachable in tests because cli.ChooseIndex / cli.Confirm
+// read raw-TTY stdin. With the cli.Prompter seam, we can drive each
+// branch deterministically.
+func TestWalkthroughProfile(t *testing.T) {
+	t.Run("host route keeps command on host", func(t *testing.T) {
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{idx: 0}}, // host
+		}
+		in := &detect.ProjectProfile{
+			Commands:      []string{"bundle install"},
+			HasDocker:     true,
+			DockerService: "web",
+		}
+		got := walkthroughProfile(in, p)
+		if !reflect.DeepEqual(got.Commands, []string{"bundle install"}) {
+			t.Errorf("Commands = %#v, want [bundle install]", got.Commands)
+		}
+		if len(got.ContainerCommands) != 0 {
+			t.Errorf("expected no ContainerCommands, got %#v", got.ContainerCommands)
+		}
+	})
+
+	t.Run("container route moves command to ContainerCommands with declared service", func(t *testing.T) {
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{idx: 1}}, // container
+		}
+		in := &detect.ProjectProfile{
+			Commands:      []string{"bundle install"},
+			HasDocker:     true,
+			DockerService: "web",
+		}
+		got := walkthroughProfile(in, p)
+		if len(got.Commands) != 0 {
+			t.Errorf("expected Commands empty after container routing, got %#v", got.Commands)
+		}
+		want := []detect.ContainerCommand{{Service: "web", Command: "bundle install"}}
+		if !reflect.DeepEqual(got.ContainerCommands, want) {
+			t.Errorf("ContainerCommands = %#v, want %#v", got.ContainerCommands, want)
+		}
+	})
+
+	t.Run("container route falls back to service \"app\" when none declared", func(t *testing.T) {
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{idx: 1}}, // container
+		}
+		in := &detect.ProjectProfile{
+			Commands:      []string{"npm install"},
+			HasDocker:     true,
+			DockerService: "", // unknown
+		}
+		got := walkthroughProfile(in, p)
+		want := []detect.ContainerCommand{{Service: "app", Command: "npm install"}}
+		if !reflect.DeepEqual(got.ContainerCommands, want) {
+			t.Errorf("ContainerCommands = %#v, want %#v (service should default to \"app\")", got.ContainerCommands, want)
+		}
+	})
+
+	t.Run("skip route drops command", func(t *testing.T) {
+		// hasDocker=true → 3 options [host, container, skip] at index 2.
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{idx: 2}},
+		}
+		in := &detect.ProjectProfile{
+			Commands:      []string{"bundle install"},
+			HasDocker:     true,
+			DockerService: "web",
+		}
+		got := walkthroughProfile(in, p)
+		if len(got.Commands) != 0 || len(got.ContainerCommands) != 0 {
+			t.Errorf("skip should drop command; got Commands=%#v Container=%#v", got.Commands, got.ContainerCommands)
+		}
+	})
+
+	t.Run("ChooseIndex error defaults to skip", func(t *testing.T) {
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{err: errors.New("canceled")}},
+		}
+		in := &detect.ProjectProfile{
+			Commands:      []string{"bundle install"},
+			HasDocker:     true,
+			DockerService: "web",
+		}
+		got := walkthroughProfile(in, p)
+		if len(got.Commands) != 0 || len(got.ContainerCommands) != 0 {
+			t.Errorf("error should drop command; got Commands=%#v Container=%#v", got.Commands, got.ContainerCommands)
+		}
+	})
+
+	t.Run("container command demoted to host", func(t *testing.T) {
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{idx: 0}}, // host (index 0 of [host, container, skip])
+		}
+		in := &detect.ProjectProfile{
+			ContainerCommands: []detect.ContainerCommand{{Service: "web", Command: "rails db:setup"}},
+		}
+		got := walkthroughProfile(in, p)
+		if !reflect.DeepEqual(got.Commands, []string{"rails db:setup"}) {
+			t.Errorf("expected demoted command on Commands, got %#v", got.Commands)
+		}
+		if len(got.ContainerCommands) != 0 {
+			t.Errorf("expected ContainerCommands cleared after demotion, got %#v", got.ContainerCommands)
+		}
+	})
+
+	t.Run("container command kept", func(t *testing.T) {
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{idx: 1}}, // container
+		}
+		in := &detect.ProjectProfile{
+			ContainerCommands: []detect.ContainerCommand{{Service: "web", Command: "rails db:setup"}},
+		}
+		got := walkthroughProfile(in, p)
+		want := []detect.ContainerCommand{{Service: "web", Command: "rails db:setup"}}
+		if !reflect.DeepEqual(got.ContainerCommands, want) {
+			t.Errorf("ContainerCommands = %#v, want %#v", got.ContainerCommands, want)
+		}
+		if len(got.Commands) != 0 {
+			t.Errorf("expected Commands empty, got %#v", got.Commands)
+		}
+	})
+
+	t.Run("copy and symlink prompts filter via Confirm", func(t *testing.T) {
+		p := &fakePrompter{
+			confirmQueue: []confirmResult{
+				{ok: true},  // keep .env
+				{ok: false}, // drop config/master.key
+				{ok: true},  // keep node_modules
+			},
+		}
+		in := &detect.ProjectProfile{
+			Copy:     []string{".env", "config/master.key"},
+			Symlinks: []string{"node_modules"},
+		}
+		got := walkthroughProfile(in, p)
+		if !reflect.DeepEqual(got.Copy, []string{".env"}) {
+			t.Errorf("Copy = %#v, want [.env]", got.Copy)
+		}
+		if !reflect.DeepEqual(got.Symlinks, []string{"node_modules"}) {
+			t.Errorf("Symlinks = %#v, want [node_modules]", got.Symlinks)
+		}
+	})
+
+	t.Run("empty profile is a no-op and never prompts", func(t *testing.T) {
+		p := &fakePrompter{} // empty queues; any call panics
+		in := &detect.ProjectProfile{}
+		got := walkthroughProfile(in, p)
+		if len(got.Commands) != 0 || len(got.ContainerCommands) != 0 || len(got.Copy) != 0 || len(got.Symlinks) != 0 {
+			t.Errorf("empty profile should stay empty, got %#v", got)
+		}
+		if len(p.chooseLog) != 0 || len(p.confirmLog) != 0 {
+			t.Errorf("expected no prompts, got chooseLog=%d confirmLog=%d", len(p.chooseLog), len(p.confirmLog))
+		}
+	})
+
+	t.Run("input profile is not mutated", func(t *testing.T) {
+		// Container route on a host command must not write through to the
+		// input slices (regression check on the fresh-allocation logic).
+		p := &fakePrompter{
+			chooseQueue: []chooseResult{{idx: 1}}, // container
+		}
+		origCmds := []string{"bundle install"}
+		origContainer := []detect.ContainerCommand{{Service: "web", Command: "rails db:setup"}}
+		in := &detect.ProjectProfile{
+			Commands:          append([]string{}, origCmds...),
+			ContainerCommands: append([]detect.ContainerCommand{}, origContainer...),
+			HasDocker:         true,
+			DockerService:     "web",
+		}
+		// Need a second prompt for the second loop (ContainerCommands).
+		p.chooseQueue = append(p.chooseQueue, chooseResult{idx: 1}) // keep container
+
+		_ = walkthroughProfile(in, p)
+		if !reflect.DeepEqual(in.Commands, origCmds) {
+			t.Errorf("input Commands mutated: got %#v, want %#v", in.Commands, origCmds)
+		}
+		if !reflect.DeepEqual(in.ContainerCommands, origContainer) {
+			t.Errorf("input ContainerCommands mutated: got %#v, want %#v", in.ContainerCommands, origContainer)
+		}
+	})
+}
+
+// Compile-time check that fakePrompter satisfies the cli.Prompter interface.
+var _ cli.Prompter = (*fakePrompter)(nil)

--- a/internal/cli/prompt.go
+++ b/internal/cli/prompt.go
@@ -18,6 +18,29 @@ func IsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
+// Prompter is the surface used by interactive command flows. Production code
+// uses StdPrompter; tests inject fakes so prompt branches are reachable
+// without raw-TTY stdin.
+type Prompter interface {
+	ChooseIndex(title string, options []string) (int, error)
+	Confirm(question string, defaultYes bool) (bool, error)
+	IsInteractive() bool
+}
+
+// StdPrompter delegates to the package-level prompt functions, which read
+// from os.Stdin.
+type StdPrompter struct{}
+
+func (StdPrompter) ChooseIndex(title string, options []string) (int, error) {
+	return ChooseIndex(title, options)
+}
+
+func (StdPrompter) Confirm(question string, defaultYes bool) (bool, error) {
+	return Confirm(question, defaultYes)
+}
+
+func (StdPrompter) IsInteractive() bool { return IsInteractive() }
+
 // ReadLine reads a single line of input from stdin, displaying the given prompt.
 // Uses raw terminal mode to properly handle Escape and Ctrl+C as cancellation.
 // Returns ErrPromptCanceled if the user cancels.

--- a/internal/cli/prompt_test.go
+++ b/internal/cli/prompt_test.go
@@ -56,3 +56,25 @@ func TestChoose_NonInteractive(t *testing.T) {
 		t.Error("Choose() expected error in non-interactive mode, got nil")
 	}
 }
+
+// TestStdPrompter_DelegatesToFreeFunctions verifies the default Prompter
+// implementation forwards to the package-level helpers — IsInteractive,
+// Confirm, ChooseIndex — so behavior in production code matches what
+// tests see when they substitute a fake.
+func TestStdPrompter_DelegatesToFreeFunctions(t *testing.T) {
+	p := StdPrompter{}
+
+	if got, want := p.IsInteractive(), IsInteractive(); got != want {
+		t.Errorf("StdPrompter.IsInteractive() = %v, want %v (must match free function)", got, want)
+	}
+
+	if IsInteractive() {
+		t.Skip("stdin is a TTY — skipping non-interactive delegation checks")
+	}
+	if _, err := p.Confirm("continue?", false); err == nil {
+		t.Error("StdPrompter.Confirm() expected error in non-interactive mode")
+	}
+	if _, err := p.ChooseIndex("pick", []string{"a", "b"}); err == nil {
+		t.Error("StdPrompter.ChooseIndex() expected error in non-interactive mode")
+	}
+}


### PR DESCRIPTION
Closes #38.

## Summary

Adds the test scaffolding the v0.7.0 release-readiness review called out as
non-trivial: prompt mocking and filesystem fixtures for the init / doctor
flows.

- `cli.Prompter` interface + `StdPrompter` (in `internal/cli`), threaded
  through `resolveInitMode`, `walkthroughProfile`, `promptCommandRouting`,
  and `filterByPrompt` so the interactive branches are reachable from
  `go test` (which can't drive raw-TTY stdin).
- `testProject(t, opts)` helper in `doctor_test.go` that materializes a
  Dockerfile + compose + hooks.toml under `t.TempDir()`, generalizing the
  inline pattern used by `TestCheckHooksDockerRouting_*`.

No public CLI behavior, config schema, or doc changes.

## New tests

| Gap | Test | Notes |
|---|---|---|
| 1 | `TestWalkthroughProfile` | host/container/skip routing, service-name fallback, container→host demotion, copy/symlink filtering, no-op on empty profile, input-not-mutated invariant |
| 2 | `TestResolveInitMode_Interactive` | drives prompt branch via scripted `fakePrompter` |
| 3 | `TestFilterProfileForExternalDocker` | table-driven: empty ext, overlapping copy/symlink, pip+.venv, nil-ContainerCommands, plus the original bundle/npm regression |
| 4 | `TestFixHostInstallsInDockerProject` | no-Docker, no-compose, uninferable-service, missing-hooks.toml, read-only-grove, happy path |
| 5 | `TestRewriteHostInstallsToCompose_FurtherEdgeCases` | pins current regex behavior on indented headers, multi-line strings, quoted keys, inline tables, with TODOs pointing at the companion TOML-parser refactor issue |

Coverage: `cmd/grove/commands` 12.5% → 15.1%; `internal/cli` 49.1% → 49.6%.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/grove/commands/ ./internal/cli/ -count=1` — all new + existing tests pass (one unrelated pre-existing failure: `TestGetCurrentCommit_Normal`, reproduces on `main` due to git-signing config in this sandbox)
- [x] `make lint` — 0 issues
- [x] Targeted runs of every new test name — all green; the read-only-`.grove` subtest correctly skips when running as root

https://claude.ai/code/session_016dqqpYzBc9bz7kF1y3kH7w

---
_Generated by [Claude Code](https://claude.ai/code/session_016dqqpYzBc9bz7kF1y3kH7w)_