### PR TITLE
fix(worktree): surface post-create hook failures to stderr

### DIFF
--- a/cmd/grove/commands/adopt.go
+++ b/cmd/grove/commands/adopt.go
@@ -97,7 +97,7 @@ Examples:
 			MainPath:     ctx.ProjectRoot,
 			ProjectName:  projectName,
 		}
-		if err := worktree.BootstrapWorktree(ctx.State, ctx.Config, bootstrapOpts); err != nil {
+		if err := worktree.BootstrapWorktree(ctx.State, ctx.Config, bootstrapOpts, w); err != nil {
 			return fmt.Errorf("bootstrap: %w", err)
 		}
 

--- a/cmd/grove/commands/helpers.go
+++ b/cmd/grove/commands/helpers.go
@@ -133,7 +133,11 @@ func setupCreatedWorktree(ctx *GroveContext, mgr *worktree.Manager, name, branch
 		IsEnvironment: opts.IsEnvironment,
 		Mirror:        opts.Mirror,
 	}
-	if err := worktree.BootstrapWorktree(ctx.State, ctx.Config, bootstrapOpts); err != nil {
+	var bootstrapWriter *cli.Writer
+	if !opts.JSONOutput {
+		bootstrapWriter = w
+	}
+	if err := worktree.BootstrapWorktree(ctx.State, ctx.Config, bootstrapOpts, bootstrapWriter); err != nil {
 		if !opts.JSONOutput {
 			cli.Warning(w, "Bootstrap failed: %v", err)
 			cli.Faint(w, "run 'grove repair' to fix")

--- a/internal/worktree/bootstrap.go
+++ b/internal/worktree/bootstrap.go
@@ -36,9 +36,12 @@ type BootstrapOpts struct {
 // via docker:compose handlers) run.
 //
 // Returns an error only if state registration or symlinking fails irrecoverably.
-// Hook and SetupFiles failures are always printed via w (stderr) so the user
-// sees them, and are also written to grove.log when GROVE_LOG=1 is set.
-// Pass a nil w to suppress the stderr output (e.g. in tests that don't care).
+// Hook and SetupFiles failures are non-fatal; they are reported via w so the
+// user sees them on stderr. Pass a non-nil w for interactive callers (grove new,
+// grove adopt). Pass nil for JSON-mode callers where stderr would corrupt
+// machine-readable output, or for tests that don't assert on warning output.
+// With nil, hook failures are still written to grove.log when GROVE_LOG=1 is
+// set, but are otherwise invisible.
 func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts BootstrapOpts, w *cli.Writer) error {
 	if opts.WorktreePath == "" || opts.MainPath == "" {
 		return fmt.Errorf("WorktreePath and MainPath are required")

--- a/internal/worktree/bootstrap.go
+++ b/internal/worktree/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/config"
 	"github.com/lost-in-the/grove/internal/grove"
 	"github.com/lost-in-the/grove/internal/hooks"
@@ -35,8 +36,10 @@ type BootstrapOpts struct {
 // via docker:compose handlers) run.
 //
 // Returns an error only if state registration or symlinking fails irrecoverably.
-// Hook and SetupFiles failures are logged but do not abort the bootstrap.
-func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts BootstrapOpts) error {
+// Hook and SetupFiles failures are always printed via w (stderr) so the user
+// sees them, and are also written to grove.log when GROVE_LOG=1 is set.
+// Pass a nil w to suppress the stderr output (e.g. in tests that don't care).
+func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts BootstrapOpts, w *cli.Writer) error {
 	if opts.WorktreePath == "" || opts.MainPath == "" {
 		return fmt.Errorf("WorktreePath and MainPath are required")
 	}
@@ -67,6 +70,9 @@ func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts Bootstr
 	if cfg != nil && cfg.Plugins.Docker.External != nil {
 		if err := SetupFiles(cfg.Plugins.Docker.External, opts.WorktreePath, opts.MainPath); err != nil {
 			log.Printf("file setup: %v", err)
+			if w != nil {
+				cli.Warning(w, "file setup: %v", err)
+			}
 		}
 	}
 
@@ -80,6 +86,9 @@ func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts Bootstr
 	}
 	if err := hooks.Fire(hooks.EventPostCreate, globalHookCtx); err != nil {
 		log.Printf("hooks: global post-create plugin hook failed: %v", err)
+		if w != nil {
+			cli.Warning(w, "post-create plugin hook failed: %v", err)
+		}
 	}
 
 	// Per-project (config-driven) post-create hooks last — these may target
@@ -87,6 +96,9 @@ func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts Bootstr
 	hookExecutor, hookErr := hooks.NewExecutor()
 	if hookErr != nil {
 		log.Printf("hooks: failed to load config during bootstrap: %v", hookErr)
+		if w != nil {
+			cli.Warning(w, "post-create hooks: failed to load config: %v", hookErr)
+		}
 	} else if hookExecutor.HasHooksForEvent(hooks.EventPostCreate) {
 		hookCtx := &hooks.ExecutionContext{
 			Event:        hooks.EventPostCreate,
@@ -99,6 +111,9 @@ func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts Bootstr
 		}
 		if err := hookExecutor.Execute(hooks.EventPostCreate, hookCtx); err != nil {
 			log.Printf("hooks: post-create project hook failed: %v", err)
+			if w != nil {
+				cli.Warning(w, "post-create hook failed: %v", err)
+			}
 		}
 	}
 

--- a/internal/worktree/bootstrap_test.go
+++ b/internal/worktree/bootstrap_test.go
@@ -106,59 +106,86 @@ func TestBootstrapWorktree_RejectsEmptyPaths(t *testing.T) {
 	}
 }
 
-// TestBootstrapWorktree_HookFailureSurfacesToWriter verifies that a failing
-// post-create hook writes a warning to the supplied writer without requiring
-// GROVE_LOG=1 to be set.
-func TestBootstrapWorktree_HookFailureSurfacesToWriter(t *testing.T) {
-	tmpDir := t.TempDir()
-	mainDir := filepath.Join(tmpDir, "main")
-	groveDir := filepath.Join(mainDir, ".grove")
-	if err := os.MkdirAll(groveDir, 0755); err != nil {
-		t.Fatalf("mkdir grove: %v", err)
-	}
-	wtPath := filepath.Join(tmpDir, "feature")
-	if err := os.MkdirAll(wtPath, 0755); err != nil {
-		t.Fatalf("mkdir wt: %v", err)
+// TestBootstrapWorktree_HookFailure covers both the writer and nil-writer paths
+// for a failing post-create hook.
+//   - withWriter: warning must appear in the buffer, function must return nil
+//   - nilWriter:  function must return nil and must not panic (regression guard
+//     against future callers dropping a w != nil guard)
+func TestBootstrapWorktree_HookFailure(t *testing.T) {
+	tests := []struct {
+		name        string
+		useWriter   bool
+		wantWarning string
+	}{
+		{
+			name:        "withWriter surfaces warning to stderr",
+			useWriter:   true,
+			wantWarning: "post-create hook failed",
+		},
+		{
+			name:      "nilWriter does not panic",
+			useWriter: false,
+		},
 	}
 
-	// Write a hooks.toml with a required command that always fails.
-	hooksToml := `[hooks]
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			mainDir := filepath.Join(tmpDir, "main")
+			groveDir := filepath.Join(mainDir, ".grove")
+			if err := os.MkdirAll(groveDir, 0755); err != nil {
+				t.Fatalf("mkdir grove: %v", err)
+			}
+			wtPath := filepath.Join(tmpDir, "feature")
+			if err := os.MkdirAll(wtPath, 0755); err != nil {
+				t.Fatalf("mkdir wt: %v", err)
+			}
+
+			// Write a hooks.toml with a required command that always fails.
+			hooksToml := `[hooks]
 [[hooks.post_create]]
 type = "command"
 command = "false"
 required = true
 `
-	if err := os.WriteFile(filepath.Join(groveDir, "hooks.toml"), []byte(hooksToml), 0644); err != nil {
-		t.Fatalf("write hooks.toml: %v", err)
-	}
+			if err := os.WriteFile(filepath.Join(groveDir, "hooks.toml"), []byte(hooksToml), 0644); err != nil {
+				t.Fatalf("write hooks.toml: %v", err)
+			}
 
-	// hooks.NewExecutor() uses cwd to find .grove/hooks.toml, so chdir to mainDir.
-	t.Chdir(mainDir)
+			// hooks.NewExecutor() uses cwd to find .grove/hooks.toml, so chdir to mainDir.
+			t.Chdir(mainDir)
 
-	stateMgr, err := state.NewManager(groveDir)
-	if err != nil {
-		t.Fatalf("state mgr: %v", err)
-	}
+			stateMgr, err := state.NewManager(groveDir)
+			if err != nil {
+				t.Fatalf("state mgr: %v", err)
+			}
 
-	var buf bytes.Buffer
-	w := cli.NewWriter(&buf, false)
+			var buf bytes.Buffer
+			var w *cli.Writer
+			if tt.useWriter {
+				w = cli.NewWriter(&buf, false)
+			}
 
-	cfg := config.LoadDefaults()
-	opts := BootstrapOpts{
-		Name:         "feature",
-		Branch:       "feature",
-		WorktreePath: wtPath,
-		MainPath:     mainDir,
-		ProjectName:  "test-proj",
-	}
+			cfg := config.LoadDefaults()
+			opts := BootstrapOpts{
+				Name:         "feature",
+				Branch:       "feature",
+				WorktreePath: wtPath,
+				MainPath:     mainDir,
+				ProjectName:  "test-proj",
+			}
 
-	// BootstrapWorktree must return nil (hook failures are non-fatal).
-	if err := BootstrapWorktree(stateMgr, cfg, opts, w); err != nil {
-		t.Fatalf("BootstrapWorktree returned unexpected error: %v", err)
-	}
+			// Hook failures are non-fatal — must always return nil.
+			if err := BootstrapWorktree(stateMgr, cfg, opts, w); err != nil {
+				t.Fatalf("BootstrapWorktree returned unexpected error: %v", err)
+			}
 
-	got := buf.String()
-	if !strings.Contains(got, "post-create hook failed") {
-		t.Errorf("expected warning about post-create hook failure on writer, got: %q", got)
+			if tt.wantWarning != "" {
+				got := buf.String()
+				if !strings.Contains(got, tt.wantWarning) {
+					t.Errorf("expected warning %q on writer, got: %q", tt.wantWarning, got)
+				}
+			}
+		})
 	}
 }

--- a/internal/worktree/bootstrap_test.go
+++ b/internal/worktree/bootstrap_test.go
@@ -1,10 +1,13 @@
 package worktree
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/config"
 	"github.com/lost-in-the/grove/internal/state"
 )
@@ -35,7 +38,7 @@ func TestBootstrapWorktree_RegistersInState(t *testing.T) {
 		ProjectName:  "test-proj",
 	}
 
-	if err := BootstrapWorktree(stateMgr, cfg, opts); err != nil {
+	if err := BootstrapWorktree(stateMgr, cfg, opts, nil); err != nil {
 		t.Fatalf("BootstrapWorktree: %v", err)
 	}
 
@@ -76,10 +79,10 @@ func TestBootstrapWorktree_IdempotentOnSecondCall(t *testing.T) {
 		ProjectName:  "test-proj",
 	}
 
-	if err := BootstrapWorktree(stateMgr, cfg, opts); err != nil {
+	if err := BootstrapWorktree(stateMgr, cfg, opts, nil); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
-	if err := BootstrapWorktree(stateMgr, cfg, opts); err != nil {
+	if err := BootstrapWorktree(stateMgr, cfg, opts, nil); err != nil {
 		t.Fatalf("second call should not error: %v", err)
 	}
 }
@@ -95,10 +98,67 @@ func TestBootstrapWorktree_RejectsEmptyPaths(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := BootstrapWorktree(nil, nil, tt.opts)
+			err := BootstrapWorktree(nil, nil, tt.opts, nil)
 			if err == nil {
 				t.Errorf("expected error, got nil")
 			}
 		})
+	}
+}
+
+// TestBootstrapWorktree_HookFailureSurfacesToWriter verifies that a failing
+// post-create hook writes a warning to the supplied writer without requiring
+// GROVE_LOG=1 to be set.
+func TestBootstrapWorktree_HookFailureSurfacesToWriter(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "main")
+	groveDir := filepath.Join(mainDir, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatalf("mkdir grove: %v", err)
+	}
+	wtPath := filepath.Join(tmpDir, "feature")
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+
+	// Write a hooks.toml with a required command that always fails.
+	hooksToml := `[hooks]
+[[hooks.post_create]]
+type = "command"
+command = "false"
+required = true
+`
+	if err := os.WriteFile(filepath.Join(groveDir, "hooks.toml"), []byte(hooksToml), 0644); err != nil {
+		t.Fatalf("write hooks.toml: %v", err)
+	}
+
+	// hooks.NewExecutor() uses cwd to find .grove/hooks.toml, so chdir to mainDir.
+	t.Chdir(mainDir)
+
+	stateMgr, err := state.NewManager(groveDir)
+	if err != nil {
+		t.Fatalf("state mgr: %v", err)
+	}
+
+	var buf bytes.Buffer
+	w := cli.NewWriter(&buf, false)
+
+	cfg := config.LoadDefaults()
+	opts := BootstrapOpts{
+		Name:         "feature",
+		Branch:       "feature",
+		WorktreePath: wtPath,
+		MainPath:     mainDir,
+		ProjectName:  "test-proj",
+	}
+
+	// BootstrapWorktree must return nil (hook failures are non-fatal).
+	if err := BootstrapWorktree(stateMgr, cfg, opts, w); err != nil {
+		t.Fatalf("BootstrapWorktree returned unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "post-create hook failed") {
+		t.Errorf("expected warning about post-create hook failure on writer, got: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `BootstrapWorktree` now accepts a `*cli.Writer` parameter and calls `cli.Warning` on each of the three non-fatal failure paths: `SetupFiles`, global plugin hook, and config-driven hooks
- Existing `log.Printf` calls are preserved so failures still land in `grove.log` when `GROVE_LOG=1`
- Callers (`grove new` via `setupCreatedWorktree`, `grove adopt`) pass their writer; JSON mode passes `nil` to suppress output as before
- Adds `TestBootstrapWorktree_HookFailureSurfacesToWriter` — writes a required-but-failing `hooks.toml` post-create command, confirms the warning appears on the injected writer without `GROVE_LOG=1`

Closes #58

## Test plan

- [ ] `make lint test` passes (verified locally)
- [ ] New test `TestBootstrapWorktree_HookFailureSurfacesToWriter` passes and proves warning is visible on writer
- [ ] Existing bootstrap tests updated for the new signature (pass `nil` writer)