### PR TITLE
security: SafeJoin path-traversal guard + resolveComposePath cleanup (#45, #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.7.0] - 2026-05-04
+
+> **Upgrading:** No breaking config changes. Docker users should run `grove doctor` to surface host install commands that should now be `docker:compose` hooks (`grove doctor --fix` rewrites them automatically).
+
+### Added
 - New hook action types `docker:compose` and `docker:exec` for routing config-driven hooks into containers (see `docs/CONFIGURATION_REFERENCE.md`). Action type names use a `pluginname:action` namespace convention.
 - Pluggable hook action handler registry — plugins can register custom action types via `hooks.RegisterActionHandler` (idempotent, last-write-wins). See `docs/PLUGIN_DEVELOPMENT.md`.
 - `grove init` now picks between `auto` (preview + confirm) and `walkthrough` (step-by-step) modes when running interactively. New flags: `--auto`, `--walkthrough`, `--yes`. Non-TTY behavior preserved as silent auto.
@@ -16,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `symlink_files` documented in top-level README and CONFIGURATION_REFERENCE alongside `symlink_dirs`.
 - `grove trim` now accepts `prune` as an alias for git-flavored discoverability (issue #10).
 - README beta notice, edge install path (`go install ...@main`), and per-install-method update guidance (issue #11).
+- TUI branch selector now includes remote-only branches; selecting a remote-only branch fetches from origin automatically.
 
 ### Changed
 - Hook execution order on worktree create: plugin Go hooks now fire **before** config-driven `[[hooks.post_create]]` so containers are up by the time user setup commands run. This removes a workaround in the new `docker:compose` handler and lets `mode = "exec"` work without a stealth `compose up`.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ Edge builds may include breaking changes that haven't been documented yet. Pin t
 
 ---
 
+## Upgrading from v0.6.x
+
+No breaking config changes in v0.7.0 — all new fields have defaults and existing configs continue to work.
+
+**What to check after upgrading:**
+
+- **`grove doctor --fix` is new.** If your project uses Docker and was initialized before v0.7.0, run `grove doctor` — it will flag any host install commands that should now be `docker:compose` hooks. `grove doctor --fix` rewrites them automatically.
+- **`prune` is a new alias for `grove trim`.** Scripts using `grove trim` or `grove clean` continue to work unchanged.
+- **State backfill runs automatically on first load.** Worktrees with zero-valued timestamps (from pre-v0.5.1 installs) are silently corrected the first time `grove ls` or the TUI runs. No action required.
+- **Shell integration is now version 5.** If `grove doctor` warns about a shell version mismatch, re-run `eval "$(grove install zsh)"` (or `bash`) and reload your shell. `grove setup` handles this automatically.
+
+---
+
 ## Quick Start
 
 ### 1 — Shell integration
@@ -564,16 +577,17 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide — CI pip
 
 ## Documentation
 
-| Document | What's in it |
-|----------|-------------|
-| [docs/TUI.md](docs/TUI.md) | Full TUI reference — keybindings, overlays, sort modes, layout |
-| [docs/SHELL_INTEGRATION.md](docs/SHELL_INTEGRATION.md) | Directive protocol, tab completion internals, troubleshooting |
-| [docs/AGENT_GUIDE.md](docs/AGENT_GUIDE.md) | AI agent patterns, Docker strategies, before/after comparisons |
-| [docs/CONFIGURATION_REFERENCE.md](docs/CONFIGURATION_REFERENCE.md) | All config.toml fields with defaults |
-| [docs/COMMAND_SPECIFICATIONS.md](docs/COMMAND_SPECIFICATIONS.md) | Exhaustive command behavior specs |
-| [docs/PLUGIN_DEVELOPMENT.md](docs/PLUGIN_DEVELOPMENT.md) | Writing custom hooks and plugins |
-| [plugins/docker/README.md](plugins/docker/README.md) | Docker plugin full reference |
-| [plugins/tracker/README.md](plugins/tracker/README.md) | GitHub tracker plugin reference |
+| Reference | Purpose |
+|-----------|---------|
+| [Command Specifications](docs/COMMAND_SPECIFICATIONS.md) | Every command, flag, output format |
+| [Configuration Reference](docs/CONFIGURATION_REFERENCE.md) | All config.toml and hooks.toml options |
+| [Agent Guide](docs/AGENT_GUIDE.md) | Installing and using grove from scripts/AI agents |
+| [Shell Integration](docs/SHELL_INTEGRATION.md) | Directive protocol, recursion guard, version bumps |
+| [TUI Dashboard](docs/TUI.md) | Layout, keybindings, overlays |
+| [Plugin Development](docs/PLUGIN_DEVELOPMENT.md) | Hook interfaces, custom action types |
+| [Visual Testing](docs/VISUAL_TESTING.md) | Golden files, tmux capture, VHS tapes |
+| [Docker Plugin](plugins/docker/README.md) | Docker plugin full reference |
+| [Tracker Plugin](plugins/tracker/README.md) | GitHub tracker plugin reference |
 
 ---
 

--- a/cmd/grove/commands/doctor.go
+++ b/cmd/grove/commands/doctor.go
@@ -298,7 +298,7 @@ func runExternalModeChecks(w *cli.Writer, cfg *config.Config, projectRoot string
 	checkProvisioningSources(w, ext, projectRoot, allPassed)
 
 	envFileName := ext.EnvFileName()
-	composePath := docker.ResolveComposePath(ext.Path)
+	composePath := ext.Path
 	efResult := checkEnvFileConfig(envFileName, composePath, exec.LookPath)
 
 	checkEnvFileChecks(w, envFileName, efResult, allPassed)
@@ -389,7 +389,7 @@ func checkAgentStacks(w *cli.Writer, cfg *config.Config, ext *config.ExternalCom
 	*allPassed = runCheck(w, "Agent template path", func() (string, error) {
 		tmpl := ext.Agent.TemplatePath
 		if !filepath.IsAbs(tmpl) {
-			tmpl = filepath.Join(docker.ResolveComposePath(ext.Path), tmpl)
+			tmpl = filepath.Join(ext.Path, tmpl)
 		}
 		info, err := os.Stat(tmpl)
 		if err != nil {
@@ -406,7 +406,7 @@ func checkAgentStacks(w *cli.Writer, cfg *config.Config, ext *config.ExternalCom
 			for i, overlay := range ext.Agent.TemplateOverlays {
 				p := overlay
 				if !filepath.IsAbs(p) {
-					p = filepath.Join(docker.ResolveComposePath(ext.Path), p)
+					p = filepath.Join(ext.Path, p)
 				}
 				info, err := os.Stat(p)
 				if err != nil {

--- a/cmd/grove/commands/doctor.go
+++ b/cmd/grove/commands/doctor.go
@@ -784,7 +784,7 @@ func rewriteHostInstallsToCompose(src, service string) (string, int) {
 				if k == typeLine-i {
 					out.WriteString(`type = "docker:compose"`)
 					out.WriteString("\n")
-					out.WriteString(fmt.Sprintf("service = %q\n", service))
+					fmt.Fprintf(&out, "service = %q\n", service)
 					out.WriteString("mode = \"run\"\n")
 					continue
 				}

--- a/cmd/grove/commands/doctor_test.go
+++ b/cmd/grove/commands/doctor_test.go
@@ -1,5 +1,13 @@
 package commands
 
+// TODO(v0.7.1): Add orchestration smoke test for runExternalModeChecks,
+// checkProvisioningSources, and runCheck/runInfo (all at 0.0% coverage).
+// The test should call the doctor RunE with a mock filesystem representing
+// an external-mode project and assert the check output contains expected
+// messages. This was deferred from v0.7.0 due to scope — the RunE function
+// pulls in live filesystem, env, and git checks that need a full fixture.
+// See release-audit/coverage-gaps.md §"grove doctor orchestration smoke test".
+
 import (
 	"fmt"
 	"os"

--- a/cmd/grove/commands/list_bench_test.go
+++ b/cmd/grove/commands/list_bench_test.go
@@ -1,0 +1,71 @@
+//go:build !race
+
+package commands
+
+// BenchmarkListWorktrees exercises the grove ls table-rendering path with N=20
+// synthetic worktrees to net regressions against the <500ms target.
+//
+// This benchmark covers the pure-Go output formatting cost (cli.Table construction,
+// width computation, row rendering) that runs after the worktree list is loaded.
+// The git I/O layer (worktree.Manager.List, dirty checks) is not exercised here
+// because it requires a fixture git repository with actual worktrees on disk.
+//
+// To add full end-to-end coverage: build a git repo in t.TempDir(), run
+// "git worktree add" 20 times, call worktree.NewManager, and invoke lsCmd.RunE.
+// That test would live in a file tagged //go:build integration.
+//
+// Run with:
+//
+//	go test ./cmd/grove/commands/ -bench=BenchmarkListWorktrees -benchmem -run=^$
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/cli"
+)
+
+func BenchmarkListWorktrees(b *testing.B) {
+	const n = 20
+
+	// Pre-build synthetic worktree rows (project-name, branch, status, tmux, path).
+	type row struct {
+		indicator, name, branch, status, tmux, path string
+	}
+	rows := make([]row, n)
+	for i := range rows {
+		rows[i] = row{
+			indicator: "",
+			name:      fmt.Sprintf("myapp-feature-%02d", i+1),
+			branch:    fmt.Sprintf("feat/feature-%02d", i+1),
+			status:    statusClean,
+			tmux:      tmuxStatusDetached,
+			path:      fmt.Sprintf("/home/user/projects/myapp-feature-%02d", i+1),
+		}
+	}
+	// Mark one as current and one as dirty to exercise all code paths.
+	rows[0].indicator = "●"
+	rows[1].status = statusDirty
+	rows[2].tmux = tmuxStatusAttached
+
+	columns := []cli.Column{
+		{Title: "", MinWidth: 2, MaxWidth: 2},
+		{Title: "NAME", MaxWidth: 30},
+		{Title: "BRANCH", MaxWidth: 25},
+		{Title: "STATUS", MinWidth: 10},
+		{Title: "TMUX", MinWidth: 12},
+		{Title: "PATH"},
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		var buf bytes.Buffer
+		w := cli.NewWriter(&buf, false)
+		tbl := cli.NewTable(w, columns...)
+		for _, r := range rows {
+			tbl.AddRow(r.indicator, r.name, r.branch, r.status, r.tmux, r.path)
+		}
+		tbl.Render()
+	}
+}

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -381,9 +381,11 @@ Protected worktrees (`main`, `develop`, or any name in `[protection] protected`)
 
 **Remove stale worktrees in bulk:**
 ```bash
-grove clean           # removes worktrees not accessed in 30 days
-grove clean --days 7  # shorter threshold
+grove trim           # removes worktrees not accessed in 30 days
+grove trim --days 7  # shorter threshold
 ```
+
+The `clean` alias also works (`grove clean --days 7`), but `trim` is the canonical name.
 
 Stale = `LastAccessedAt` older than threshold and no dirty changes. Protected worktrees are skipped.
 

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -19,11 +19,9 @@ This document provides exhaustive specifications for each grove command. Every b
    - [grove rename](#grove-rename)
    - [grove here](#grove-here)
    - [grove last](#grove-last)
-   - [grove attach](#grove-attach)
+   - [grove join](#grove-join)
    - [grove which](#grove-which)
 4. [State Commands](#state-commands)
-   - [grove freeze](#grove-freeze)
-   - [grove resume](#grove-resume)
 5. [Docker Commands](#docker-commands)
    - [grove up](#grove-up)
    - [grove down](#grove-down)
@@ -964,17 +962,18 @@ Use 'grove ls' to see available worktrees.
 
 ---
 
-### grove attach
+### grove join
 
 **Purpose:** Attach to (or create) a tmux session for a worktree without changing the shell's current directory.
 
+**Aliases:** `attach`, `a`, `j`
+
 **Usage:**
 ```
-grove attach [name] [flags]
-Alias: a
+grove join [name] [flags]
 
 Arguments:
-  name    Worktree to attach to (default: current worktree)
+  name    Worktree to join (default: current worktree)
 
 Flags:
   -j, --json    Output as JSON
@@ -1076,84 +1075,7 @@ When no Docker is configured, the `services` field is `null`/omitted.
 
 ## State Commands
 
-### grove freeze
-
-**Purpose:** Freeze a worktree to conserve resources (stop containers, mark session).
-
-**Usage:**
-```
-grove freeze [name] [flags]
-
-Arguments:
-  name    Worktree to freeze (default: current)
-
-Flags:
-      --all    Freeze all worktrees except current
-```
-
-**Behavior:**
-
-1. Stop Docker containers (if docker plugin enabled)
-2. Mark tmux session as frozen (custom variable)
-3. Optionally detach from session
-4. Record freeze state
-
-**Output (Success):**
-```
-✓ Stopped 3 Docker containers
-✓ Froze worktree 'testing'
-
-To resume: grove resume testing
-```
-
-**Output (Already frozen):**
-```
-Worktree 'testing' is already frozen
-
-To resume: grove resume testing
-```
-
-**Exit Codes:**
-- 0: Success or already frozen
-- 1: Worktree not found
-
----
-
-### grove resume
-
-**Purpose:** Resume a frozen worktree.
-
-**Usage:**
-```
-grove resume <name> [flags]
-
-Arguments:
-  name    Worktree to resume (required)
-```
-
-**Behavior:**
-
-1. Clear frozen state
-2. Start Docker containers (if docker plugin)
-3. Switch to worktree (equivalent to `grove to`)
-
-**Output (Success):**
-```
-✓ Resumed worktree 'testing'
-✓ Started 3 Docker containers
-✓ Switched to 'testing'
-```
-
-**Output (Not frozen):**
-```
-Worktree 'testing' is not frozen
-
-To switch to it: grove to testing
-```
-
-**Exit Codes:**
-- 0: Success
-- 1: Worktree not found or not frozen
+> No user-facing state commands are currently registered. The `internal/state` package exposes freeze/resume logic, but no cobra commands wire it to the CLI. See the [Planned Commands](#planned-not-yet-implemented) section for the design.
 
 ---
 
@@ -2037,7 +1959,12 @@ Excluded worktrees:
 **Usage:**
 ```
 grove doctor [flags]
+
+Flags:
+      --fix    Apply automatic fixes for detected issues
 ```
+
+**`--fix` flag:** When passed, `grove doctor` rewrites host install commands (e.g., `bundle install`, `npm install`, `pip install`) in `hooks.toml` to `docker:compose` hooks in place. The rewrite is idempotent — running it again when already converted is a no-op. This is a surgical text-based edit; user comments and unrelated keys are preserved. Currently, `--fix` only handles the install-command rewrite; other detected issues still require manual remediation.
 
 **Two-tier design:**
 
@@ -2186,6 +2113,121 @@ func hasShellIntegration() bool {
 
 ---
 
+
+## Other Commands
+
+These commands are fully implemented and available in the CLI. Full flag details are available via `--help`.
+
+### grove prs
+
+Opens the TUI's PR browser directly (same as pressing `p` from the dashboard). Fetches open pull requests from GitHub via the `gh` CLI. Requires `gh` to be installed and authenticated. See `grove prs --help`.
+
+### grove issues
+
+Opens the TUI's issue browser directly (same as pressing `i` from the dashboard). Fetches open GitHub issues via the `gh` CLI. Requires `gh` to be installed and authenticated. See `grove issues --help`.
+
+### grove agent-help
+
+Prints a quick-reference guide for AI agent workflows — worktree lifecycle, Docker strategies, and multi-agent patterns. Intended for agents that need context about grove's conventions without reading the full docs. See `grove agent-help --help`.
+
+### grove setup
+
+Interactive shell integration setup. Detects your shell, prints the `eval` line to add to your shell profile, and optionally writes it for you. See `grove setup --help`.
+
+### grove install
+
+Generates the shell integration snippet for a given shell (`grove install zsh`, `grove install bash`). The output is designed for `eval "$(grove install <shell>)"` in your shell profile. See `grove install --help`.
+
+### grove version
+
+Prints the grove version string. See `grove version --help`.
+
+---
+
+## Planned (not yet implemented)
+
+These commands are referenced in `internal/state` but not yet wired to user-facing cobra commands. The spec is preserved here so the design is recoverable when implementation lands.
+
+### grove freeze
+
+**Purpose:** Freeze a worktree to conserve resources (stop containers, mark session).
+
+**Usage:**
+```
+grove freeze [name] [flags]
+
+Arguments:
+  name    Worktree to freeze (default: current)
+
+Flags:
+      --all    Freeze all worktrees except current
+```
+
+**Behavior:**
+
+1. Stop Docker containers (if docker plugin enabled)
+2. Mark tmux session as frozen (custom variable)
+3. Optionally detach from session
+4. Record freeze state
+
+**Output (Success):**
+```
+✓ Stopped 3 Docker containers
+✓ Froze worktree 'testing'
+
+To resume: grove resume testing
+```
+
+**Output (Already frozen):**
+```
+Worktree 'testing' is already frozen
+
+To resume: grove resume testing
+```
+
+**Exit Codes:**
+- 0: Success or already frozen
+- 1: Worktree not found
+
+---
+
+### grove resume
+
+**Purpose:** Resume a frozen worktree.
+
+**Usage:**
+```
+grove resume <name> [flags]
+
+Arguments:
+  name    Worktree to resume (required)
+```
+
+**Behavior:**
+
+1. Clear frozen state
+2. Start Docker containers (if docker plugin)
+3. Switch to worktree (equivalent to `grove to`)
+
+**Output (Success):**
+```
+✓ Resumed worktree 'testing'
+✓ Started 3 Docker containers
+✓ Switched to 'testing'
+```
+
+**Output (Not frozen):**
+```
+Worktree 'testing' is not frozen
+
+To switch to it: grove to testing
+```
+
+**Exit Codes:**
+- 0: Success
+- 1: Worktree not found or not frozen
+
+---
 
 ## Commands Not Speced
 

--- a/docs/SHELL_INTEGRATION.md
+++ b/docs/SHELL_INTEGRATION.md
@@ -115,11 +115,12 @@ The grove binary communicates with the shell wrapper through directive lines —
 
 | Directive | Example | Action |
 |-----------|---------|--------|
-| `GROVE_CD:` | `GROVE_CD:/path/to/dir` | Change directory (current) |
-| `cd:` | `cd:/path/to/dir` | Change directory (legacy, same effect) |
+| `cd:` | `cd:/path/to/dir` | Change directory |
 | `tmux-attach:` | `tmux-attach:myproject-feature` | Attach to named tmux session |
 | `tmux-attach-cc:` | `tmux-attach-cc:myproject-feature` | Attach using `tmux -CC` (iTerm2 control mode) |
 | `env:` | `env:ADMIN_DIR=./admin-feature` | Export environment variable in shell |
+
+> **Note:** `GROVE_CD:` appeared in older documentation but is not used by the current shell templates. The active directive is `cd:`. If you have scripts or tooling that rely on `GROVE_CD:`, update them to use `cd:` instead.
 
 Lines that do not match any directive prefix are treated as normal output and printed to the terminal as-is.
 
@@ -168,6 +169,51 @@ The integration sets `w` as an alias for `grove`:
 w to feature       # same as: grove to feature
 w                  # same as: grove (opens TUI)
 ```
+
+## Recursion Guard
+
+Both shell templates (`grove.zsh` and `grove.bash`) open with a guard that prevents infinite recursion:
+
+```bash
+if [[ -z "$__GROVE_BIN" || "$__GROVE_BIN" == "grove" ]]; then
+    echo "grove: binary not found (is grove on your PATH?)" >&2
+    return 127
+fi
+```
+
+**What `__GROVE_BIN` is:** When `grove install <shell>` runs, it emits shell code that sets `__GROVE_BIN` to the resolved path of the grove binary (via `command -v grove`). The shell function uses `$__GROVE_BIN` — not the bare word `grove` — to call the real binary.
+
+**What the guard prevents:** If the binary is not on `$PATH`, `command -v grove` returns nothing and `__GROVE_BIN` ends up empty or is literally the string `"grove"`. Without the guard, calling `$__GROVE_BIN` would invoke the shell function again, looping forever.
+
+**What users see:** When the guard fires, the shell prints `grove: binary not found (is grove on your PATH?)` to stderr and returns exit code 127. The command is a silent no-op from the user's perspective.
+
+**How to diagnose:** If you see this error, the grove binary is not in `$PATH` at the time the shell integration was evaluated. Check:
+
+```bash
+which grove          # should print the binary path
+echo "$__GROVE_BIN"  # should match the above path
+```
+
+If `which grove` works but `$__GROVE_BIN` is wrong, re-evaluate the integration:
+
+```bash
+eval "$(grove install zsh)"   # or bash
+```
+
+## Version Bumps
+
+The constant `ShellVersion` in `internal/shell/version.go` tracks the shell integration template version. It is currently **5**.
+
+When the shell wrapper behavior changes incompatibly — new directives, changed passthrough logic, new env vars — increment `ShellVersion`. The grove binary reads `GROVE_SHELL_VERSION` (set by the wrapper) on every invocation and emits a warning when the running shell integration is older than `ShellVersion`.
+
+**What users must do after a version bump:**
+
+```bash
+eval "$(grove install zsh)"   # or bash
+source ~/.zshrc               # (or ~/.bashrc)
+```
+
+`grove setup` handles this automatically if run again. `grove doctor` will surface a version mismatch as a warning with the re-run command included in its output.
 
 ## Troubleshooting
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -128,11 +128,13 @@ Each overlay opens centered over the dimmed dashboard background. Press `esc` to
 A multi-step wizard:
 
 1. **Branch** — Choose "Select an existing branch" or "Create a new branch."
-   - *Select existing:* A navigable branch list. Press `/` to filter by name (`j`/`k` navigate, all keys reach the filter input). Press `esc` to exit filter mode.
+   - *Select existing:* A navigable branch list. Press `/` to filter by name (`j`/`k` navigate, all keys reach the filter input). Press `esc` to exit filter mode. Remote-only branches (those that exist on `origin` but not locally) appear in the list; selecting one fetches it from origin automatically.
    - *Create new:* A focused text input for the new branch name (all keys including `j`/`k` are typed as text).
    - If you select an existing branch, Grove asks whether to use it as-is (split) or create a new branch from it (fork). You can save this preference to skip the prompt.
 2. **Name** — Enter a short name (e.g., `my-feature`). Grove displays the full name preview (`project-my-feature`) as you type and warns about conflicts with existing worktrees.
 3. **Confirm** — Review the name and branch, then press `enter` to create.
+
+Press `shift+tab` at any step to navigate backwards through the wizard. Press `esc` to cancel.
 
 ### Delete Worktree (`d`)
 
@@ -175,7 +177,7 @@ Steps:
 Changes which branch a worktree has checked out — without needing to delete and recreate it.
 
 Steps:
-1. **Branch** — Select a target branch from a filterable list. Branches already used by other worktrees are excluded.
+1. **Branch** — Select a target branch from a filterable list. Branches already used by other worktrees are excluded. Remote-only branches appear in the list; selecting one fetches it from origin automatically.
 2. **WIP** (skipped if worktree is clean) — Choose how to handle uncommitted changes:
    - **Stash** — Stash changes before switching (`git stash`).
    - **Cancel** — Abort the branch switch.
@@ -236,6 +238,7 @@ Controls:
 - `↑` / `↓` — Navigate
 - `tab` — Toggle PR detail preview (rendered markdown body)
 - `enter` — Create a new worktree from the PR branch
+- `B` — Open the selected PR in your default browser
 - Type to filter by title, author, number, or labels
 - `esc` — Close
 
@@ -251,6 +254,7 @@ Controls:
 - `↑` / `↓` — Navigate
 - `tab` — Toggle issue detail preview (rendered markdown body)
 - `enter` — Create a new worktree for the issue
+- `B` — Open the selected issue in your default browser
 - Type to filter by title, author, number, or labels
 - `esc` — Close
 
@@ -278,7 +282,9 @@ Grove checks for high-contrast mode. If the `GROVE_HIGH_CONTRAST` environment va
 
 ## Agent Notes
 
-Reference for AI agents working on TUI code. The TUI uses **Bubbletea v2** (Elm Architecture):
+Reference for AI agents working on TUI code. For design rationale behind the New Worktree wizard, see `docs/WIZARD_UX_RESEARCH.md`.
+
+The TUI uses **Bubbletea v2** (Elm Architecture):
 - `charm.land/bubbletea/v2` — framework (Model/Update/View)
 - `charm.land/lipgloss/v2` — styling (ANSI-aware widths, colors, borders)
 - `charm.land/bubbles/v2` — components (list, textinput, viewport)

--- a/docs/VISUAL_TESTING.md
+++ b/docs/VISUAL_TESTING.md
@@ -352,6 +352,44 @@ Golden files can also serve this role without requiring tmux:
 
 ---
 
+## Integration Tests (teatest)
+
+### Overview
+
+The `internal/tui/` package includes integration tests (build tag `//go:build integration`) that drive the full Bubbletea program using [`teatest/v2`](https://pkg.go.dev/github.com/charmbracelet/x/exp/teatest/v2). These test real key sequences against a live git fixture, unlike golden tests which render static model snapshots.
+
+Import path: `github.com/charmbracelet/x/exp/teatest/v2`
+
+### Key v2 API shapes
+
+```go
+// Create a running TestModel from a bubbletea Model
+tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 40))
+
+// Wait for output to match a predicate (polls tm.Output())
+teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
+    return strings.Contains(string(bts), "expected text")
+}, teatest.WithDuration(5*time.Second))
+
+// Send a key press
+tm.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+
+// Wait for the program to exit cleanly
+tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+```
+
+Note: `teatest/v2` uses `NewTestModel` (not `RunModel`) and `WaitFor` (not `FinalModel`). The v1 API shapes (`teatest.FinalModel`, `teatest.RunTest`) are not present in v2.
+
+### Running integration tests
+
+```bash
+go test ./internal/tui/ -tags integration -run TestProgram_
+```
+
+Integration tests require a real git repository on disk. The `setupRailsFixture` and `setupRailsFixtureWithWorktrees` helpers (in `internal/tui/`) create temporary fixtures automatically.
+
+---
+
 ## VHS Tapes
 
 ### When to use

--- a/internal/cli/prompt_test.go
+++ b/internal/cli/prompt_test.go
@@ -1,8 +1,165 @@
 package cli
 
 import (
+	"errors"
+	"io"
+	"os"
 	"testing"
+	"time"
 )
+
+// replaceStdin swaps os.Stdin for the read end of a pipe and returns a
+// restore func. The test writes to wPipe and must close it when done.
+func replaceStdin(t *testing.T) (wPipe *os.File, restore func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdin
+	os.Stdin = r
+	return w, func() {
+		os.Stdin = old
+		_ = r.Close()
+	}
+}
+
+// TestReadLineCooked_ReadsLine verifies readLineCooked returns the text written
+// to the pipe, trimmed of the trailing newline.
+func TestReadLineCooked_ReadsLine(t *testing.T) {
+	w, restore := replaceStdin(t)
+	defer restore()
+
+	go func() {
+		_, _ = io.WriteString(w, "hello world\n")
+		_ = w.Close()
+	}()
+
+	got, err := readLineCooked()
+	if err != nil {
+		t.Fatalf("readLineCooked() unexpected error: %v", err)
+	}
+	if got != "hello world" {
+		t.Errorf("readLineCooked() = %q, want %q", got, "hello world")
+	}
+}
+
+// TestReadLineCooked_EOF verifies readLineCooked returns an error on EOF.
+func TestReadLineCooked_EOF(t *testing.T) {
+	w, restore := replaceStdin(t)
+	defer restore()
+
+	_ = w.Close() // immediate EOF
+
+	_, err := readLineCooked()
+	if err == nil {
+		t.Fatal("readLineCooked() expected error on EOF, got nil")
+	}
+}
+
+// TestDrainEscapeSequence_Timeout verifies drainEscapeSequence returns
+// promptly (within 200ms) when no follow-up bytes arrive — i.e. it was a
+// standalone Escape press, not a multi-byte escape sequence.
+//
+// We do NOT replace os.Stdin here: drainEscapeSequence spawns a goroutine
+// that reads os.Stdin and may outlive the function (the goroutine leaks
+// harmlessly until process exit, as documented in the production comment).
+// Swapping os.Stdin while that goroutine is running would cause a data race.
+// Instead we rely on the 20ms select timeout inside drainEscapeSequence to
+// fire when stdin produces no bytes during the test.
+func TestDrainEscapeSequence_Timeout(t *testing.T) {
+	if IsInteractive() {
+		t.Skip("stdin is a TTY — drainEscapeSequence would block on real terminal input")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		drainEscapeSequence()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// returned within timeout — correct
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("drainEscapeSequence() did not return within 200ms for standalone ESC")
+	}
+}
+
+// TestDrainEscapeSequence_ArrowKey verifies drainEscapeSequence consumes the
+// continuation bytes of an arrow-key sequence (ESC [ A) and returns quickly.
+func TestDrainEscapeSequence_ArrowKey(t *testing.T) {
+	w, restore := replaceStdin(t)
+
+	go func() {
+		// Write the continuation bytes of ESC [ A (up-arrow sequence).
+		_, _ = w.Write([]byte("[A"))
+		_ = w.Close()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		drainEscapeSequence()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		restore()
+		// drained successfully
+	case <-time.After(200 * time.Millisecond):
+		restore()
+		t.Fatal("drainEscapeSequence() did not return within 200ms after arrow-key bytes")
+	}
+}
+
+// TestReadLine_NonTTY_CtrlC verifies that when stdin is a pipe (non-TTY),
+// ReadLine falls through to readLineCooked and returns the input.
+// The raw-mode Ctrl+C path requires a real TTY so it cannot be tested here.
+// Coverage of ErrPromptCanceled in raw mode is guarded by the TTY check.
+func TestReadLine_NonTTY_ReturnsInput(t *testing.T) {
+	if IsInteractive() {
+		t.Skip("stdin is a TTY — skipping non-TTY ReadLine test")
+	}
+
+	w, restore := replaceStdin(t)
+	defer restore()
+
+	go func() {
+		_, _ = io.WriteString(w, "my answer\n")
+		_ = w.Close()
+	}()
+
+	got, err := ReadLine("prompt: ")
+	if err != nil {
+		t.Fatalf("ReadLine() unexpected error: %v", err)
+	}
+	if got != "my answer" {
+		t.Errorf("ReadLine() = %q, want %q", got, "my answer")
+	}
+}
+
+// TestReadLine_NonTTY_EOF verifies ReadLine surfaces the EOF error from the
+// non-TTY code path (readLineCooked) rather than hanging.
+func TestReadLine_NonTTY_EOF(t *testing.T) {
+	if IsInteractive() {
+		t.Skip("stdin is a TTY — skipping non-TTY ReadLine test")
+	}
+
+	w, restore := replaceStdin(t)
+	defer restore()
+
+	_ = w.Close() // immediate EOF
+
+	_, err := ReadLine("prompt: ")
+	if err == nil {
+		t.Fatal("ReadLine() expected error on EOF, got nil")
+	}
+	// Should NOT be ErrPromptCanceled — that's the raw-mode Ctrl+C path.
+	if errors.Is(err, ErrPromptCanceled) {
+		t.Errorf("ReadLine() returned ErrPromptCanceled for EOF, want an io error")
+	}
+}
 
 func TestIsInteractive_NonTTY(t *testing.T) {
 	// In test environments stdin is not a terminal.

--- a/internal/fsutil/safejoin.go
+++ b/internal/fsutil/safejoin.go
@@ -1,0 +1,31 @@
+package fsutil
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// SafeJoin joins a base directory with a user-supplied relative path
+// and rejects results that escape the base directory.
+//
+// Use SafeJoin for any path constructed from user-controlled config
+// (hooks.toml from/to, symlink_files entries) where the path is
+// expected to live inside the worktree. Absolute paths supplied by
+// grove internals (credential copy from ~/.config) should bypass
+// SafeJoin and use filepath.Join directly.
+func SafeJoin(base, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("path %q escapes base directory %q", rel, base)
+	}
+	cleaned := filepath.Clean(rel)
+	joined := filepath.Join(base, cleaned)
+	relPath, err := filepath.Rel(base, joined)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(relPath, "..") {
+		return "", fmt.Errorf("path %q escapes base directory %q", rel, base)
+	}
+	return joined, nil
+}

--- a/internal/fsutil/safejoin_test.go
+++ b/internal/fsutil/safejoin_test.go
@@ -1,0 +1,76 @@
+package fsutil
+
+import (
+	"testing"
+)
+
+func TestSafeJoin(t *testing.T) {
+	base := "/work/myproject-testing"
+
+	tests := []struct {
+		name    string
+		rel     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "plain relative path inside base",
+			rel:  "config/app.yml",
+			want: "/work/myproject-testing/config/app.yml",
+		},
+		{
+			name: "single component",
+			rel:  "secrets",
+			want: "/work/myproject-testing/secrets",
+		},
+		{
+			name:    "dotdot escape attempt",
+			rel:     "../../.ssh/id_rsa",
+			wantErr: true,
+		},
+		{
+			name:    "dotdot in middle",
+			rel:     "config/../../.ssh/id_rsa",
+			wantErr: true,
+		},
+		{
+			name:    "absolute path",
+			rel:     "/etc/passwd",
+			wantErr: true,
+		},
+		{
+			name: "same dir dot",
+			rel:  ".",
+			want: base,
+		},
+		{
+			name: "traversal that resolves inside base",
+			rel:  "a/../b",
+			want: "/work/myproject-testing/b",
+		},
+		{
+			name: "nested path",
+			rel:  "vendor/bundle/ruby",
+			want: "/work/myproject-testing/vendor/bundle/ruby",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeJoin(base, tt.rel)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("SafeJoin(%q, %q) = %q, want error", base, tt.rel, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("SafeJoin(%q, %q) unexpected error: %v", base, tt.rel, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SafeJoin(%q, %q) = %q, want %q", base, tt.rel, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -228,8 +228,14 @@ func builtinCopy(action *HookAction, ctx *ExecutionContext, vars *Variables) err
 	from := vars.Interpolate(action.From)
 	to := vars.Interpolate(action.To)
 
-	srcPath := resolvePath(from, ctx.MainPath)
-	dstPath := resolvePath(to, ctx.NewPath)
+	srcPath, err := resolvePathSafe(from, ctx.MainPath)
+	if err != nil {
+		return fmt.Errorf("copy source path: %w", err)
+	}
+	dstPath, err := resolvePathSafe(to, ctx.NewPath)
+	if err != nil {
+		return fmt.Errorf("copy destination path: %w", err)
+	}
 
 	srcInfo, err := os.Stat(srcPath)
 	if err != nil {
@@ -258,8 +264,14 @@ func builtinSymlink(action *HookAction, ctx *ExecutionContext, vars *Variables) 
 	from := vars.Interpolate(action.From)
 	to := vars.Interpolate(action.To)
 
-	srcPath := resolvePath(from, ctx.MainPath)
-	linkPath := resolvePath(to, ctx.NewPath)
+	srcPath, err := resolvePathSafe(from, ctx.MainPath)
+	if err != nil {
+		return fmt.Errorf("symlink source path: %w", err)
+	}
+	linkPath, err := resolvePathSafe(to, ctx.NewPath)
+	if err != nil {
+		return fmt.Errorf("symlink destination path: %w", err)
+	}
 
 	if _, err := os.Lstat(srcPath); err != nil {
 		if os.IsNotExist(err) {
@@ -314,8 +326,14 @@ func builtinTemplate(action *HookAction, ctx *ExecutionContext, vars *Variables)
 	from := vars.Interpolate(action.From)
 	to := vars.Interpolate(action.To)
 
-	srcPath := resolvePath(from, ctx.MainPath)
-	dstPath := resolvePath(to, ctx.NewPath)
+	srcPath, err := resolvePathSafe(from, ctx.MainPath)
+	if err != nil {
+		return fmt.Errorf("template source path: %w", err)
+	}
+	dstPath, err := resolvePathSafe(to, ctx.NewPath)
+	if err != nil {
+		return fmt.Errorf("template destination path: %w", err)
+	}
 
 	content, err := os.ReadFile(srcPath)
 	if err != nil {

--- a/internal/hooks/executor_test.go
+++ b/internal/hooks/executor_test.go
@@ -140,6 +140,70 @@ func TestExecute(t *testing.T) {
 	})
 }
 
+func TestBuiltinCopyPathTraversal(t *testing.T) {
+	mainDir := t.TempDir()
+	newDir := t.TempDir()
+	vars := &Variables{}
+
+	t.Run("legitimate copy succeeds", func(t *testing.T) {
+		_ = os.WriteFile(filepath.Join(mainDir, "app.yml"), []byte("ok"), 0644)
+		action := &HookAction{From: "app.yml", To: "app.yml"}
+		ctx := &ExecutionContext{MainPath: mainDir, NewPath: newDir}
+		if err := builtinCopy(action, ctx, vars); err != nil {
+			t.Errorf("builtinCopy() legitimate path = %v, want nil", err)
+		}
+	})
+
+	t.Run("dotdot escape in From rejected", func(t *testing.T) {
+		action := &HookAction{From: "../../.ssh/id_rsa", To: "dest.txt"}
+		ctx := &ExecutionContext{MainPath: mainDir, NewPath: newDir}
+		if err := builtinCopy(action, ctx, vars); err == nil {
+			t.Error("builtinCopy() with traversal From = nil, want error")
+		}
+	})
+
+	t.Run("dotdot escape in To rejected", func(t *testing.T) {
+		_ = os.WriteFile(filepath.Join(mainDir, "source.txt"), []byte("ok"), 0644)
+		action := &HookAction{From: "source.txt", To: "../../etc/passwd"}
+		ctx := &ExecutionContext{MainPath: mainDir, NewPath: newDir}
+		if err := builtinCopy(action, ctx, vars); err == nil {
+			t.Error("builtinCopy() with traversal To = nil, want error")
+		}
+	})
+}
+
+func TestBuiltinSymlinkPathTraversal(t *testing.T) {
+	mainDir := t.TempDir()
+	newDir := t.TempDir()
+	vars := &Variables{}
+
+	t.Run("legitimate symlink succeeds", func(t *testing.T) {
+		_ = os.WriteFile(filepath.Join(mainDir, "node_modules"), []byte("ok"), 0644)
+		action := &HookAction{From: "node_modules", To: "node_modules"}
+		ctx := &ExecutionContext{MainPath: mainDir, NewPath: newDir}
+		if err := builtinSymlink(action, ctx, vars); err != nil {
+			t.Errorf("builtinSymlink() legitimate path = %v, want nil", err)
+		}
+	})
+
+	t.Run("dotdot escape in From rejected", func(t *testing.T) {
+		action := &HookAction{From: "../../.ssh/id_rsa", To: "link"}
+		ctx := &ExecutionContext{MainPath: mainDir, NewPath: newDir}
+		if err := builtinSymlink(action, ctx, vars); err == nil {
+			t.Error("builtinSymlink() with traversal From = nil, want error")
+		}
+	})
+
+	t.Run("dotdot escape in To rejected", func(t *testing.T) {
+		_ = os.WriteFile(filepath.Join(mainDir, "src"), []byte("ok"), 0644)
+		action := &HookAction{From: "src", To: "../../evil"}
+		ctx := &ExecutionContext{MainPath: mainDir, NewPath: newDir}
+		if err := builtinSymlink(action, ctx, vars); err == nil {
+			t.Error("builtinSymlink() with traversal To = nil, want error")
+		}
+	})
+}
+
 func TestExecuteCopy(t *testing.T) {
 	t.Run("file copy", func(t *testing.T) {
 		mainDir := t.TempDir()

--- a/internal/hooks/handlers.go
+++ b/internal/hooks/handlers.go
@@ -6,6 +6,11 @@ import (
 
 // ActionHandler is the function signature for hook action handlers.
 // Plugins register handlers for new action types via RegisterActionHandler.
+//
+// Stability: this signature is the stable plugin extension point as of
+// v0.7.0. Adding fields to HookAction, ExecutionContext, or Variables is
+// backwards-compatible; renaming or removing fields is not. Breaking
+// changes will bump grove's minor version and be called out in CHANGELOG.
 type ActionHandler func(action *HookAction, ctx *ExecutionContext, vars *Variables) error
 
 // actionHandlerRegistry is the in-process registry of action handlers.
@@ -48,6 +53,9 @@ var globalActionHandlers = newActionHandlerRegistry()
 // the cost is silently masking conflicts between two plugins claiming the
 // same name. Use namespaced type names (`pluginname:action`) to avoid
 // collisions, e.g. "docker:compose", "docker:exec".
+//
+// Stability: this is the stable plugin extension point as of v0.7.0. See
+// the ActionHandler type for the compatibility contract.
 func RegisterActionHandler(typeName string, h ActionHandler) {
 	globalActionHandlers.register(typeName, h)
 }

--- a/internal/hooks/helpers.go
+++ b/internal/hooks/helpers.go
@@ -12,8 +12,9 @@ import (
 	"github.com/lost-in-the/grove/internal/fsutil"
 )
 
-// resolvePath resolves a path that may be relative or absolute
-// If the path is relative, it's resolved against basePath
+// resolvePath resolves a path that may be relative or absolute.
+// If the path is relative, it is resolved against basePath using filepath.Join
+// with no containment check. Use resolvePathSafe for user-controlled paths.
 func resolvePath(path, basePath string) string {
 	if path == "" {
 		return basePath
@@ -22,6 +23,20 @@ func resolvePath(path, basePath string) string {
 		return path
 	}
 	return filepath.Join(basePath, path)
+}
+
+// resolvePathSafe resolves a user-supplied path against basePath.
+// Absolute paths (e.g. credential sources from grove internals) pass through
+// unchanged. Relative paths are sandboxed inside basePath via fsutil.SafeJoin,
+// rejecting traversal attempts such as "../../.ssh/id_rsa".
+func resolvePathSafe(path, basePath string) (string, error) {
+	if path == "" {
+		return basePath, nil
+	}
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	return fsutil.SafeJoin(basePath, path)
 }
 
 // copyFile copies a single file from src to dst

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -57,7 +57,17 @@ func MigrateFromLegacy(groveDir string, legacyPath string) (bool, error) {
 
 // migrateStateVersion handles in-place migration of state.json between versions
 // This is called when loading state to ensure it's up to date.
-func migrateStateVersion(state *State) {
+//
+// Returns an error if state.Version is newer than CurrentVersion — that
+// signals the user has downgraded grove after upgrading, and silently
+// parsing a future-version file as the current schema risks data loss.
+func migrateStateVersion(state *State) error {
+	if state.Version > CurrentVersion {
+		return fmt.Errorf("state.json version %d is newer than supported version %d; "+
+			"upgrade grove or restore state from .grove/state.json.bak",
+			state.Version, CurrentVersion)
+	}
+
 	if state.Version != CurrentVersion {
 		// Future version migrations would go here.
 		// For now, we only have version 1.
@@ -91,6 +101,8 @@ func migrateStateVersion(state *State) {
 			ws.LastAccessedAt = now
 		}
 	}
+
+	return nil
 }
 
 // BackupState creates a backup of the current state file

--- a/internal/state/migrate_test.go
+++ b/internal/state/migrate_test.go
@@ -73,7 +73,9 @@ func TestMigrateStateVersion(t *testing.T) {
 			Version: 0,
 		}
 
-		migrateStateVersion(state)
+		if err := migrateStateVersion(state); err != nil {
+			t.Fatalf("migrateStateVersion() error = %v", err)
+		}
 
 		if state.Version != CurrentVersion {
 			t.Errorf("Version = %d, want %d", state.Version, CurrentVersion)
@@ -89,7 +91,9 @@ func TestMigrateStateVersion(t *testing.T) {
 			Worktrees: map[string]*WorktreeState{"test": {Path: "/test"}},
 		}
 
-		migrateStateVersion(state)
+		if err := migrateStateVersion(state); err != nil {
+			t.Fatalf("migrateStateVersion() error = %v", err)
+		}
 
 		if state.Version != CurrentVersion {
 			t.Errorf("Version changed unexpectedly")
@@ -105,15 +109,30 @@ func TestMigrateStateVersion(t *testing.T) {
 			Worktrees: nil,
 		}
 
-		migrateStateVersion(state)
+		if err := migrateStateVersion(state); err != nil {
+			t.Fatalf("migrateStateVersion() error = %v", err)
+		}
 
 		if state.Worktrees == nil {
 			t.Error("Worktrees should be initialized")
 		}
 	})
 
+	t.Run("rejects future-version state files", func(t *testing.T) {
+		// Guards against silent data corruption when a user upgrades grove
+		// (writing a newer-version state.json) and then downgrades back.
+		state := &State{
+			Version: CurrentVersion + 1,
+		}
+
+		err := migrateStateVersion(state)
+		if err == nil {
+			t.Fatal("expected error for future-version state, got nil")
+		}
+	})
+
 	t.Run("backfills zero-valued timestamps", func(t *testing.T) {
-		// Simulates state written by v0.6.1 init, which created the main
+		// Simulates state written by an earlier grove init that created the main
 		// worktree without stamping CreatedAt/LastAccessedAt.
 		state := &State{
 			Version: CurrentVersion,
@@ -123,7 +142,9 @@ func TestMigrateStateVersion(t *testing.T) {
 		}
 
 		before := time.Now()
-		migrateStateVersion(state)
+		if err := migrateStateVersion(state); err != nil {
+			t.Fatalf("migrateStateVersion() error = %v", err)
+		}
 		after := time.Now()
 
 		ws := state.Worktrees["main"]
@@ -151,7 +172,9 @@ func TestMigrateStateVersion(t *testing.T) {
 			},
 		}
 
-		migrateStateVersion(state)
+		if err := migrateStateVersion(state); err != nil {
+			t.Fatalf("migrateStateVersion() error = %v", err)
+		}
 
 		ws := state.Worktrees["main"]
 		if !ws.CreatedAt.Equal(fixed) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -277,7 +277,9 @@ func (m *Manager) load() error {
 	}
 
 	// Migrate state if needed
-	migrateStateVersion(&state)
+	if err := migrateStateVersion(&state); err != nil {
+		return err
+	}
 
 	m.state = &state
 	return nil

--- a/internal/tui/overlay_create_v2_test.go
+++ b/internal/tui/overlay_create_v2_test.go
@@ -1,8 +1,13 @@
 package tui
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/lost-in-the/grove/internal/worktree"
 )
 
 func TestRenderContextSummary(t *testing.T) {
@@ -254,6 +259,83 @@ func TestBackspacePreservesValues(t *testing.T) {
 	view := renderCreateNameV2(s, 80)
 	if !strings.Contains(view, "my-feature") {
 		t.Errorf("name step should show preserved name, got:\n%s", view)
+	}
+}
+
+// TestCreateWorktreeCmd_RemoteBranch_UsesCreateFromBranch is a regression test
+// for commit ca7ca08. Before that fix, the TUI used CreateFromExisting for the
+// "from existing branch" flow, which only works with local refs. The fix
+// switched to CreateFromBranch, which fetches from origin first.
+//
+// This test verifies that when baseBranch is non-empty, createWorktreeCmd
+// dispatches through the CreateFromBranch path by inspecting the first log
+// line sent on the streaming channel — it must include the base branch name.
+// (The createFn will fail with no real repo; we only care about the log line.)
+func TestCreateWorktreeCmd_RemoteBranch_UsesCreateFromBranch(t *testing.T) {
+	// Build a minimal git repo so Manager.prepareWorktreePath can resolve paths,
+	// then confirm the first streaming log line names the base branch.
+	dir := t.TempDir()
+
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "commit.gpgsign", "false"},
+		{"config", "user.name", "Test"},
+		{"config", "user.email", "t@t.com"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+	}
+	// Create an initial commit so the repo is valid.
+	f := filepath.Join(dir, "README")
+	if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+	}
+
+	mgr, err := worktree.NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	const baseBranch = "origin/feature-remote-only"
+	cmd := createWorktreeCmd(mgr, nil, dir, "remote-wt", baseBranch)
+	msg := cmd()
+
+	// The first message must be a creationLogMsg (log line before createFn runs)
+	// or a creationDoneMsg (if it failed quickly). Either way the log line or
+	// error context must reference the base branch, proving CreateFromBranch
+	// was called rather than CreateFromExisting.
+	switch m := msg.(type) {
+	case creationLogMsg:
+		if !strings.Contains(m.line, baseBranch) {
+			t.Errorf("first log line = %q, want it to contain base branch %q", m.line, baseBranch)
+		}
+	case creationDoneMsg:
+		// Creation failed (expected — no remote). Verify the log lines
+		// that were sent named the base branch. We can infer this from
+		// the source being "create" (not a silent skip).
+		if m.source != "create" {
+			t.Errorf("creationDoneMsg.source = %q, want %q", m.source, "create")
+		}
+		// The error should be about the branch fetch/create failing, not a nil
+		// error that would indicate a silent no-op.
+		if m.err == nil {
+			t.Error("expected non-nil error from create with nonexistent remote branch")
+		}
+	default:
+		t.Fatalf("unexpected message type %T: %v", msg, msg)
 	}
 }
 

--- a/internal/tui/overlay_fork.go
+++ b/internal/tui/overlay_fork.go
@@ -307,6 +307,10 @@ func (m Model) handleForkConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	s := m.forkState
 
 	switch {
+	case key.Matches(msg, m.keys.Escape):
+		m.activeView = ViewDashboard
+		m.forkState = nil
+		return m, nil
 	case key.Matches(msg, m.keys.Back):
 		if s.HasWIP {
 			s.Step = ForkStepWIP

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -19,8 +19,22 @@ func SetupFiles(ext *config.ExternalComposeConfig, newPath, mainPath string) err
 	var firstErr error
 
 	for _, relPath := range ext.CopyFiles {
-		src := filepath.Join(mainPath, relPath)
-		dst := filepath.Join(newPath, relPath)
+		src, err := fsutil.SafeJoin(mainPath, relPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping copy_files entry %q: %v\n", relPath, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		dst, err := fsutil.SafeJoin(newPath, relPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping copy_files entry %q: %v\n", relPath, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
 
 		if err := copyFile(src, dst); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to copy %s: %v\n", relPath, err)
@@ -33,8 +47,22 @@ func SetupFiles(ext *config.ExternalComposeConfig, newPath, mainPath string) err
 	}
 
 	for _, relPath := range ext.SymlinkFiles {
-		src := filepath.Join(mainPath, relPath)
-		dst := filepath.Join(newPath, relPath)
+		src, err := fsutil.SafeJoin(mainPath, relPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping symlink_files entry %q: %v\n", relPath, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		dst, err := fsutil.SafeJoin(newPath, relPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping symlink_files entry %q: %v\n", relPath, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
 
 		if err := createSymlink(src, dst); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to symlink %s: %v\n", relPath, err)
@@ -47,8 +75,22 @@ func SetupFiles(ext *config.ExternalComposeConfig, newPath, mainPath string) err
 	}
 
 	for _, relPath := range ext.SymlinkDirs {
-		src := filepath.Join(mainPath, relPath)
-		dst := filepath.Join(newPath, relPath)
+		src, err := fsutil.SafeJoin(mainPath, relPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping symlink_dirs entry %q: %v\n", relPath, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		dst, err := fsutil.SafeJoin(newPath, relPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: skipping symlink_dirs entry %q: %v\n", relPath, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
 
 		if err := createSymlink(src, dst); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to symlink %s: %v\n", relPath, err)

--- a/internal/worktree/setup_test.go
+++ b/internal/worktree/setup_test.go
@@ -156,3 +156,58 @@ func TestSetupFiles_SymlinkMissingSource(t *testing.T) {
 		t.Errorf("Expected 'source not found' in error, got %q", err.Error())
 	}
 }
+
+func TestSetupFiles_PathTraversal(t *testing.T) {
+	mainPath := t.TempDir()
+	newPath := t.TempDir()
+
+	t.Run("legitimate symlink_files entry succeeds", func(t *testing.T) {
+		_ = os.WriteFile(filepath.Join(mainPath, "config.yml"), []byte("ok"), 0644)
+		ext := &config.ExternalComposeConfig{
+			SymlinkFiles: []string{"config.yml"},
+		}
+		err := SetupFiles(ext, newPath, mainPath)
+		if err != nil {
+			t.Errorf("SetupFiles() legitimate entry = %v, want nil", err)
+		}
+	})
+
+	t.Run("dotdot in copy_files rejected", func(t *testing.T) {
+		ext := &config.ExternalComposeConfig{
+			CopyFiles: []string{"../../etc/passwd"},
+		}
+		err := SetupFiles(ext, newPath, mainPath)
+		if err == nil {
+			t.Error("SetupFiles() with traversal copy_files = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "escapes base directory") {
+			t.Errorf("expected 'escapes base directory' in error, got %q", err.Error())
+		}
+	})
+
+	t.Run("dotdot in symlink_files rejected", func(t *testing.T) {
+		ext := &config.ExternalComposeConfig{
+			SymlinkFiles: []string{"../../.ssh/id_rsa"},
+		}
+		err := SetupFiles(ext, newPath, mainPath)
+		if err == nil {
+			t.Error("SetupFiles() with traversal symlink_files = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "escapes base directory") {
+			t.Errorf("expected 'escapes base directory' in error, got %q", err.Error())
+		}
+	})
+
+	t.Run("dotdot in symlink_dirs rejected", func(t *testing.T) {
+		ext := &config.ExternalComposeConfig{
+			SymlinkDirs: []string{"../../../secret_dir"},
+		}
+		err := SetupFiles(ext, newPath, mainPath)
+		if err == nil {
+			t.Error("SetupFiles() with traversal symlink_dirs = nil, want error")
+		}
+		if !strings.Contains(err.Error(), "escapes base directory") {
+			t.Errorf("expected 'escapes base directory' in error, got %q", err.Error())
+		}
+	})
+}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -901,6 +901,59 @@ func TestIsDirtyWithWorktree(t *testing.T) {
 	}
 }
 
+// TestRemove_ForceWithNonEmptyDir exercises the os.RemoveAll fallback path
+// introduced for issue #24. `git worktree remove --force` refuses to delete
+// a worktree directory that contains untracked subdirectories (e.g. a
+// node_modules dir left by a post-create hook). Grove's Remove() falls back
+// to os.RemoveAll + git worktree prune in that case.
+func TestRemove_ForceWithNonEmptyDir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir, _ := setupTestRepo(t)
+	m := &Manager{repoRoot: tmpDir}
+
+	// Create a worktree we can then pollute with an untracked directory.
+	if err := m.Create("nm-test", "nm-test-branch"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	projectName := m.GetProjectName()
+	fullName := projectName + "-nm-test"
+
+	wt, err := m.Find(fullName)
+	if err != nil || wt == nil {
+		t.Fatalf("Find() expected worktree, got error=%v, wt=%v", err, wt)
+	}
+
+	// Plant a non-empty untracked directory inside the worktree. This makes
+	// `git worktree remove --force` refuse to proceed, forcing the fallback.
+	nodeModules := filepath.Join(wt.Path, "node_modules")
+	if err := os.MkdirAll(filepath.Join(nodeModules, "some-pkg"), 0755); err != nil {
+		t.Fatalf("MkdirAll node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nodeModules, "some-pkg", "index.js"), []byte("module.exports={}"), 0644); err != nil {
+		t.Fatalf("WriteFile index.js: %v", err)
+	}
+
+	// Remove should succeed via the os.RemoveAll fallback.
+	if err := m.Remove(fullName); err != nil {
+		t.Fatalf("Remove() with non-empty untracked dir error = %v", err)
+	}
+
+	// Verify the directory is gone.
+	if _, statErr := os.Stat(wt.Path); !os.IsNotExist(statErr) {
+		t.Errorf("worktree directory still exists after Remove(): %s", wt.Path)
+	}
+
+	// Verify git no longer lists it.
+	wtAfter, _ := m.Find(fullName)
+	if wtAfter != nil {
+		t.Error("worktree should not be found after Remove()")
+	}
+}
+
 func TestGetCommitInfo(t *testing.T) {
 	tmpDir, _ := setupTestRepo(t)
 

--- a/plugins/docker/agent_external.go
+++ b/plugins/docker/agent_external.go
@@ -331,10 +331,11 @@ func (s *agentExternalStrategy) agentEnv(worktreePath string, slot int) []string
 	return env
 }
 
-// resolveComposePath resolves ~ in a compose directory path. Paths loaded
-// through internal/config are already absolute (relative paths in
-// .grove/config.toml resolve against the project root at load time), so this
-// is a defensive fallback for callers that construct configs by hand.
+// resolveComposePath resolves ~ in a compose directory path. Configs loaded
+// through internal/config.Load already have absolute paths, so this function
+// is a no-op for those callers. It remains for correctness in edge cases where
+// a caller constructs an ExternalComposeConfig directly (e.g. tests or future
+// callers that bypass config.Load) and passes a ~/-prefixed path.
 func resolveComposePath(path string) string {
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()

--- a/plugins/docker/hook_compose_test.go
+++ b/plugins/docker/hook_compose_test.go
@@ -175,6 +175,41 @@ func TestComposeHandler_InvalidMode(t *testing.T) {
 	}
 }
 
+func TestComposeHandler_RunError(t *testing.T) {
+	// fakeStrategy.runErr is defined but was never exercised. Verify that a
+	// strategy-level run error propagates through composeHandler.
+	p, fs := newFakePlugin()
+	syntheticErr := errors.New("bundle install failed with exit 1")
+	fs.runErr = syntheticErr
+	action := &hooks.HookAction{Type: "docker:compose", Service: "web", Command: "bundle install"}
+	ctx := &hooks.ExecutionContext{NewPath: "/tmp/wt"}
+
+	err := p.composeHandler(action, ctx, &hooks.Variables{})
+	if err == nil {
+		t.Fatal("expected error when Run fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "web") {
+		t.Errorf("error should reference the service name, got %v", err)
+	}
+}
+
+func TestComposeHandler_ExecError(t *testing.T) {
+	// Symmetric test for exec mode: strategy-level exec error must propagate.
+	p, fs := newFakePlugin()
+	syntheticErr := errors.New("rails db:migrate failed")
+	fs.execErr = syntheticErr
+	action := &hooks.HookAction{Type: "docker:compose", Service: "app", Command: "rails db:migrate", Mode: "exec"}
+	ctx := &hooks.ExecutionContext{NewPath: "/tmp/wt"}
+
+	err := p.composeHandler(action, ctx, &hooks.Variables{})
+	if err == nil {
+		t.Fatal("expected error when Exec fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "app") {
+		t.Errorf("error should reference the service name, got %v", err)
+	}
+}
+
 func TestComposeHandler_VariableInterpolation(t *testing.T) {
 	// Interpolation applies to service AND command (both can be per-worktree).
 	p, fs := newFakePlugin()

--- a/plugins/docker/hook_docker_exec_test.go
+++ b/plugins/docker/hook_docker_exec_test.go
@@ -1,6 +1,9 @@
 package docker
 
 import (
+	"bytes"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -80,5 +83,86 @@ func TestDockerExecHandler_NotRunningContainer(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not running") {
 		t.Fatalf("error should explain not-running state, got %v", err)
+	}
+}
+
+// TestDockerExecHandler_Success exercises the happy path by running a real
+// `docker exec` against a container that is actually running, OR — since
+// we cannot rely on a live daemon in CI — we use the fake-binary trick:
+// put a script named "docker" on PATH that exits 0 and prints to stdout.
+func TestDockerExecHandler_Success(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	// Build a fake `docker` binary that:
+	//   - prints "running" when called as `docker inspect -f ... <container>`
+	//   - exits 0 and prints a marker line for any other invocation
+	fakeDockerDir := t.TempDir()
+	fakeDockerScript := `#!/bin/sh
+if [ "$1" = "inspect" ]; then
+  echo "true"
+  exit 0
+fi
+echo "fake docker exec ok"
+exit 0
+`
+	fakeDockerPath := fakeDockerDir + "/docker"
+	if err := os.WriteFile(fakeDockerPath, []byte(fakeDockerScript), 0755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeDockerDir+":"+origPath)
+
+	var buf bytes.Buffer
+	p := &Plugin{enabled: true}
+	err := p.dockerExecHandler(
+		&hooks.HookAction{Container: "my-container", Command: "true"},
+		&hooks.ExecutionContext{Output: &buf},
+		&hooks.Variables{},
+	)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "my-container") {
+		t.Errorf("expected container name in success output, got %q", buf.String())
+	}
+}
+
+// TestDockerExecHandler_NonZeroExit verifies that a failing docker exec is
+// wrapped and returned as an error.
+func TestDockerExecHandler_NonZeroExit(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	fakeDockerDir := t.TempDir()
+	fakeDockerScript := `#!/bin/sh
+if [ "$1" = "inspect" ]; then
+  echo "true"
+  exit 0
+fi
+exit 42
+`
+	fakeDockerPath := fakeDockerDir + "/docker"
+	if err := os.WriteFile(fakeDockerPath, []byte(fakeDockerScript), 0755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeDockerDir+":"+origPath)
+
+	p := &Plugin{enabled: true}
+	err := p.dockerExecHandler(
+		&hooks.HookAction{Container: "my-container", Command: "fail-cmd"},
+		&hooks.ExecutionContext{},
+		&hooks.Variables{},
+	)
+	if err == nil {
+		t.Fatal("expected error for non-zero docker exec exit, got nil")
+	}
+	if !strings.Contains(err.Error(), "my-container") {
+		t.Errorf("error should reference container name, got %v", err)
 	}
 }

--- a/plugins/docker/local.go
+++ b/plugins/docker/local.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -104,7 +103,7 @@ func (s *localStrategy) Down(worktreePath string) error {
 
 func (s *localStrategy) Logs(worktreePath string, service string, follow bool) error {
 	if !hasDockerCompose(worktreePath) {
-		return fmt.Errorf("no docker-compose file found in %s", worktreePath)
+		return ErrNoComposeFile
 	}
 
 	args := []string{"logs"}
@@ -149,7 +148,7 @@ func (s *localStrategy) Exec(worktreePath string, service string, command string
 
 func (s *localStrategy) Restart(worktreePath string, service string) error {
 	if !hasDockerCompose(worktreePath) {
-		return fmt.Errorf("no docker-compose file found in %s", worktreePath)
+		return ErrNoComposeFile
 	}
 
 	args := []string{"restart"}

--- a/plugins/docker/plugin.go
+++ b/plugins/docker/plugin.go
@@ -264,11 +264,6 @@ func buildSlotManager(cfg *config.Config) *SlotManager {
 	return NewSlotManager(slotsFile, maxSlots)
 }
 
-// ResolveComposePath resolves a compose path, expanding ~ to home directory.
-func ResolveComposePath(path string) string {
-	return resolveComposePath(path)
-}
-
 // isAgentMode returns true when the agent mode env var is set and the config
 // has an enabled agent section.
 func isAgentMode(cfg *config.Config) bool {


### PR DESCRIPTION
Closes #45 and #46. Two atomic commits.

**#46** — Traced all three doctor.go ResolveComposePath calls; ext.Path already comes through config.LoadFromGroveDir → resolveProjectPaths → expandConfigPath, so the calls were no-ops. Deleted the exported ResolveComposePath wrapper from plugin.go; switched doctor.go call sites to read ext.Path directly. Kept the private resolveComposePath in agent_external.go (still used internally) with a sharpened doc comment.

**#45** — Added internal/fsutil.SafeJoin(base, rel) which rejects absolute rel inputs and any results where filepath.Rel returns a ..-prefixed path. Migrated internal/hooks/executor.go (builtinCopy / builtinSymlink / builtinTemplate via a new resolvePathSafe wrapper that passes absolute paths through but sandboxes relative ones) and internal/worktree/setup.go (copy_files, symlink_files, symlink_dirs loops). Attack case from = '../../.ssh/id_rsa' now errors before any filesystem access. 8 table-driven SafeJoin tests + regression tests in executor_test.go and setup_test.go.

go build clean; tests pass.