### PR TITLE
fix(docker): cap teeBuffer on single large writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compose `--env-file` is honored when reading the active-worktree env var (previously hardcoded to `.env`)
 
 ### Fixed
+- `teeBuffer` (Docker compose stderr capture) now correctly caps single writes larger than the 8KB sliding window — the previous path stored the full oversized chunk before trimming, briefly exceeding the cap
 - `grove test` now translates `compose run` "service didn't complete successfully" errors into actionable grove-styled messages
 - `grove up` no longer silently swallows compose-up failures when the post-up health probe returns no statuses
 - `grove up` skips the post-up health probe when compose-up succeeded (previously paid up to 1s on every successful run)

--- a/plugins/docker/run_error.go
+++ b/plugins/docker/run_error.go
@@ -42,8 +42,12 @@ type teeBuffer struct {
 }
 
 func (t *teeBuffer) Write(p []byte) (int, error) {
+	n := len(p)
 	if t.w != nil {
 		_, _ = t.w.Write(p)
+	}
+	if len(p) > stderrBufferLimit {
+		p = p[len(p)-stderrBufferLimit:]
 	}
 	if len(t.buf)+len(p) > stderrBufferLimit {
 		excess := len(t.buf) + len(p) - stderrBufferLimit
@@ -54,7 +58,7 @@ func (t *teeBuffer) Write(p []byte) (int, error) {
 		}
 	}
 	t.buf = append(t.buf, p...)
-	return len(p), nil
+	return n, nil
 }
 
 func (t *teeBuffer) String() string { return string(t.buf) }

--- a/plugins/docker/run_error_test.go
+++ b/plugins/docker/run_error_test.go
@@ -43,3 +43,67 @@ func TestTranslateRunError_PassThroughOnEmptyStderr(t *testing.T) {
 		t.Errorf("expected original error pass-through, got: %v", got)
 	}
 }
+
+func TestTeeBuffer_SingleWriteLargerThanCap(t *testing.T) {
+	tb := &teeBuffer{}
+	// Build a payload larger than the 8KB cap.
+	payload := make([]byte, stderrBufferLimit+1024)
+	for i := range payload {
+		payload[i] = byte(i % 256)
+	}
+
+	n, err := tb.Write(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(payload) {
+		t.Errorf("Write returned n=%d, want %d", n, len(payload))
+	}
+
+	// Buffer must not exceed the cap.
+	if len(tb.buf) > stderrBufferLimit {
+		t.Errorf("buf len %d exceeds cap %d", len(tb.buf), stderrBufferLimit)
+	}
+
+	// Tail bytes must be preserved.
+	tail := payload[len(payload)-stderrBufferLimit:]
+	if string(tb.buf) != string(tail) {
+		t.Errorf("buf does not contain the tail of the written payload")
+	}
+}
+
+func TestTeeBuffer_MultipleSmallWrites(t *testing.T) {
+	tb := &teeBuffer{}
+	chunk := []byte(strings.Repeat("x", 1024))
+
+	// Write 10 chunks of 1KB each — total 10KB, cap is 8KB.
+	for i := 0; i < 10; i++ {
+		if _, err := tb.Write(chunk); err != nil {
+			t.Fatalf("Write %d failed: %v", i, err)
+		}
+	}
+
+	if len(tb.buf) > stderrBufferLimit {
+		t.Errorf("buf len %d exceeds cap %d after multiple writes", len(tb.buf), stderrBufferLimit)
+	}
+	// The buffer should hold exactly the last 8 chunks.
+	want := strings.Repeat("x", stderrBufferLimit)
+	if tb.String() != want {
+		t.Errorf("buf content mismatch: got len %d, want len %d", len(tb.buf), stderrBufferLimit)
+	}
+}
+
+func TestTeeBuffer_ExactCapWrite(t *testing.T) {
+	tb := &teeBuffer{}
+	payload := make([]byte, stderrBufferLimit)
+	for i := range payload {
+		payload[i] = byte(i % 256)
+	}
+
+	if _, err := tb.Write(payload); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tb.buf) != stderrBufferLimit {
+		t.Errorf("buf len %d, want %d", len(tb.buf), stderrBufferLimit)
+	}
+}


### PR DESCRIPTION
## Summary

- `teeBuffer.Write` would exceed the 8KB cap when a single write arrived with `len(p) > stderrBufferLimit`: with an empty buf, `excess >= len(buf)` cleared buf but then appended all of `p` unchecked.
- Fix: trim `p` to its tail (`p[len(p)-stderrBufferLimit:]`) **before** the existing buf-trim logic, so no single write can overflow the cap. The original `len(p)` is returned to satisfy the `io.Writer` contract.

## Test plan

- [ ] `TestTeeBuffer_SingleWriteLargerThanCap` — single write >8KB: asserts buf stays within cap and tail bytes are preserved
- [ ] `TestTeeBuffer_MultipleSmallWrites` — 10x 1KB writes (10KB total): asserts buf holds exactly the last 8KB
- [ ] `TestTeeBuffer_ExactCapWrite` — write of exactly 8KB: asserts buf holds all bytes
- [ ] `make lint test` passes

Closes #60