### PR TITLE
fix: agent slot leak on rm + service inference priority (#56, #57)

### DIFF
--- a/internal/detect/compose.go
+++ b/internal/detect/compose.go
@@ -35,6 +35,24 @@ var infraServiceNames = map[string]bool{
 	"minio":         true,
 }
 
+// appServicePriorityNames are canonical names for the "main" application
+// service. When a compose file declares one of these alongside other
+// non-infra services, we prefer it. Order in the slice is preference order:
+// `web` is the most common Rails convention, `app` covers Django/Node, etc.
+//
+// This exists because the previous heuristic ("first non-infra in declaration
+// order") got confused by stacks like Rails+webpack: `webpack` declared
+// before `web` would win, even though `bundle install` belongs in `web`.
+var appServicePriorityNames = []string{
+	"web",
+	"app",
+	"rails",
+	"backend",
+	"api",
+	"server",
+	"application",
+}
+
 // FindComposeFile returns the path to the first compose file present in dir,
 // or empty string if none.
 func FindComposeFile(dir string) string {
@@ -78,6 +96,14 @@ func InferAppService(composePath string) (string, bool) {
 }
 
 // pickAppService applies the inference heuristic to a service list.
+//
+// Order:
+//  1. Single service → return it.
+//  2. Service name matches one of appServicePriorityNames (case-insensitive)
+//     → return it. This catches the common case where a Rails app has a
+//     `web` service alongside `webpack` / `worker` / `mailer`.
+//  3. First non-infra service in declaration order.
+//  4. No services or all infra → ("", false).
 func pickAppService(services []string) (string, bool) {
 	if len(services) == 0 {
 		return "", false
@@ -85,6 +111,21 @@ func pickAppService(services []string) (string, bool) {
 	if len(services) == 1 {
 		return services[0], true
 	}
+
+	// Build a set for O(1) lookup of the declared services.
+	declared := make(map[string]string, len(services))
+	for _, s := range services {
+		declared[strings.ToLower(s)] = s
+	}
+
+	// First pass: prefer canonical app names if any are declared.
+	for _, name := range appServicePriorityNames {
+		if original, ok := declared[name]; ok {
+			return original, true
+		}
+	}
+
+	// Second pass: first non-infra in declaration order.
 	for _, s := range services {
 		if !infraServiceNames[strings.ToLower(s)] {
 			return s, true

--- a/internal/detect/compose_test.go
+++ b/internal/detect/compose_test.go
@@ -36,6 +36,67 @@ services:
 	}
 }
 
+func TestInferAppService_PrefersCanonicalNameOverDeclarationOrder(t *testing.T) {
+	// Regression for the acupoll case (issue #56): a Rails+webpack stack
+	// declares `webpack` before `web`. The previous heuristic ("first
+	// non-infra in declaration order") picked `webpack` and routed
+	// `bundle install` to the asset pipeline. The priority list pulls
+	// `web` ahead.
+	dir := t.TempDir()
+	writeFile(t, dir, "docker-compose.yml", `services:
+  postgres:
+    image: postgres:16
+  redis:
+    image: redis:7
+  webpack:
+    image: node:20
+  worker:
+    build: .
+  web:
+    build: .
+    depends_on:
+      - postgres
+`)
+	got, ok := InferAppService(filepath.Join(dir, "docker-compose.yml"))
+	if !ok || got != "web" {
+		t.Fatalf("got %q,%v; want web,true (priority list should pull web ahead of webpack)", got, ok)
+	}
+}
+
+func TestInferAppService_FallsBackToDeclarationOrderWhenNoCanonicalName(t *testing.T) {
+	// When no service matches the priority list, fall back to the original
+	// "first non-infra" heuristic so existing behavior is preserved.
+	dir := t.TempDir()
+	writeFile(t, dir, "docker-compose.yml", `services:
+  postgres:
+    image: postgres:16
+  webpack:
+    image: node:20
+  worker:
+    build: .
+`)
+	got, ok := InferAppService(filepath.Join(dir, "docker-compose.yml"))
+	if !ok || got != "webpack" {
+		t.Fatalf("got %q,%v; want webpack,true (no canonical name → first non-infra)", got, ok)
+	}
+}
+
+func TestInferAppService_PriorityNameIsCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "docker-compose.yml", `services:
+  Postgres:
+    image: postgres:16
+  Worker:
+    build: .
+  Web:
+    build: .
+`)
+	got, ok := InferAppService(filepath.Join(dir, "docker-compose.yml"))
+	if !ok || got != "Web" {
+		t.Fatalf("got %q,%v; want Web,true (case-insensitive priority match should preserve original casing)", got, ok)
+	}
+}
+
 func TestInferAppService_AllInfraReturnsFalse(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "docker-compose.yml", `services:

--- a/plugins/docker/plugin.go
+++ b/plugins/docker/plugin.go
@@ -144,18 +144,22 @@ func (p *Plugin) onPreRemove(ctx *hooks.Context) error {
 		return nil
 	}
 
-	// Clean up env var entry for external strategy
+	// Phase 1: env var cleanup runs whenever an external strategy is active.
 	if ext, ok := p.strategy.(*externalStrategy); ok {
 		if err := ext.removeEnvVar(ctx.WorktreePath); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to clean %s from %s: %v\n",
 				ext.ext.EnvVar, ext.ext.EnvFileName(), err)
 		}
-		return nil
 	}
 
-	// Tear down agent stack if running
-	agent, ok := p.strategy.(*agentExternalStrategy)
-	if !ok {
+	// Phase 2: agent slot teardown. Runs whenever the project has agent stacks
+	// configured, even if the active strategy is plain external — covers
+	// `grove rm` from a shell that didn't set GROVE_AGENT_MODE=1, where the
+	// non-agent strategy was selected at plugin init but the worktree being
+	// removed still owns a slot in .slots.json. Without this, the slot would
+	// leak whenever rm was invoked without the env var.
+	agent := p.agentStrategyForTeardown()
+	if agent == nil {
 		return nil
 	}
 	wtName := filepath.Base(ctx.WorktreePath)
@@ -164,7 +168,7 @@ func (p *Plugin) onPreRemove(ctx *hooks.Context) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stderr, "Stopping agent stack for '%s'...\n", ctx.Worktree)
-	downErr := p.strategy.Down(ctx.WorktreePath)
+	downErr := agent.Down(ctx.WorktreePath)
 	if downErr == nil {
 		// Down() releases the slot itself on success.
 		return nil
@@ -176,6 +180,30 @@ func (p *Plugin) onPreRemove(ctx *hooks.Context) error {
 		fmt.Fprintf(os.Stderr, "warning: failed to release agent slot %d after teardown failure: %v\n", slot, relErr)
 	}
 	return downErr
+}
+
+// agentStrategyForTeardown returns the agent strategy to use for slot
+// teardown during pre-remove. Falls back to constructing a transient agent
+// strategy when the active strategy is plain external but the project has
+// agent stacks configured — necessary so `grove rm` releases slots even when
+// invoked without GROVE_AGENT_MODE=1 set.
+//
+// Returns nil when the project doesn't use agent stacks at all.
+func (p *Plugin) agentStrategyForTeardown() *agentExternalStrategy {
+	if a, ok := p.strategy.(*agentExternalStrategy); ok {
+		return a
+	}
+	if p.cfg == nil {
+		return nil
+	}
+	ext := p.cfg.Plugins.Docker.External
+	if ext == nil || ext.Agent == nil {
+		return nil
+	}
+	if ext.Agent.Enabled == nil || !*ext.Agent.Enabled {
+		return nil
+	}
+	return newAgentExternalStrategy(p.cfg)
 }
 
 // SetIsolated forces the plugin to use the agent external strategy,

--- a/plugins/docker/plugin_test.go
+++ b/plugins/docker/plugin_test.go
@@ -997,3 +997,83 @@ func TestPlugin_OnPreRemove_AgentSlotReleasedOnDownFailure(t *testing.T) {
 		t.Errorf("slot %d still allocated after onPreRemove (originally slot %d) — leaked", slotAfter, allocatedSlot)
 	}
 }
+
+// TestPlugin_OnPreRemove_AgentSlotReleasedWithoutAgentMode covers issue #57:
+// when `grove rm` runs from a shell that didn't set GROVE_AGENT_MODE=1, the
+// plugin selects the plain external strategy at Init time. Before the fix,
+// OnPreRemove early-returned through the external-strategy branch and the
+// agent slot teardown never ran, so a worktree that owned a slot leaked it
+// when removed. The fix added a transient agent-strategy fallback in
+// agentStrategyForTeardown so slot release happens regardless of which
+// strategy was selected at Init.
+func TestPlugin_OnPreRemove_AgentSlotReleasedWithoutAgentMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	composeDir := filepath.Join(tmpDir, "compose")
+	if err := os.MkdirAll(filepath.Join(composeDir, "agent-stacks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	enabled := true
+	cfg := &config.Config{
+		ProjectName: "myapp",
+		Plugins: config.PluginsConfig{
+			Docker: config.DockerPluginConfig{
+				Mode: "external",
+				External: &config.ExternalComposeConfig{
+					Path:     composeDir,
+					EnvVar:   "APP_DIR",
+					Services: []string{"app"},
+					Agent: &config.AgentStackConfig{
+						Enabled:      &enabled,
+						MaxSlots:     3,
+						Services:     []string{"app"},
+						TemplatePath: "agent-stacks/template.yml",
+					},
+				},
+			},
+		},
+		// AgentMode intentionally NOT set — this is the bug scenario.
+	}
+
+	// Make sure GROVE_AGENT_MODE is unset so isAgentMode() returns false and
+	// the plugin selects the plain external strategy.
+	t.Setenv("GROVE_AGENT_MODE", "")
+
+	plugin := New()
+	if err := plugin.Init(cfg); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	if _, ok := plugin.strategy.(*externalStrategy); !ok {
+		t.Fatalf("expected external strategy when AgentMode is unset, got %T", plugin.strategy)
+	}
+
+	// Allocate a slot directly so the test doesn't depend on the create flow.
+	wtName := "myapp-leak-test"
+	worktreePath := filepath.Join(tmpDir, wtName)
+	slotsFile := filepath.Join(composeDir, "agent-stacks", ".slots.json")
+	slots := NewSlotManager(slotsFile, 3)
+	allocatedSlot, err := slots.Allocate(wtName)
+	if err != nil {
+		t.Fatalf("Allocate() error = %v", err)
+	}
+
+	ctx := &hooks.Context{
+		Worktree:     wtName,
+		Config:       cfg,
+		WorktreePath: worktreePath,
+	}
+
+	// onPreRemove will try Down on a fresh agent strategy; it'll fail because
+	// there's no daemon / template, but the slot should still be released.
+	_ = plugin.onPreRemove(ctx)
+
+	slotAfter, err := slots.FindSlot(wtName)
+	if err != nil {
+		t.Fatalf("FindSlot() error = %v", err)
+	}
+	if slotAfter != 0 {
+		t.Errorf("slot %d still allocated after onPreRemove (originally slot %d) — leaked because external strategy didn't run agent teardown",
+			slotAfter, allocatedSlot)
+	}
+}

--- a/tests/integration/browse_e2e_test.go
+++ b/tests/integration/browse_e2e_test.go
@@ -2,9 +2,9 @@
 
 // End-to-end coverage for `grove browse --json` covering the three
 // resolution paths from PR #53 (cherry-picked from release/v0.7.0):
-//   1. open PR found for the current branch  → source = "pr"
-//   2. worktree name "issue-<n>-..." parses out a known issue → "issue"
-//   3. neither — compare-page fallback                       → "compare"
+//  1. open PR found for the current branch  → source = "pr"
+//  2. worktree name "issue-<n>-..." parses out a known issue → "issue"
+//  3. neither — compare-page fallback                       → "compare"
 //
 // gh is stubbed on PATH so the test runs offline; `auth status`, `repo view`,
 // `pr view`, and `issue view` are scripted per scenario via the GROVE_TEST_GH

--- a/tests/integration/browse_e2e_test.go
+++ b/tests/integration/browse_e2e_test.go
@@ -1,0 +1,215 @@
+//go:build integration
+
+// End-to-end coverage for `grove browse --json` covering the three
+// resolution paths from PR #53 (cherry-picked from release/v0.7.0):
+//   1. open PR found for the current branch  → source = "pr"
+//   2. worktree name "issue-<n>-..." parses out a known issue → "issue"
+//   3. neither — compare-page fallback                       → "compare"
+//
+// gh is stubbed on PATH so the test runs offline; `auth status`, `repo view`,
+// `pr view`, and `issue view` are scripted per scenario via the GROVE_TEST_GH
+// env var the fake reads.
+package integration_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/testhelper"
+)
+
+var (
+	groveBinaryOnce sync.Once
+	groveBinaryPath string
+	groveBinaryErr  error
+)
+
+// buildGroveBinary compiles cmd/grove into a tempdir once per test run and
+// returns the path. Subsequent callers reuse the same binary.
+func buildGroveBinary(t *testing.T) string {
+	t.Helper()
+	groveBinaryOnce.Do(func() {
+		root, err := repoRootDir()
+		if err != nil {
+			groveBinaryErr = err
+			return
+		}
+		dir, err := os.MkdirTemp("", "grove-bin-*")
+		if err != nil {
+			groveBinaryErr = err
+			return
+		}
+		groveBinaryPath = filepath.Join(dir, "grove")
+		cmd := exec.Command("go", "build", "-o", groveBinaryPath, "./cmd/grove")
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			groveBinaryErr = &buildErr{out: out, err: err}
+		}
+	})
+	if groveBinaryErr != nil {
+		t.Fatalf("build grove binary: %v", groveBinaryErr)
+	}
+	return groveBinaryPath
+}
+
+type buildErr struct {
+	out []byte
+	err error
+}
+
+func (b *buildErr) Error() string { return b.err.Error() + "\n" + string(b.out) }
+
+// repoRootDir walks up from CWD until it finds go.mod.
+func repoRootDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
+}
+
+// installFakeGh writes a shell script named "gh" into a fresh tempdir and
+// returns the directory. Callers prepend this dir to PATH so the script
+// shadows the real gh CLI.
+func installFakeGh(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1 $2" in
+  "auth status") exit 0 ;;
+  "repo view")
+    echo "test-org/test-repo"
+    exit 0 ;;
+  "pr view")
+    case "$GROVE_TEST_GH" in
+      pr-found)
+        echo '{"number":42,"title":"Test PR","state":"OPEN","url":"https://github.com/test-org/test-repo/pull/42"}'
+        exit 0 ;;
+      *) exit 1 ;;
+    esac ;;
+  "issue view")
+    case "$GROVE_TEST_GH" in
+      issue-found)
+        echo '{"number":7,"title":"Test Issue","state":"OPEN","url":"https://github.com/test-org/test-repo/issues/7"}'
+        exit 0 ;;
+      *) exit 1 ;;
+    esac ;;
+esac
+exit 1
+`
+	path := filepath.Join(dir, "gh")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	return dir
+}
+
+// setupBrowseRepo prepares a temp grove project with a single worktree,
+// returning the worktree path so tests can run grove browse from inside it.
+// worktreeName is used as both the worktree short name and the branch name
+// (worktree dir layout: <project>-<name>, branch: <name>).
+func setupBrowseRepo(t *testing.T, worktreeName string) string {
+	t.Helper()
+	repo := testhelper.SetupRailsFixture(t)
+
+	// Make a real linked worktree so `grove browse` running inside it
+	// resolves a non-empty branch and short name.
+	wtPath := filepath.Join(filepath.Dir(repo), "rails-app-"+worktreeName)
+	testhelper.RunGit(t, repo, "worktree", "add", "-b", worktreeName, wtPath)
+
+	// Initialize .grove with a state.json that knows about both worktrees so
+	// Manager.GetCurrent doesn't trip over an empty store.
+	groveDir := filepath.Join(repo, ".grove")
+	state := []byte(`{"version": 1, "worktrees": {}}`)
+	if err := os.WriteFile(filepath.Join(groveDir, "state.json"), state, 0644); err != nil {
+		t.Fatalf("write state.json: %v", err)
+	}
+
+	return wtPath
+}
+
+func runGroveBrowse(t *testing.T, wtPath, fakeGhDir, scenario string) (url, source string) {
+	t.Helper()
+	binary := buildGroveBinary(t)
+
+	cmd := exec.Command(binary, "browse", "--json")
+	cmd.Dir = wtPath
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeGhDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GROVE_TEST_GH="+scenario,
+	)
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("grove browse failed: %v\nstderr: %s\nstdout: %s", err, ee.Stderr, out)
+		}
+		t.Fatalf("grove browse failed: %v\nstdout: %s", err, out)
+	}
+
+	var result struct {
+		URL    string `json:"url"`
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("parse JSON output: %v\nraw: %s", err, out)
+	}
+	return result.URL, result.Source
+}
+
+func TestGroveBrowse_PRFound(t *testing.T) {
+	wtPath := setupBrowseRepo(t, "feat-test")
+	fakeGh := installFakeGh(t)
+
+	url, source := runGroveBrowse(t, wtPath, fakeGh, "pr-found")
+
+	if source != "pr" {
+		t.Errorf("source = %q, want %q", source, "pr")
+	}
+	if url != "https://github.com/test-org/test-repo/pull/42" {
+		t.Errorf("url = %q, want PR URL", url)
+	}
+}
+
+func TestGroveBrowse_IssueFromWorktreeName(t *testing.T) {
+	// Worktree name shaped as "issue-<n>-..." triggers the issue lookup path.
+	wtPath := setupBrowseRepo(t, "issue-7-fix-something")
+	fakeGh := installFakeGh(t)
+
+	url, source := runGroveBrowse(t, wtPath, fakeGh, "issue-found")
+
+	if source != "issue" {
+		t.Errorf("source = %q, want %q", source, "issue")
+	}
+	if url != "https://github.com/test-org/test-repo/issues/7" {
+		t.Errorf("url = %q, want issue URL", url)
+	}
+}
+
+func TestGroveBrowse_CompareFallback(t *testing.T) {
+	wtPath := setupBrowseRepo(t, "feat-no-pr")
+	fakeGh := installFakeGh(t)
+
+	url, source := runGroveBrowse(t, wtPath, fakeGh, "no-match")
+
+	if source != "compare" {
+		t.Errorf("source = %q, want %q", source, "compare")
+	}
+	want := "https://github.com/test-org/test-repo/compare/feat-no-pr"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+}

--- a/tests/integration/doctor_fix_e2e_test.go
+++ b/tests/integration/doctor_fix_e2e_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+// End-to-end coverage for `grove doctor --fix`. The underlying rewrite logic
+// (fixHostInstallsInDockerProject) has rich unit coverage in doctor_test.go;
+// this test pins the cobra flag wiring + binary invocation so a regression in
+// the top-level glue surfaces in CI rather than during manual release sanity.
+
+package integration_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/testhelper"
+)
+
+func TestGroveDoctor_FixRewritesHostInstall(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	// Build a Rails-shaped project with compose + a hooks.toml carrying a
+	// host bundle-install command. doctor --fix should rewrite this in place.
+	repo := testhelper.SetupRailsFixture(t)
+	mustWrite(t, filepath.Join(repo, "Dockerfile"), "FROM ruby\n")
+	mustWrite(t, filepath.Join(repo, "docker-compose.yml"),
+		"services:\n  web:\n    image: ruby\n")
+
+	groveDir := filepath.Join(repo, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(groveDir, "state.json"),
+		`{"version": 1, "worktrees": {}}`)
+	hooksPath := filepath.Join(groveDir, "hooks.toml")
+	mustWrite(t, hooksPath, `[[hooks.post_create]]
+type = "command"
+command = "bundle install"
+`)
+
+	cmd := exec.Command(binary, "doctor", "--fix")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("grove doctor --fix failed: %v\noutput: %s", err, out)
+	}
+
+	got, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read back hooks.toml: %v", err)
+	}
+	hooks := string(got)
+
+	if !strings.Contains(hooks, `type = "docker:compose"`) {
+		t.Errorf("hooks.toml not rewritten to docker:compose:\n%s", hooks)
+	}
+	if !strings.Contains(hooks, `service = "web"`) {
+		t.Errorf("hooks.toml missing inferred service:\n%s", hooks)
+	}
+	// The original `bundle install` command should still be present (preserved
+	// inside the now-routed compose hook), not replaced.
+	if !strings.Contains(hooks, "bundle install") {
+		t.Errorf("hooks.toml dropped the original command:\n%s", hooks)
+	}
+}
+
+// TestGroveDoctor_NoFixLeavesHooksAlone asserts that running doctor without
+// --fix leaves hooks.toml untouched (the diagnostic still prints, but the
+// file isn't modified).
+func TestGroveDoctor_NoFixLeavesHooksAlone(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	repo := testhelper.SetupRailsFixture(t)
+	mustWrite(t, filepath.Join(repo, "Dockerfile"), "FROM ruby\n")
+	mustWrite(t, filepath.Join(repo, "docker-compose.yml"),
+		"services:\n  web:\n    image: ruby\n")
+
+	groveDir := filepath.Join(repo, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(groveDir, "state.json"),
+		`{"version": 1, "worktrees": {}}`)
+	hooksPath := filepath.Join(groveDir, "hooks.toml")
+	original := `[[hooks.post_create]]
+type = "command"
+command = "bundle install"
+`
+	mustWrite(t, hooksPath, original)
+
+	cmd := exec.Command(binary, "doctor")
+	cmd.Dir = repo
+	if _, err := cmd.CombinedOutput(); err != nil {
+		// doctor prints a warning and may exit non-zero when checks fail —
+		// that's fine; we only care that the file is untouched.
+		_ = err
+	}
+
+	got, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks.toml: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("hooks.toml mutated without --fix:\nwant:\n%s\ngot:\n%s", original, got)
+	}
+}
+
+func mustWrite(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/tests/integration/state_future_version_test.go
+++ b/tests/integration/state_future_version_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+// Future-version state.json error guard. Covers the manual validation in PR #48
+// that asks: "simulate a future-version state.json and confirm grove errors
+// instead of silently parsing." End-to-end via state.NewManager so this
+// verifies the production load path (migrate.go → state.go).
+
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/state"
+)
+
+func TestStateLoad_RejectsFutureVersion(t *testing.T) {
+	groveDir := filepath.Join(t.TempDir(), ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a state.json claiming a version far in the future. This simulates
+	// a user who upgraded grove (which wrote a newer schema), then downgraded
+	// back. Without the guard added in v0.7.0, the older grove would silently
+	// parse the file as v1 and risk dropping fields it doesn't recognize.
+	futureState := []byte(`{"version": 99, "worktrees": {}}`)
+	if err := os.WriteFile(filepath.Join(groveDir, "state.json"), futureState, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := state.NewManager(groveDir)
+	if err == nil {
+		t.Fatal("expected state.NewManager to error on future-version state.json, got nil")
+	}
+
+	// The error should explicitly mention the version mismatch so the user
+	// knows what's going on.
+	msg := err.Error()
+	if !strings.Contains(msg, "version 99") || !strings.Contains(msg, "newer than supported") {
+		t.Errorf("expected error to identify the future version; got: %v", err)
+	}
+}
+
+func TestStateLoad_AcceptsCurrentVersion(t *testing.T) {
+	groveDir := filepath.Join(t.TempDir(), ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity check: the current version still loads without error.
+	currentState := []byte(`{"version": 1, "worktrees": {}}`)
+	if err := os.WriteFile(filepath.Join(groveDir, "state.json"), currentState, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := state.NewManager(groveDir); err != nil {
+		t.Fatalf("current-version state should load cleanly: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #56 and #57. Two atomic commits, surfaced during v0.7.0 manual validation against a single-contained Rails+webpack project and an external-compose project with agent stacks enabled.

## #56 — service inference picks first non-infra in declaration order

The detector picked `webpack` for a Rails+webpack stack because webpack was declared before web. `bundle install` then got routed to the asset pipeline.

**Fix**: small priority list (`web, app, rails, backend, api, server, application`) checked before the declaration-order fallback. Falls through to the existing heuristic when no canonical name matches. Validated by 3 new sub-tests in `compose_test.go`.

## #57 — slot release bypassed when grove rm runs without GROVE_AGENT_MODE=1

PR #31 added slot release on teardown failure during `grove rm`. The fix only fired when the agent strategy was the active one — which required either `AgentMode=true` in config or `GROVE_AGENT_MODE=1` in the shell. A natural `grove rm <agent-worktree>` invocation got the plain external strategy, OnPreRemove early-returned, and the slot leaked.

**Fix**: refactored `onPreRemove` into two phases. Phase 1 (env var cleanup) runs only when external strategy is active. Phase 2 (agent slot teardown) runs whenever the project has agent stacks enabled, with a transient agent strategy constructed when the active one is plain external. New `agentStrategyForTeardown` helper consolidates the strategy selection.

Live-validated against an external-compose project with agent stacks enabled: pre-existing fixture with leaked slot in `.slots.json`, ran `DOCKER_HOST=tcp://127.0.0.1:1 grove rm fake-leaked --force` (no `GROVE_AGENT_MODE` set). With the fix: "Stopping agent stack..." fires, Down errors as expected, slot is released to `[]`.

## Verification
- `make lint` → 0 issues
- `make test` → all packages pass; `plugins/docker` coverage moves 60.0% → 60.2%
- 3 new tests in `internal/detect/compose_test.go` (priority match, fallback, case-insensitive)
- 1 new test in `plugins/docker/plugin_test.go` (`TestPlugin_OnPreRemove_AgentSlotReleasedWithoutAgentMode`) covering the exact bug scenario
- Existing `TestPlugin_OnPreRemove_AgentSlotReleasedOnDownFailure` (the PR #31 happy-path test) still passes

## Test plan
- [ ] CI passes
- [ ] Manual: against an external-compose project with agent stacks, `GROVE_AGENT_MODE=1 grove new x` → `grove rm x` (without env var) → `.slots.json` returns to `[]`
- [ ] Manual: `grove init --auto` against a Rails+webpack project (Postgres + Redis + Webpack + Worker + Web) → generated hooks.toml uses `service = "web"` not `service = "webpack"`