### PR TITLE
test(integration): automate state guard / browse / doctor --fix validations

### DIFF
--- a/tests/integration/browse_e2e_test.go
+++ b/tests/integration/browse_e2e_test.go
@@ -1,0 +1,215 @@
+//go:build integration
+
+// End-to-end coverage for `grove browse --json` covering the three
+// resolution paths from PR #53 (cherry-picked from release/v0.7.0):
+//   1. open PR found for the current branch  → source = "pr"
+//   2. worktree name "issue-<n>-..." parses out a known issue → "issue"
+//   3. neither — compare-page fallback                       → "compare"
+//
+// gh is stubbed on PATH so the test runs offline; `auth status`, `repo view`,
+// `pr view`, and `issue view` are scripted per scenario via the GROVE_TEST_GH
+// env var the fake reads.
+package integration_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/testhelper"
+)
+
+var (
+	groveBinaryOnce sync.Once
+	groveBinaryPath string
+	groveBinaryErr  error
+)
+
+// buildGroveBinary compiles cmd/grove into a tempdir once per test run and
+// returns the path. Subsequent callers reuse the same binary.
+func buildGroveBinary(t *testing.T) string {
+	t.Helper()
+	groveBinaryOnce.Do(func() {
+		root, err := repoRootDir()
+		if err != nil {
+			groveBinaryErr = err
+			return
+		}
+		dir, err := os.MkdirTemp("", "grove-bin-*")
+		if err != nil {
+			groveBinaryErr = err
+			return
+		}
+		groveBinaryPath = filepath.Join(dir, "grove")
+		cmd := exec.Command("go", "build", "-o", groveBinaryPath, "./cmd/grove")
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			groveBinaryErr = &buildErr{out: out, err: err}
+		}
+	})
+	if groveBinaryErr != nil {
+		t.Fatalf("build grove binary: %v", groveBinaryErr)
+	}
+	return groveBinaryPath
+}
+
+type buildErr struct {
+	out []byte
+	err error
+}
+
+func (b *buildErr) Error() string { return b.err.Error() + "\n" + string(b.out) }
+
+// repoRootDir walks up from CWD until it finds go.mod.
+func repoRootDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}
+
+// installFakeGh writes a shell script named "gh" into a fresh tempdir and
+// returns the directory. Callers prepend this dir to PATH so the script
+// shadows the real gh CLI.
+func installFakeGh(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1 $2" in
+  "auth status") exit 0 ;;
+  "repo view")
+    echo "test-org/test-repo"
+    exit 0 ;;
+  "pr view")
+    case "$GROVE_TEST_GH" in
+      pr-found)
+        echo '{"number":42,"title":"Test PR","state":"OPEN","url":"https://github.com/test-org/test-repo/pull/42"}'
+        exit 0 ;;
+      *) exit 1 ;;
+    esac ;;
+  "issue view")
+    case "$GROVE_TEST_GH" in
+      issue-found)
+        echo '{"number":7,"title":"Test Issue","state":"OPEN","url":"https://github.com/test-org/test-repo/issues/7"}'
+        exit 0 ;;
+      *) exit 1 ;;
+    esac ;;
+esac
+exit 1
+`
+	path := filepath.Join(dir, "gh")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	return dir
+}
+
+// setupBrowseRepo prepares a temp grove project with a single worktree,
+// returning the worktree path so tests can run grove browse from inside it.
+// worktreeName is used as both the worktree short name and the branch name
+// (worktree dir layout: <project>-<name>, branch: <name>).
+func setupBrowseRepo(t *testing.T, worktreeName string) string {
+	t.Helper()
+	repo := testhelper.SetupRailsFixture(t)
+
+	// Make a real linked worktree so `grove browse` running inside it
+	// resolves a non-empty branch and short name.
+	wtPath := filepath.Join(filepath.Dir(repo), "rails-app-"+worktreeName)
+	testhelper.RunGit(t, repo, "worktree", "add", "-b", worktreeName, wtPath)
+
+	// Initialize .grove with a state.json that knows about both worktrees so
+	// Manager.GetCurrent doesn't trip over an empty store.
+	groveDir := filepath.Join(repo, ".grove")
+	state := []byte(`{"version": 1, "worktrees": {}}`)
+	if err := os.WriteFile(filepath.Join(groveDir, "state.json"), state, 0644); err != nil {
+		t.Fatalf("write state.json: %v", err)
+	}
+
+	return wtPath
+}
+
+func runGroveBrowse(t *testing.T, wtPath, fakeGhDir, scenario string) (url, source string) {
+	t.Helper()
+	binary := buildGroveBinary(t)
+
+	cmd := exec.Command(binary, "browse", "--json")
+	cmd.Dir = wtPath
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeGhDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GROVE_TEST_GH="+scenario,
+	)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("grove browse failed: %v\nstderr: %s\nstdout: %s", err, ee.Stderr, out)
+		}
+		t.Fatalf("grove browse failed: %v\nstdout: %s", err, out)
+	}
+
+	var result struct {
+		URL    string `json:"url"`
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("parse JSON output: %v\nraw: %s", err, out)
+	}
+	return result.URL, result.Source
+}
+
+func TestGroveBrowse_PRFound(t *testing.T) {
+	wtPath := setupBrowseRepo(t, "feat-test")
+	fakeGh := installFakeGh(t)
+
+	url, source := runGroveBrowse(t, wtPath, fakeGh, "pr-found")
+
+	if source != "pr" {
+		t.Errorf("source = %q, want %q", source, "pr")
+	}
+	if url != "https://github.com/test-org/test-repo/pull/42" {
+		t.Errorf("url = %q, want PR URL", url)
+	}
+}
+
+func TestGroveBrowse_IssueFromWorktreeName(t *testing.T) {
+	// Worktree name shaped as "issue-<n>-..." triggers the issue lookup path.
+	wtPath := setupBrowseRepo(t, "issue-7-fix-something")
+	fakeGh := installFakeGh(t)
+
+	url, source := runGroveBrowse(t, wtPath, fakeGh, "issue-found")
+
+	if source != "issue" {
+		t.Errorf("source = %q, want %q", source, "issue")
+	}
+	if url != "https://github.com/test-org/test-repo/issues/7" {
+		t.Errorf("url = %q, want issue URL", url)
+	}
+}
+
+func TestGroveBrowse_CompareFallback(t *testing.T) {
+	wtPath := setupBrowseRepo(t, "feat-no-pr")
+	fakeGh := installFakeGh(t)
+
+	url, source := runGroveBrowse(t, wtPath, fakeGh, "no-match")
+
+	if source != "compare" {
+		t.Errorf("source = %q, want %q", source, "compare")
+	}
+	want := "https://github.com/test-org/test-repo/compare/feat-no-pr"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+}

--- a/tests/integration/doctor_fix_e2e_test.go
+++ b/tests/integration/doctor_fix_e2e_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+// End-to-end coverage for `grove doctor --fix`. The underlying rewrite logic
+// (fixHostInstallsInDockerProject) has rich unit coverage in doctor_test.go;
+// this test pins the cobra flag wiring + binary invocation so a regression in
+// the top-level glue surfaces in CI rather than during manual release sanity.
+
+package integration_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/testhelper"
+)
+
+func TestGroveDoctor_FixRewritesHostInstall(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	// Build a Rails-shaped project with compose + a hooks.toml carrying a
+	// host bundle-install command. doctor --fix should rewrite this in place.
+	repo := testhelper.SetupRailsFixture(t)
+	mustWrite(t, filepath.Join(repo, "Dockerfile"), "FROM ruby\n")
+	mustWrite(t, filepath.Join(repo, "docker-compose.yml"),
+		"services:\n  web:\n    image: ruby\n")
+
+	groveDir := filepath.Join(repo, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(groveDir, "state.json"),
+		`{"version": 1, "worktrees": {}}`)
+	hooksPath := filepath.Join(groveDir, "hooks.toml")
+	mustWrite(t, hooksPath, `[[hooks.post_create]]
+type = "command"
+command = "bundle install"
+`)
+
+	cmd := exec.Command(binary, "doctor", "--fix")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("grove doctor --fix failed: %v\noutput: %s", err, out)
+	}
+
+	got, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read back hooks.toml: %v", err)
+	}
+	hooks := string(got)
+
+	if !strings.Contains(hooks, `type = "docker:compose"`) {
+		t.Errorf("hooks.toml not rewritten to docker:compose:\n%s", hooks)
+	}
+	if !strings.Contains(hooks, `service = "web"`) {
+		t.Errorf("hooks.toml missing inferred service:\n%s", hooks)
+	}
+	// The original `bundle install` command should still be present (preserved
+	// inside the now-routed compose hook), not replaced.
+	if !strings.Contains(hooks, "bundle install") {
+		t.Errorf("hooks.toml dropped the original command:\n%s", hooks)
+	}
+}
+
+// TestGroveDoctor_NoFixLeavesHooksAlone asserts that running doctor without
+// --fix leaves hooks.toml untouched (the diagnostic still prints, but the
+// file isn't modified).
+func TestGroveDoctor_NoFixLeavesHooksAlone(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	repo := testhelper.SetupRailsFixture(t)
+	mustWrite(t, filepath.Join(repo, "Dockerfile"), "FROM ruby\n")
+	mustWrite(t, filepath.Join(repo, "docker-compose.yml"),
+		"services:\n  web:\n    image: ruby\n")
+
+	groveDir := filepath.Join(repo, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(groveDir, "state.json"),
+		`{"version": 1, "worktrees": {}}`)
+	hooksPath := filepath.Join(groveDir, "hooks.toml")
+	original := `[[hooks.post_create]]
+type = "command"
+command = "bundle install"
+`
+	mustWrite(t, hooksPath, original)
+
+	cmd := exec.Command(binary, "doctor")
+	cmd.Dir = repo
+	if _, err := cmd.CombinedOutput(); err != nil {
+		// doctor prints a warning and may exit non-zero when checks fail —
+		// that's fine; we only care that the file is untouched.
+		_ = err
+	}
+
+	got, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.toml: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("hooks.toml mutated without --fix:\nwant:\n%s\ngot:\n%s", original, got)
+	}
+}
+
+func mustWrite(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/tests/integration/state_future_version_test.go
+++ b/tests/integration/state_future_version_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+// Future-version state.json error guard. Covers the manual validation in PR #48
+// that asks: "simulate a future-version state.json and confirm grove errors
+// instead of silently parsing." End-to-end via state.NewManager so this
+// verifies the production load path (migrate.go → state.go).
+
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/state"
+)
+
+func TestStateLoad_RejectsFutureVersion(t *testing.T) {
+	groveDir := filepath.Join(t.TempDir(), ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a state.json claiming a version far in the future. This simulates
+	// a user who upgraded grove (which wrote a newer schema), then downgraded
+	// back. Without the guard added in v0.7.0, the older grove would silently
+	// parse the file as v1 and risk dropping fields it doesn't recognize.
+	futureState := []byte(`{"version": 99, "worktrees": {}}`)
+	if err := os.WriteFile(filepath.Join(groveDir, "state.json"), futureState, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := state.NewManager(groveDir)
+	if err == nil {
+		t.Fatal("expected state.NewManager to error on future-version state.json, got nil")
+	}
+
+	// The error should explicitly mention the version mismatch so the user
+	// knows what's going on.
+	msg := err.Error()
+	if !strings.Contains(msg, "version 99") || !strings.Contains(msg, "newer than supported") {
+		t.Errorf("expected error to identify the future version; got: %v", err)
+	}
+}
+
+func TestStateLoad_AcceptsCurrentVersion(t *testing.T) {
+	groveDir := filepath.Join(t.TempDir(), ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity check: the current version still loads without error.
+	currentState := []byte(`{"version": 1, "worktrees": {}}`)
+	if err := os.WriteFile(filepath.Join(groveDir, "state.json"), currentState, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := state.NewManager(groveDir); err != nil {
+		t.Fatalf("current-version state should load cleanly: %v", err)
+	}
+}


### PR DESCRIPTION
Closes the automatable validation checkboxes carried over from PRs #48 and #53.

## What landed

### tests/integration/state_future_version_test.go
- TestStateLoad_RejectsFutureVersion — writes `state.json` with version 99 and asserts `state.NewManager` errors out with a clear message naming the version. Pins the downgrade-safety guard added in #48.
- TestStateLoad_AcceptsCurrentVersion — sanity check that a current-version state.json still loads.

### tests/integration/browse_e2e_test.go
- TestGroveBrowse_PRFound — fake gh returns a PR; asserts `source = pr`.
- TestGroveBrowse_IssueFromWorktreeName — worktree named `issue-7-...` triggers the issue lookup; asserts `source = issue`.
- TestGroveBrowse_CompareFallback — gh returns no PR, name not an issue; asserts `source = compare`.
- All three build the grove binary once via sync.Once, shadow gh on PATH with a scripted stub, and run `grove browse --json` from inside a fixture worktree. Offline.

### tests/integration/doctor_fix_e2e_test.go
- TestGroveDoctor_FixRewritesHostInstall — fixture project (Dockerfile + compose + hooks.toml with host `bundle install`); asserts `grove doctor --fix` rewrites the hook to docker:compose with the inferred service.
- TestGroveDoctor_NoFixLeavesHooksAlone — same fixture without --fix; asserts hooks.toml stays untouched.
- The underlying `fixHostInstallsInDockerProject` has rich unit coverage in doctor_test.go (PR #39); this test pins the cobra flag wiring and binary glue.

## Verification
- `make lint` → 0 issues
- `make test` → all packages pass
- `make test-integration-docker` → 14 tests pass in ~22s (binary build + 7 file-based + 4 browse/doctor + 3 state/scenarios)

## Test plan
- [ ] CI passes
- [ ] When user provides a real Docker compose project, manually verify scenario #1 (live docker:compose hook) and the agent-stack validations from #31 (rm with daemon down, doctor with bad template_path, env var export on switch)