### PR TITLE
feat(test): hint when --no-deps causes connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Behavior change:** `grove test` now passes `--no-deps` to `compose run` by default. Tests that rely on dependency services starting (e.g., a database) need either `[test] include_deps = true` in config or the `--with-deps` flag.
+- When `grove test` exits non-zero with a connection-refused or DNS error (e.g. "connection refused", "no such host") and the user has not opted into `include_deps`, grove appends a hint pointing at `--with-deps` and `[test] include_deps = true`.
 - **Behavior change:** `grove up` against an external stack tolerates failures of services listed in `non_blocking_services` — the command no longer exits non-zero when only one-shot init services failed.
 - **Behavior change:** `grove ps` external-stack status is now driven by `docker compose ps --format json` and the `non_blocking_services` list. A stack with only non-blocking services exited cleanly is `up`, not `degraded`.
 - `TestConfig.IncludeDeps` is now `*bool` so a project-level `false` can override a global `true`

--- a/plugins/docker/external.go
+++ b/plugins/docker/external.go
@@ -169,7 +169,7 @@ func (s *externalStrategy) Run(worktreePath string, service string, command stri
 	cmd.Stderr = stderrBuf
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
-		return translateRunError(stderrBuf.String(), err)
+		return translateRunError(stderrBuf.String(), err, s.cfg.Test.IncludeDepsValue())
 	}
 	return nil
 }

--- a/plugins/docker/local.go
+++ b/plugins/docker/local.go
@@ -133,7 +133,7 @@ func (s *localStrategy) Run(worktreePath string, service string, command string)
 	cmd.Stderr = stderrBuf
 	cmd.Stdin = os.Stdin
 	if err := cmd.Run(); err != nil {
-		return translateRunError(stderrBuf.String(), err)
+		return translateRunError(stderrBuf.String(), err, s.cfg.Test.IncludeDepsValue())
 	}
 	return nil
 }

--- a/plugins/docker/run_error.go
+++ b/plugins/docker/run_error.go
@@ -4,15 +4,30 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 )
 
 // dependencyFailureRE matches compose's "service \"X\" didn't complete successfully" message.
 var dependencyFailureRE = regexp.MustCompile(`service "([^"]+)" didn't complete successfully`)
 
+// connectionErrorRE matches connection/DNS failure patterns that suggest a
+// missing depends_on service (database, cache, MQ, etc.).
+var connectionErrorRE = regexp.MustCompile(`(?i)connection refused|no such host|temporary failure in name resolution|connection reset`)
+
+// noDepHint is appended to the error message when a connection error is detected
+// and the user is on the default --no-deps behavior (include_deps not explicitly set).
+const noDepHint = "\nhint: this looks like a missing depends_on service. By default, `grove test` runs with --no-deps.\n" +
+	"      Try `grove test --with-deps`, or set `[test] include_deps = true` in .grove/config.toml."
+
 // translateRunError inspects captured compose stderr and rewrites the error
 // when it matches a known unactionable pattern. Returns the original error
 // when no pattern matches.
-func translateRunError(stderr string, original error) error {
+//
+// includeDeps should be true when the caller explicitly opted into dependency
+// resolution (via --with-deps or include_deps = true in config). When false
+// (the default), a connection-error match appends a hint directing the user
+// to --with-deps.
+func translateRunError(stderr string, original error, includeDeps bool) error {
 	if stderr == "" {
 		return original
 	}
@@ -28,6 +43,9 @@ func translateRunError(stderr string, original error) error {
 				"underlying error: %w",
 			service, original,
 		)
+	}
+	if !includeDeps && connectionErrorRE.MatchString(stderr) {
+		return fmt.Errorf("%w%s", original, strings.TrimRight(noDepHint, "\n"))
 	}
 	return original
 }

--- a/plugins/docker/run_error_test.go
+++ b/plugins/docker/run_error_test.go
@@ -11,7 +11,7 @@ func TestTranslateRunError_DependencyDidntComplete(t *testing.T) {
 service "asset_precompile" didn't complete successfully: exit 1`
 	original := errors.New("exit status 1")
 
-	got := translateRunError(stderr, original)
+	got := translateRunError(stderr, original, false)
 
 	if got == nil {
 		t.Fatal("expected translated error, got nil")
@@ -29,7 +29,7 @@ func TestTranslateRunError_PassThroughOnUnknownPattern(t *testing.T) {
 	stderr := "some other docker error"
 	original := errors.New("exit status 1")
 
-	got := translateRunError(stderr, original)
+	got := translateRunError(stderr, original, false)
 
 	if got != original {
 		t.Errorf("expected original error pass-through, got: %v", got)
@@ -38,9 +38,70 @@ func TestTranslateRunError_PassThroughOnUnknownPattern(t *testing.T) {
 
 func TestTranslateRunError_PassThroughOnEmptyStderr(t *testing.T) {
 	original := errors.New("exit status 1")
-	got := translateRunError("", original)
+	got := translateRunError("", original, false)
 	if got != original {
 		t.Errorf("expected original error pass-through, got: %v", got)
+	}
+}
+
+// Tests for the --no-deps connection-error hint (issue #62).
+
+func TestTranslateRunError_ConnectionRefused_NoIncludeDeps_HintAppended(t *testing.T) {
+	stderr := "dial tcp 127.0.0.1:5432: connect: connection refused"
+	original := errors.New("exit status 1")
+
+	got := translateRunError(stderr, original, false)
+
+	if got == nil {
+		t.Fatal("expected error with hint, got nil")
+	}
+	msg := got.Error()
+	if !strings.Contains(msg, "exit status 1") {
+		t.Errorf("expected original error text preserved, got: %s", msg)
+	}
+	if !strings.Contains(msg, "--with-deps") {
+		t.Errorf("expected --with-deps hint in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "include_deps") {
+		t.Errorf("expected include_deps hint in message, got: %s", msg)
+	}
+}
+
+func TestTranslateRunError_ConnectionRefused_IncludeDeps_NoHint(t *testing.T) {
+	stderr := "dial tcp 127.0.0.1:5432: connect: connection refused"
+	original := errors.New("exit status 1")
+
+	got := translateRunError(stderr, original, true)
+
+	// When the user already opted into include_deps, no hint should be added.
+	if got != original {
+		t.Errorf("expected original error pass-through (no hint), got: %v", got)
+	}
+}
+
+func TestTranslateRunError_NoSuchHost_NoIncludeDeps_HintAppended(t *testing.T) {
+	stderr := "Error response from daemon: no such host: db"
+	original := errors.New("exit status 1")
+
+	got := translateRunError(stderr, original, false)
+
+	if got == nil {
+		t.Fatal("expected error with hint, got nil")
+	}
+	msg := got.Error()
+	if !strings.Contains(msg, "--with-deps") {
+		t.Errorf("expected --with-deps hint, got: %s", msg)
+	}
+}
+
+func TestTranslateRunError_UnrelatedError_NoIncludeDeps_NoHint(t *testing.T) {
+	stderr := "ERROR: Service 'web' failed to build: dockerfile parse error"
+	original := errors.New("exit status 1")
+
+	got := translateRunError(stderr, original, false)
+
+	if got != original {
+		t.Errorf("expected original error pass-through for unrelated error, got: %v", got)
 	}
 }
 

--- a/plugins/docker/run_error_test.go
+++ b/plugins/docker/run_error_test.go
@@ -94,6 +94,36 @@ func TestTranslateRunError_NoSuchHost_NoIncludeDeps_HintAppended(t *testing.T) {
 	}
 }
 
+func TestTranslateRunError_TemporaryFailureInNameResolution_NoIncludeDeps_HintAppended(t *testing.T) {
+	stderr := "dial tcp: lookup db on 127.0.0.11:53: temporary failure in name resolution"
+	original := errors.New("exit status 1")
+
+	got := translateRunError(stderr, original, false)
+
+	if got == nil {
+		t.Fatal("expected error with hint, got nil")
+	}
+	msg := got.Error()
+	if !strings.Contains(msg, "--with-deps") {
+		t.Errorf("expected --with-deps hint, got: %s", msg)
+	}
+}
+
+func TestTranslateRunError_ConnectionReset_NoIncludeDeps_HintAppended(t *testing.T) {
+	stderr := "read tcp 172.17.0.3:54321->172.17.0.2:5432: read: connection reset by peer"
+	original := errors.New("exit status 1")
+
+	got := translateRunError(stderr, original, false)
+
+	if got == nil {
+		t.Fatal("expected error with hint, got nil")
+	}
+	msg := got.Error()
+	if !strings.Contains(msg, "--with-deps") {
+		t.Errorf("expected --with-deps hint, got: %s", msg)
+	}
+}
+
 func TestTranslateRunError_UnrelatedError_NoIncludeDeps_NoHint(t *testing.T) {
 	stderr := "ERROR: Service 'web' failed to build: dockerfile parse error"
 	original := errors.New("exit status 1")


### PR DESCRIPTION
## Summary

- Extends `translateRunError` in `plugins/docker/run_error.go` with a third `includeDeps bool` parameter
- When `compose run` exits non-zero with stderr matching connection-refused / no-such-host / DNS patterns, and `include_deps` is unset (default), appends a hint pointing at `--with-deps` and `[test] include_deps = true`
- The hint is suppressed when `includeDeps = true` so users who already opted in don't see it

Closes #62

## Test plan

- [x] `connection refused` stderr + `includeDeps=false` - hint appended (new test)
- [x] `connection refused` stderr + `includeDeps=true` - no hint (new test)
- [x] Unrelated error + `includeDeps=false` - no hint (new test)
- [x] `no such host` stderr + `includeDeps=false` - hint appended (new test)
- [x] Existing dependency-failure and pass-through tests updated for new signature
- [x] `make lint test` passes