### PR TITLE
feat(docker): support compose overlays for agent stacks

### DIFF
--- a/cmd/grove/commands/doctor.go
+++ b/cmd/grove/commands/doctor.go
@@ -401,6 +401,25 @@ func checkAgentStacks(w *cli.Writer, cfg *config.Config, ext *config.ExternalCom
 		return tmpl, nil
 	}) && *allPassed
 
+	if len(ext.Agent.TemplateOverlays) > 0 {
+		*allPassed = runCheck(w, "Agent template overlays", func() (string, error) {
+			for i, overlay := range ext.Agent.TemplateOverlays {
+				p := overlay
+				if !filepath.IsAbs(p) {
+					p = filepath.Join(docker.ResolveComposePath(ext.Path), p)
+				}
+				info, err := os.Stat(p)
+				if err != nil {
+					return "", fmt.Errorf("overlay[%d] %s: %w", i, p, err)
+				}
+				if info.IsDir() {
+					return "", fmt.Errorf("overlay[%d] %s is a directory, expected a compose file", i, p)
+				}
+			}
+			return fmt.Sprintf("%d overlay(s) ok", len(ext.Agent.TemplateOverlays)), nil
+		}) && *allPassed
+	}
+
 	checkAgentNetwork(w, ext.Agent.Network, allPassed)
 
 	slots, err := docker.ListActiveSlots(cfg)

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -320,6 +320,14 @@ services = ["web", "worker"]       # string array (required when enabled)
 # Required when enabled = true.
 template_path = "~/work/compose-dev/agent-compose.yml"  # string (required when enabled)
 
+# Optional overlay compose files merged on top of template_path in declared
+# order. Each becomes an extra `-f` flag on `docker compose` invocations.
+# Useful for per-project overrides (per-slot volume mounts, env files, service
+# tweaks) without forking the base template. Relative paths resolve against
+# plugins.docker.external.path, same as template_path. ~/ expands to $HOME.
+# Default: [] (no overlays)
+template_overlays = ["overrides/dev.yml"]  # string array (optional)
+
 # URL pattern for accessing agent services.
 # {port} is replaced with the allocated port.
 # Default: "http://localhost:{port}"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,12 +114,18 @@ func (e *ExternalComposeConfig) EnvFileName() string {
 
 // AgentStackConfig configures agent stack support for external compose mode.
 type AgentStackConfig struct {
-	Enabled      *bool    `toml:"enabled"`
-	MaxSlots     int      `toml:"max_slots"`
-	Services     []string `toml:"services"`
-	TemplatePath string   `toml:"template_path"`
-	URLPattern   string   `toml:"url_pattern"`
-	Network      string   `toml:"network"` // External Docker network that must exist for agent stacks
+	Enabled  *bool    `toml:"enabled"`
+	MaxSlots int      `toml:"max_slots"`
+	Services []string `toml:"services"`
+	// TemplatePath is the base compose file for an agent stack. Required.
+	TemplatePath string `toml:"template_path"`
+	// TemplateOverlays are additional compose files merged on top of TemplatePath
+	// in declared order. Each becomes an extra `-f` flag on docker compose
+	// invocations — useful for per-project overrides (volume mounts, env files,
+	// per-slot tweaks) without forking the base template.
+	TemplateOverlays []string `toml:"template_overlays"`
+	URLPattern       string   `toml:"url_pattern"`
+	Network          string   `toml:"network"` // External Docker network that must exist for agent stacks
 }
 
 // GetConfigPaths returns the paths to check for config files

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -853,6 +853,7 @@ enabled = true
 max_slots = 3
 services = ["agent"]
 template_path = "/tmp/agent-template"
+template_overlays = ["/tmp/overlay-a.yml", "/tmp/overlay-b.yml"]
 url_pattern = "http://localhost:{port}"
 `
 	configPath := filepath.Join(tmpDir, "config.toml")
@@ -885,8 +886,56 @@ url_pattern = "http://localhost:{port}"
 	if agent.TemplatePath != "/tmp/agent-template" {
 		t.Errorf("Expected template_path '/tmp/agent-template', got %q", agent.TemplatePath)
 	}
+	wantOverlays := []string{"/tmp/overlay-a.yml", "/tmp/overlay-b.yml"}
+	if len(agent.TemplateOverlays) != len(wantOverlays) {
+		t.Fatalf("Expected %d overlays, got %d (%v)", len(wantOverlays), len(agent.TemplateOverlays), agent.TemplateOverlays)
+	}
+	for i, want := range wantOverlays {
+		if agent.TemplateOverlays[i] != want {
+			t.Errorf("template_overlays[%d] = %q, want %q", i, agent.TemplateOverlays[i], want)
+		}
+	}
 	if agent.URLPattern != "http://localhost:{port}" {
 		t.Errorf("Expected url_pattern 'http://localhost:{port}', got %q", agent.URLPattern)
+	}
+}
+
+func TestLoadAgentStackConfig_NoOverlays(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "shared-infra")
+	if err := os.MkdirAll(composePath, 0755); err != nil {
+		t.Fatalf("Failed to create compose dir: %v", err)
+	}
+
+	configData := `
+[plugins.docker]
+enabled = true
+mode = "external"
+
+[plugins.docker.external]
+path = "` + composePath + `"
+env_var = "APP_DIR"
+services = ["app"]
+
+[plugins.docker.external.agent]
+enabled = true
+max_slots = 3
+services = ["agent"]
+template_path = "/tmp/agent-template"
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigFromPath(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfigFromPath() error = %v", err)
+	}
+
+	agent := cfg.Plugins.Docker.External.Agent
+	if len(agent.TemplateOverlays) != 0 {
+		t.Errorf("Expected no overlays without template_overlays key, got %v", agent.TemplateOverlays)
 	}
 }
 
@@ -977,6 +1026,31 @@ func TestValidateAgentConfig(t *testing.T) {
 				}
 			},
 			wantErr: false,
+		},
+		{
+			name: "agent enabled with template_overlays is valid",
+			modify: func(c *Config) {
+				c.Plugins.Docker.External.Agent = &AgentStackConfig{
+					Enabled:          &boolTrue,
+					Services:         []string{"agent"},
+					TemplatePath:     "/tmp/tpl",
+					TemplateOverlays: []string{"/tmp/overlay.yml"},
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "agent enabled with empty-string overlay is invalid",
+			modify: func(c *Config) {
+				c.Plugins.Docker.External.Agent = &AgentStackConfig{
+					Enabled:          &boolTrue,
+					Services:         []string{"agent"},
+					TemplatePath:     "/tmp/tpl",
+					TemplateOverlays: []string{"/tmp/overlay.yml", ""},
+				}
+			},
+			wantErr: true,
+			errMsg:  "agent.template_overlays",
 		},
 	}
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -26,15 +26,27 @@ func resolveProjectPaths(cfg *Config, projectRoot string) error {
 	}
 	ext.Path = resolved
 
-	// Expand ~/ in template_path; non-absolute, non-tilde values stay as written
-	// (the docker plugin joins them against the compose directory at exec time,
-	// which is the documented contract).
+	// Expand ~/ in template_path and each template_overlays entry; non-absolute,
+	// non-tilde values stay as written (the docker plugin joins them against the
+	// compose directory at exec time, which is the documented contract).
 	if ext.Agent != nil && ext.Agent.TemplatePath != "" {
 		expanded, err := expandTildePath(ext.Agent.TemplatePath)
 		if err != nil {
 			return fmt.Errorf("plugins.docker.external.agent.template_path: %w", err)
 		}
 		ext.Agent.TemplatePath = expanded
+	}
+	if ext.Agent != nil {
+		for i, overlay := range ext.Agent.TemplateOverlays {
+			if overlay == "" {
+				continue
+			}
+			expanded, err := expandTildePath(overlay)
+			if err != nil {
+				return fmt.Errorf("plugins.docker.external.agent.template_overlays[%d]: %w", i, err)
+			}
+			ext.Agent.TemplateOverlays[i] = expanded
+		}
 	}
 	return nil
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -29,14 +29,14 @@ func resolveProjectPaths(cfg *Config, projectRoot string) error {
 	// Expand ~/ in template_path and each template_overlays entry; non-absolute,
 	// non-tilde values stay as written (the docker plugin joins them against the
 	// compose directory at exec time, which is the documented contract).
-	if ext.Agent != nil && ext.Agent.TemplatePath != "" {
-		expanded, err := expandTildePath(ext.Agent.TemplatePath)
-		if err != nil {
-			return fmt.Errorf("plugins.docker.external.agent.template_path: %w", err)
-		}
-		ext.Agent.TemplatePath = expanded
-	}
 	if ext.Agent != nil {
+		if ext.Agent.TemplatePath != "" {
+			expanded, err := expandTildePath(ext.Agent.TemplatePath)
+			if err != nil {
+				return fmt.Errorf("plugins.docker.external.agent.template_path: %w", err)
+			}
+			ext.Agent.TemplatePath = expanded
+		}
 		for i, overlay := range ext.Agent.TemplateOverlays {
 			if overlay == "" {
 				continue

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -142,6 +142,50 @@ func TestResolveProjectPaths_TildeTemplatePath(t *testing.T) {
 	}
 }
 
+func TestResolveProjectPaths_TildeTemplateOverlays(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir() error = %v", err)
+	}
+
+	cfg := &Config{
+		Plugins: PluginsConfig{
+			Docker: DockerPluginConfig{
+				External: &ExternalComposeConfig{
+					Path: "/abs/orchestrator",
+					Agent: &AgentStackConfig{
+						TemplatePath: "agent-stacks/template.yml",
+						TemplateOverlays: []string{
+							"~/work/overlay-a.yml",
+							"overlay-b.yml",
+							"/abs/overlay-c.yml",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := resolveProjectPaths(cfg, "/abs/orchestrator"); err != nil {
+		t.Fatalf("resolveProjectPaths() error = %v", err)
+	}
+
+	overlays := cfg.Plugins.Docker.External.Agent.TemplateOverlays
+	want := []string{
+		filepath.Join(home, "work", "overlay-a.yml"),
+		"overlay-b.yml",
+		"/abs/overlay-c.yml",
+	}
+	if len(overlays) != len(want) {
+		t.Fatalf("TemplateOverlays length = %d, want %d", len(overlays), len(want))
+	}
+	for i, w := range want {
+		if overlays[i] != w {
+			t.Errorf("TemplateOverlays[%d] = %q, want %q", i, overlays[i], w)
+		}
+	}
+}
+
 func TestResolveProjectPaths_TemplatePathNonTildeUnchanged(t *testing.T) {
 	cfg := &Config{
 		Plugins: PluginsConfig{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -145,5 +145,10 @@ func validateExternalAgent(ext *ExternalComposeConfig) error {
 	if ext.Agent.TemplatePath == "" {
 		return fmt.Errorf("plugins.docker.external.agent.template_path is required when agent mode is enabled")
 	}
+	for i, overlay := range ext.Agent.TemplateOverlays {
+		if overlay == "" {
+			return fmt.Errorf("plugins.docker.external.agent.template_overlays[%d] must be a non-empty path", i)
+		}
+	}
 	return nil
 }

--- a/plugins/docker/agent_external.go
+++ b/plugins/docker/agent_external.go
@@ -104,7 +104,7 @@ func (s *agentExternalStrategy) Up(worktreePath string, detach bool) error {
 	if s.ext.EnvVar != "" {
 		cli.EnvDirective(s.ext.EnvVar, worktreePath)
 	}
-	templatePath := s.resolveTemplatePath()
+	templatePaths := s.resolveTemplatePaths()
 	composePath := s.composePath()
 
 	// Check that the required external Docker network exists (if configured)
@@ -134,7 +134,7 @@ func (s *agentExternalStrategy) Up(worktreePath string, detach bool) error {
 	}
 	args = append(args, s.agent.Services...)
 
-	cmd := agentComposeCommand(composePath, templatePath, projectName, env, args...)
+	cmd := agentComposeCommand(composePath, templatePaths, projectName, env, args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -162,12 +162,12 @@ func (s *agentExternalStrategy) Down(worktreePath string) error {
 	}
 
 	projectName := s.composeProjectName(slot)
-	templatePath := s.resolveTemplatePath()
+	templatePaths := s.resolveTemplatePaths()
 	composePath := s.composePath()
 
 	env := s.agentEnv(worktreePath, slot)
 
-	cmd := agentComposeCommand(composePath, templatePath, projectName, env, "down")
+	cmd := agentComposeCommand(composePath, templatePaths, projectName, env, "down")
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -184,11 +184,11 @@ func (s *agentExternalStrategy) Down(worktreePath string) error {
 
 // agentCtx holds the resolved context needed to run agent compose commands.
 type agentCtx struct {
-	composePath  string
-	templatePath string
-	projectName  string
-	env          []string
-	wtName       string
+	composePath   string
+	templatePaths []string
+	projectName   string
+	env           []string
+	wtName        string
 }
 
 // agentContext resolves compose paths, project name, and base env for a worktree.
@@ -197,11 +197,11 @@ func (s *agentExternalStrategy) agentContext(worktreePath string) agentCtx {
 	wtName := filepath.Base(worktreePath)
 	slot, _ := s.slots.FindSlot(wtName)
 	return agentCtx{
-		composePath:  s.composePath(),
-		templatePath: s.resolveTemplatePath(),
-		projectName:  s.composeProjectName(slot),
-		env:          s.agentEnv(worktreePath, slot),
-		wtName:       wtName,
+		composePath:   s.composePath(),
+		templatePaths: s.resolveTemplatePaths(),
+		projectName:   s.composeProjectName(slot),
+		env:           s.agentEnv(worktreePath, slot),
+		wtName:        wtName,
 	}
 }
 
@@ -216,7 +216,7 @@ func (s *agentExternalStrategy) Run(worktreePath string, service string, command
 		env = append(env, fmt.Sprintf("TEST_ENV_NUMBER=%d", envNum))
 	}
 
-	cmd := agentComposeCommand(ac.composePath, ac.templatePath, ac.projectName, env, "run", "--rm", service, "bash", "-cil", command)
+	cmd := agentComposeCommand(ac.composePath, ac.templatePaths, ac.projectName, env, "run", "--rm", service, "bash", "-cil", command)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
@@ -233,7 +233,7 @@ func (s *agentExternalStrategy) Exec(worktreePath string, service string, comman
 		env = append(env, fmt.Sprintf("TEST_ENV_NUMBER=%d", envNum))
 	}
 
-	cmd := agentComposeCommand(ac.composePath, ac.templatePath, ac.projectName, env, "exec", service, "bash", "-cil", command)
+	cmd := agentComposeCommand(ac.composePath, ac.templatePaths, ac.projectName, env, "exec", service, "bash", "-cil", command)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
@@ -254,7 +254,7 @@ func (s *agentExternalStrategy) Logs(worktreePath string, service string, follow
 		args = append(args, s.agent.Services...)
 	}
 
-	cmd := agentComposeCommand(ac.composePath, ac.templatePath, ac.projectName, ac.env, args...)
+	cmd := agentComposeCommand(ac.composePath, ac.templatePaths, ac.projectName, ac.env, args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
@@ -272,7 +272,7 @@ func (s *agentExternalStrategy) Restart(worktreePath string, service string) err
 		args = append(args, s.agent.Services...)
 	}
 
-	cmd := agentComposeCommand(ac.composePath, ac.templatePath, ac.projectName, ac.env, args...)
+	cmd := agentComposeCommand(ac.composePath, ac.templatePaths, ac.projectName, ac.env, args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -300,13 +300,24 @@ func (s *agentExternalStrategy) composePath() string {
 	return resolveComposePath(s.ext.Path)
 }
 
-// resolveTemplatePath returns the absolute path to the agent compose template.
-func (s *agentExternalStrategy) resolveTemplatePath() string {
-	tmpl := s.agent.TemplatePath
-	if filepath.IsAbs(tmpl) {
-		return tmpl
+// resolveTemplatePaths returns the absolute paths to the agent compose template
+// and its overlays in declared order. The base template is always element 0,
+// followed by each overlay. Relative paths are joined against the compose
+// directory; absolute paths are returned as-is.
+func (s *agentExternalStrategy) resolveTemplatePaths() []string {
+	composeDir := s.composePath()
+	resolve := func(p string) string {
+		if filepath.IsAbs(p) {
+			return p
+		}
+		return filepath.Join(composeDir, p)
 	}
-	return filepath.Join(s.composePath(), tmpl)
+	paths := make([]string, 0, 1+len(s.agent.TemplateOverlays))
+	paths = append(paths, resolve(s.agent.TemplatePath))
+	for _, overlay := range s.agent.TemplateOverlays {
+		paths = append(paths, resolve(overlay))
+	}
+	return paths
 }
 
 // agentEnv builds the environment variables for agent compose commands.
@@ -334,10 +345,16 @@ func resolveComposePath(path string) string {
 	return path
 }
 
-// agentComposeCommand creates a docker compose command with -f and -p flags for agent projects.
-func agentComposeCommand(composePath string, templateFile string, projectName string, env []string, args ...string) *exec.Cmd {
-	cmdArgs := make([]string, 0, 5+len(args))
-	cmdArgs = append(cmdArgs, "compose", "-f", templateFile, "-p", projectName)
+// agentComposeCommand creates a docker compose command with one -f flag per
+// template file (in order) and a -p project flag. The base template plus any
+// overlays merge via docker compose's standard `-f a.yml -f b.yml` semantics.
+func agentComposeCommand(composePath string, templateFiles []string, projectName string, env []string, args ...string) *exec.Cmd {
+	cmdArgs := make([]string, 0, 3+2*len(templateFiles)+len(args))
+	cmdArgs = append(cmdArgs, "compose")
+	for _, tmpl := range templateFiles {
+		cmdArgs = append(cmdArgs, "-f", tmpl)
+	}
+	cmdArgs = append(cmdArgs, "-p", projectName)
 	cmdArgs = append(cmdArgs, args...)
 
 	cmd := exec.Command("docker", cmdArgs...)

--- a/plugins/docker/agent_external_test.go
+++ b/plugins/docker/agent_external_test.go
@@ -263,21 +263,50 @@ func TestAgentExternalStrategy_ComposeProjectName_DefaultProject(t *testing.T) {
 	}
 }
 
-func TestAgentExternalStrategy_ResolveTemplatePath(t *testing.T) {
+func TestAgentExternalStrategy_ResolveTemplatePaths(t *testing.T) {
 	cfg := newTestAgentConfig(t)
 	s := newAgentExternalStrategy(cfg)
 
 	// Relative path should be joined with compose path
-	got := s.resolveTemplatePath()
-	if !strings.HasSuffix(got, "agent-stacks/template.yml") {
-		t.Errorf("resolveTemplatePath() = %q, want suffix 'agent-stacks/template.yml'", got)
+	got := s.resolveTemplatePaths()
+	if len(got) != 1 {
+		t.Fatalf("resolveTemplatePaths() returned %d paths, want 1", len(got))
+	}
+	if !strings.HasSuffix(got[0], "agent-stacks/template.yml") {
+		t.Errorf("resolveTemplatePaths()[0] = %q, want suffix 'agent-stacks/template.yml'", got[0])
 	}
 
 	// Absolute path should be returned as-is
 	s.agent.TemplatePath = "/abs/path/template.yml"
-	got = s.resolveTemplatePath()
-	if got != "/abs/path/template.yml" {
-		t.Errorf("resolveTemplatePath() = %q, want '/abs/path/template.yml'", got)
+	got = s.resolveTemplatePaths()
+	if len(got) != 1 || got[0] != "/abs/path/template.yml" {
+		t.Errorf("resolveTemplatePaths() = %v, want ['/abs/path/template.yml']", got)
+	}
+}
+
+func TestAgentExternalStrategy_ResolveTemplatePaths_WithOverlays(t *testing.T) {
+	cfg := newTestAgentConfig(t)
+	s := newAgentExternalStrategy(cfg)
+
+	// Mix of relative and absolute overlays.
+	s.agent.TemplatePath = "agent-stacks/template.yml"
+	s.agent.TemplateOverlays = []string{
+		"agent-stacks/dev.yml",
+		"/abs/overlay.yml",
+	}
+
+	got := s.resolveTemplatePaths()
+	if len(got) != 3 {
+		t.Fatalf("resolveTemplatePaths() returned %d paths, want 3 (base + 2 overlays)", len(got))
+	}
+	if !strings.HasSuffix(got[0], "agent-stacks/template.yml") {
+		t.Errorf("base path = %q, want suffix 'agent-stacks/template.yml'", got[0])
+	}
+	if !strings.HasSuffix(got[1], "agent-stacks/dev.yml") {
+		t.Errorf("overlay[0] = %q, want suffix 'agent-stacks/dev.yml'", got[1])
+	}
+	if got[2] != "/abs/overlay.yml" {
+		t.Errorf("overlay[1] = %q, want '/abs/overlay.yml'", got[2])
 	}
 }
 
@@ -313,7 +342,7 @@ func TestAgentExternalStrategy_AgentEnv(t *testing.T) {
 }
 
 func TestAgentComposeCommand(t *testing.T) {
-	cmd := agentComposeCommand("/tmp/compose", "/tmp/compose/template.yml", "myapp-agent-1", []string{"APP_DIR=/app"}, "up", "-d", "app")
+	cmd := agentComposeCommand("/tmp/compose", []string{"/tmp/compose/template.yml"}, "myapp-agent-1", []string{"APP_DIR=/app"}, "up", "-d", "app")
 
 	if cmd.Dir != "/tmp/compose" {
 		t.Errorf("cmd.Dir = %q, want /tmp/compose", cmd.Dir)
@@ -330,15 +359,42 @@ func TestAgentComposeCommand(t *testing.T) {
 	}
 }
 
+func TestAgentComposeCommand_MultipleTemplates(t *testing.T) {
+	cmd := agentComposeCommand(
+		"/tmp/compose",
+		[]string{"/tmp/compose/base.yml", "/tmp/compose/overlay-a.yml", "/tmp/compose/overlay-b.yml"},
+		"myapp-agent-1",
+		nil,
+		"up", "-d",
+	)
+
+	wantArgs := []string{
+		"docker", "compose",
+		"-f", "/tmp/compose/base.yml",
+		"-f", "/tmp/compose/overlay-a.yml",
+		"-f", "/tmp/compose/overlay-b.yml",
+		"-p", "myapp-agent-1",
+		"up", "-d",
+	}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("cmd.Args = %v, want %v", cmd.Args, wantArgs)
+	}
+	for i, want := range wantArgs {
+		if cmd.Args[i] != want {
+			t.Errorf("cmd.Args[%d] = %q, want %q", i, cmd.Args[i], want)
+		}
+	}
+}
+
 func TestAgentComposeCommand_WithEnv(t *testing.T) {
-	cmd := agentComposeCommand("/tmp", "/tmp/template.yml", "test-agent-1", []string{"FOO=bar"}, "up")
+	cmd := agentComposeCommand("/tmp", []string{"/tmp/template.yml"}, "test-agent-1", []string{"FOO=bar"}, "up")
 	if len(cmd.Env) == 0 {
 		t.Error("Expected env vars to be set")
 	}
 }
 
 func TestAgentComposeCommand_WithoutEnv(t *testing.T) {
-	cmd := agentComposeCommand("/tmp", "/tmp/template.yml", "test-agent-1", nil, "up")
+	cmd := agentComposeCommand("/tmp", []string{"/tmp/template.yml"}, "test-agent-1", nil, "up")
 	if len(cmd.Env) != 0 {
 		t.Errorf("Expected no env override, got %d vars", len(cmd.Env))
 	}


### PR DESCRIPTION
Add `template_overlays` to the agent stack config so projects can layer
extra compose files on top of `template_path` instead of forking the
base template. Each overlay becomes an extra `-f` flag on every docker
compose invocation in agent mode (up, down, logs, run, exec, restart),
which matches docker compose's standard merge semantics.

Closes #36