### PR TITLE
feat(cli): add grove context command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `grove context` command — prints full worktree context (branch, commit, remote tracking/sync, status, stash count, recent commits) for CLI/scripting use; `--json` flag emits structured machine-readable output (closes #16)
+- `grove context` command — prints full worktree context (branch, commit, remote tracking/sync, status, stash count, recent commits) for CLI/scripting use; `--json` flag emits structured machine-readable output (closes #16); JSON includes `has_remote` boolean to distinguish "no remote" from "remote, in sync" (0/0 ahead/behind)
 - `grove adopt [path]` command — bootstraps a git worktree that grove doesn't know about (config symlink, state registration, post-create hooks)
 - Drift detection — running any grove command from a worktree not in `state.json` prints a non-fatal warning suggesting `grove adopt`
 - `grove doctor` Tier-2 "Worktree registration" check — reports drifted worktrees with a `grove adopt` hint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `grove context` command — prints full worktree context (branch, commit, remote tracking/sync, status, stash count, recent commits) for CLI/scripting use; `--json` flag emits structured machine-readable output (closes #16)
 - `grove adopt [path]` command — bootstraps a git worktree that grove doesn't know about (config symlink, state registration, post-create hooks)
 - Drift detection — running any grove command from a worktree not in `state.json` prints a non-fatal warning suggesting `grove adopt`
 - `grove doctor` Tier-2 "Worktree registration" check — reports drifted worktrees with a `grove adopt` hint

--- a/cmd/grove/commands/context_cmd.go
+++ b/cmd/grove/commands/context_cmd.go
@@ -31,10 +31,11 @@ type contextRecentCommit struct {
 //	branch            - current branch name; "(detached HEAD at <sha>)" if detached
 //	commit            - { sha, message } of HEAD
 //	tracking_branch   - remote tracking branch (omitted when not set)
+//	has_remote        - true when a remote tracking branch is configured
 //	status            - "clean" or "dirty"
 //	changes           - list of changed files (omitted when clean)
-//	ahead             - commits ahead of remote (0 when no remote)
-//	behind            - commits behind remote (0 when no remote)
+//	ahead             - commits ahead of remote (meaningful only when has_remote: true)
+//	behind            - commits behind remote (meaningful only when has_remote: true)
 //	stash_count       - number of stashes (0 when none)
 //	recent_commits    - last 3–5 commits [{sha, message}, ...]
 type contextOutput struct {
@@ -43,6 +44,7 @@ type contextOutput struct {
 	Branch         string                `json:"branch"`
 	Commit         contextCommitInfo     `json:"commit"`
 	TrackingBranch string                `json:"tracking_branch,omitempty"`
+	HasRemote      bool                  `json:"has_remote"`
 	Status         string                `json:"status"`
 	Changes        []string              `json:"changes,omitempty"`
 	Ahead          int                   `json:"ahead"`
@@ -136,10 +138,11 @@ JSON schema:
   branch            current branch (or detached HEAD description)
   commit            { sha, message } of HEAD
   tracking_branch   remote tracking branch (omitted when not set)
+  has_remote        true when a remote tracking branch is configured
   status            "clean" or "dirty"
   changes           changed files (omitted when clean)
-  ahead             commits ahead of remote
-  behind            commits behind remote
+  ahead             commits ahead of remote (meaningful only when has_remote: true)
+  behind            commits behind remote (meaningful only when has_remote: true)
   stash_count       number of stashes
   recent_commits    last 5 commits [{sha, message}]`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
@@ -183,15 +186,16 @@ JSON schema:
 				Path:          tree.Path,
 				Branch:        tree.Branch,
 				Commit:        contextCommitInfo{SHA: tree.ShortCommit, Message: tree.CommitMessage},
+				HasRemote:     hasRemote,
 				Status:        wtStatus,
 				Changes:       changes,
+				Ahead:         ahead,
+				Behind:        behind,
 				StashCount:    stashCount,
 				RecentCommits: recentCommits,
 			}
 			if hasRemote {
 				result.TrackingBranch = trackingBranch
-				result.Ahead = ahead
-				result.Behind = behind
 			}
 			return output.PrintJSON(result)
 		}

--- a/cmd/grove/commands/context_cmd.go
+++ b/cmd/grove/commands/context_cmd.go
@@ -48,7 +48,7 @@ type contextOutput struct {
 	Ahead          int                   `json:"ahead"`
 	Behind         int                   `json:"behind"`
 	StashCount     int                   `json:"stash_count"`
-	RecentCommits  []contextRecentCommit `json:"recent_commits"`
+	RecentCommits  []contextRecentCommit `json:"recent_commits,omitempty"`
 }
 
 type contextCommitInfo struct {
@@ -56,19 +56,22 @@ type contextCommitInfo struct {
 	Message string `json:"message"`
 }
 
-// ctxUpstreamInfo returns ahead/behind counts and the tracking branch name.
-// Returns zeroes and empty string when no upstream is configured.
-func ctxUpstreamInfo(worktreePath string) (ahead, behind int, trackingBranch string) {
+// ctxUpstreamInfo returns ahead/behind counts, whether a remote is configured,
+// and the tracking branch name. Mirrors the signature of getUpstreamInfo in
+// internal/tui/data.go: hasRemote is false whenever no upstream is configured
+// or the rev-list output is malformed, so callers can distinguish "no remote"
+// from "0 ahead, 0 behind with a remote".
+func ctxUpstreamInfo(worktreePath string) (ahead, behind int, hasRemote bool, trackingBranch string) {
 	ctx := context.TODO()
 	out, err := cmdexec.Output(ctx, "git",
 		[]string{"rev-list", "--count", "--left-right", "@{upstream}...HEAD"},
 		worktreePath, cmdexec.GitLocal)
 	if err != nil {
-		return 0, 0, ""
+		return 0, 0, false, ""
 	}
 	parts := strings.Fields(strings.TrimSpace(string(out)))
 	if len(parts) != 2 {
-		return 0, 0, ""
+		return 0, 0, false, ""
 	}
 	b, _ := strconv.Atoi(parts[0])
 	a, _ := strconv.Atoi(parts[1])
@@ -79,7 +82,7 @@ func ctxUpstreamInfo(worktreePath string) (ahead, behind int, trackingBranch str
 	if tbErr == nil {
 		trackingBranch = strings.TrimSpace(string(tbOut))
 	}
-	return a, b, trackingBranch
+	return a, b, true, trackingBranch
 }
 
 // ctxRecentCommits returns the last n commits as (short-sha, subject) pairs.
@@ -154,12 +157,14 @@ JSON schema:
 		}
 
 		displayName := tree.DisplayName()
-		ahead, behind, trackingBranch := ctxUpstreamInfo(tree.Path)
+		ahead, behind, hasRemote, trackingBranch := ctxUpstreamInfo(tree.Path)
 		stashCount := ctxStashCount(tree.Path)
 		recentCommits := ctxRecentCommits(tree.Path, 5)
 
 		var changes []string
-		if tree.IsDirty && tree.DirtyFiles != "" {
+		// Mirror here.go convention: only check DirtyFiles, not IsDirty.
+		// IsDirty=true with DirtyFiles="" would be a bug elsewhere; we let it surface rather than hiding it.
+		if tree.DirtyFiles != "" {
 			for _, f := range strings.Split(tree.DirtyFiles, "\n") {
 				if f != "" {
 					changes = append(changes, f)
@@ -174,17 +179,19 @@ JSON schema:
 
 		if contextJSON {
 			result := contextOutput{
-				Name:           displayName,
-				Path:           tree.Path,
-				Branch:         tree.Branch,
-				Commit:         contextCommitInfo{SHA: tree.ShortCommit, Message: tree.CommitMessage},
-				TrackingBranch: trackingBranch,
-				Status:         wtStatus,
-				Changes:        changes,
-				Ahead:          ahead,
-				Behind:         behind,
-				StashCount:     stashCount,
-				RecentCommits:  recentCommits,
+				Name:          displayName,
+				Path:          tree.Path,
+				Branch:        tree.Branch,
+				Commit:        contextCommitInfo{SHA: tree.ShortCommit, Message: tree.CommitMessage},
+				Status:        wtStatus,
+				Changes:       changes,
+				StashCount:    stashCount,
+				RecentCommits: recentCommits,
+			}
+			if hasRemote {
+				result.TrackingBranch = trackingBranch
+				result.Ahead = ahead
+				result.Behind = behind
 			}
 			return output.PrintJSON(result)
 		}

--- a/cmd/grove/commands/context_cmd.go
+++ b/cmd/grove/commands/context_cmd.go
@@ -1,0 +1,250 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lost-in-the/grove/internal/cli"
+	"github.com/lost-in-the/grove/internal/cmdexec"
+	"github.com/lost-in-the/grove/internal/output"
+	"github.com/lost-in-the/grove/internal/worktree"
+)
+
+var contextJSON bool
+
+// contextRecentCommit holds a short SHA and commit message for JSON output.
+type contextRecentCommit struct {
+	SHA     string `json:"sha"`
+	Message string `json:"message"`
+}
+
+// contextOutput is the JSON schema for grove context.
+//
+// Fields:
+//
+//	name              - short display name (e.g. "my-feature")
+//	path              - absolute path to the worktree
+//	branch            - current branch name; "(detached HEAD at <sha>)" if detached
+//	commit            - { sha, message } of HEAD
+//	tracking_branch   - remote tracking branch (omitted when not set)
+//	status            - "clean" or "dirty"
+//	changes           - list of changed files (omitted when clean)
+//	ahead             - commits ahead of remote (0 when no remote)
+//	behind            - commits behind remote (0 when no remote)
+//	stash_count       - number of stashes (0 when none)
+//	recent_commits    - last 3–5 commits [{sha, message}, ...]
+type contextOutput struct {
+	Name           string                `json:"name"`
+	Path           string                `json:"path"`
+	Branch         string                `json:"branch"`
+	Commit         contextCommitInfo     `json:"commit"`
+	TrackingBranch string                `json:"tracking_branch,omitempty"`
+	Status         string                `json:"status"`
+	Changes        []string              `json:"changes,omitempty"`
+	Ahead          int                   `json:"ahead"`
+	Behind         int                   `json:"behind"`
+	StashCount     int                   `json:"stash_count"`
+	RecentCommits  []contextRecentCommit `json:"recent_commits"`
+}
+
+type contextCommitInfo struct {
+	SHA     string `json:"sha"`
+	Message string `json:"message"`
+}
+
+// ctxUpstreamInfo returns ahead/behind counts and the tracking branch name.
+// Returns zeroes and empty string when no upstream is configured.
+func ctxUpstreamInfo(worktreePath string) (ahead, behind int, trackingBranch string) {
+	ctx := context.TODO()
+	out, err := cmdexec.Output(ctx, "git",
+		[]string{"rev-list", "--count", "--left-right", "@{upstream}...HEAD"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return 0, 0, ""
+	}
+	parts := strings.Fields(strings.TrimSpace(string(out)))
+	if len(parts) != 2 {
+		return 0, 0, ""
+	}
+	b, _ := strconv.Atoi(parts[0])
+	a, _ := strconv.Atoi(parts[1])
+
+	tbOut, tbErr := cmdexec.Output(ctx, "git",
+		[]string{"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"},
+		worktreePath, cmdexec.GitLocal)
+	if tbErr == nil {
+		trackingBranch = strings.TrimSpace(string(tbOut))
+	}
+	return a, b, trackingBranch
+}
+
+// ctxRecentCommits returns the last n commits as (short-sha, subject) pairs.
+func ctxRecentCommits(worktreePath string, n int) []contextRecentCommit {
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"log", fmt.Sprintf("-%d", n), "--format=%h %s"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return nil
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil
+	}
+	lines := strings.Split(raw, "\n")
+	commits := make([]contextRecentCommit, 0, len(lines))
+	for _, line := range lines {
+		if sha, msg, ok := strings.Cut(line, " "); ok {
+			commits = append(commits, contextRecentCommit{SHA: sha, Message: msg})
+		}
+	}
+	return commits
+}
+
+// ctxStashCount returns the number of stashes in the worktree.
+func ctxStashCount(worktreePath string) int {
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"stash", "list"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return 0
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return 0
+	}
+	return len(strings.Split(raw, "\n"))
+}
+
+var contextCmd = &cobra.Command{
+	Use:   "context",
+	Short: "Show full worktree context details",
+	Long: `Display comprehensive context for the current worktree.
+
+Includes branch, commit, remote tracking status, working-tree state,
+stash count, and recent commits. Use --json for machine-readable output.
+
+JSON schema:
+  name              short display name
+  path              absolute path to worktree
+  branch            current branch (or detached HEAD description)
+  commit            { sha, message } of HEAD
+  tracking_branch   remote tracking branch (omitted when not set)
+  status            "clean" or "dirty"
+  changes           changed files (omitted when clean)
+  ahead             commits ahead of remote
+  behind            commits behind remote
+  stash_count       number of stashes
+  recent_commits    last 5 commits [{sha, message}]`,
+	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
+		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		if err != nil {
+			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+		}
+
+		tree, err := mgr.GetCurrent()
+		if err != nil {
+			return fmt.Errorf("failed to get current worktree: %w", err)
+		}
+		if tree == nil {
+			return fmt.Errorf("not in a grove worktree")
+		}
+
+		displayName := tree.DisplayName()
+		ahead, behind, trackingBranch := ctxUpstreamInfo(tree.Path)
+		stashCount := ctxStashCount(tree.Path)
+		recentCommits := ctxRecentCommits(tree.Path, 5)
+
+		var changes []string
+		if tree.IsDirty && tree.DirtyFiles != "" {
+			for _, f := range strings.Split(tree.DirtyFiles, "\n") {
+				if f != "" {
+					changes = append(changes, f)
+				}
+			}
+		}
+
+		wtStatus := statusClean
+		if tree.IsDirty {
+			wtStatus = statusDirty
+		}
+
+		if contextJSON {
+			result := contextOutput{
+				Name:           displayName,
+				Path:           tree.Path,
+				Branch:         tree.Branch,
+				Commit:         contextCommitInfo{SHA: tree.ShortCommit, Message: tree.CommitMessage},
+				TrackingBranch: trackingBranch,
+				Status:         wtStatus,
+				Changes:        changes,
+				Ahead:          ahead,
+				Behind:         behind,
+				StashCount:     stashCount,
+				RecentCommits:  recentCommits,
+			}
+			return output.PrintJSON(result)
+		}
+
+		// Human-readable output
+		w := cli.NewStdout()
+
+		cli.Header(w, "%s (%s)", displayName, tree.Branch)
+		cli.Label(w, "Path:      ", tree.Path)
+		cli.Label(w, "Branch:    ", tree.Branch)
+
+		if trackingBranch != "" {
+			syncLabel := trackingBranch
+			if ahead > 0 || behind > 0 {
+				syncLabel = fmt.Sprintf("%s  ↑%d ↓%d", trackingBranch, ahead, behind)
+			}
+			cli.Label(w, "Tracking:  ", syncLabel)
+		}
+
+		if tree.ShortCommit != "" && tree.CommitMessage != "" {
+			cli.Label(w, "Commit:    ", fmt.Sprintf("%s %s", tree.ShortCommit, tree.CommitMessage))
+		} else if tree.Commit != "" {
+			cli.Label(w, "Commit:    ", tree.Commit)
+		}
+
+		if tree.IsDirty {
+			cli.Label(w, "Status:    ", cli.StatusText(w, cli.StatusDirty, "● dirty"))
+			if len(changes) > 0 {
+				shown := changes
+				const maxShown = 5
+				if len(shown) > maxShown {
+					shown = shown[:maxShown]
+				}
+				for _, f := range shown {
+					cli.Faint(w, "           %s", f)
+				}
+				if len(changes) > maxShown {
+					cli.Faint(w, "           ... and %d more", len(changes)-maxShown)
+				}
+			}
+		} else {
+			cli.Label(w, "Status:    ", cli.StatusText(w, cli.StatusClean, "✓ clean"))
+		}
+
+		if stashCount > 0 {
+			cli.Label(w, "Stash:     ", fmt.Sprintf("%d", stashCount))
+		}
+
+		if len(recentCommits) > 0 {
+			cli.Label(w, "Recent:    ", "")
+			for _, rc := range recentCommits {
+				cli.Faint(w, "  %s %s", rc.SHA, rc.Message)
+			}
+		}
+
+		return nil
+	}),
+}
+
+func init() {
+	contextCmd.Flags().BoolVarP(&contextJSON, "json", "j", false, "Output as JSON")
+	rootCmd.AddCommand(contextCmd)
+}

--- a/cmd/grove/commands/context_cmd_test.go
+++ b/cmd/grove/commands/context_cmd_test.go
@@ -1,0 +1,249 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/cli"
+	"github.com/lost-in-the/grove/internal/output"
+)
+
+// TestContextCmd_Registration verifies the command is wired up correctly.
+func TestContextCmd_Registration(t *testing.T) {
+	if contextCmd == nil {
+		t.Fatal("contextCmd is nil")
+	}
+	if contextCmd.Use != "context" {
+		t.Errorf("contextCmd.Use = %q, want %q", contextCmd.Use, "context")
+	}
+	if contextCmd.RunE == nil {
+		t.Error("contextCmd.RunE is nil")
+	}
+	if contextCmd.Flags().Lookup("json") == nil {
+		t.Error("expected --json flag to exist")
+	}
+}
+
+// --- JSON formatter tests (pure, no git required) ---
+
+// buildContextOutput is a test helper that constructs a contextOutput and
+// round-trips it through JSON to exercise the schema.
+func buildContextOutput(overrides func(*contextOutput)) contextOutput {
+	base := contextOutput{
+		Name:   "my-feature",
+		Path:   "/home/user/project-my-feature",
+		Branch: "feat/my-feature",
+		Commit: contextCommitInfo{
+			SHA:     "abc1234",
+			Message: "initial commit",
+		},
+		TrackingBranch: "origin/feat/my-feature",
+		Status:         "clean",
+		Ahead:          2,
+		Behind:         0,
+		StashCount:     0,
+		RecentCommits: []contextRecentCommit{
+			{SHA: "abc1234", Message: "initial commit"},
+			{SHA: "def5678", Message: "second commit"},
+		},
+	}
+	if overrides != nil {
+		overrides(&base)
+	}
+	return base
+}
+
+// TestContextOutput_JSONSchema verifies that contextOutput marshals to the
+// expected snake_case field names and omits optional fields when empty.
+func TestContextOutput_JSONSchema(t *testing.T) {
+	tests := []struct {
+		name       string
+		build      func(*contextOutput)
+		wantFields []string
+		absentKeys []string
+	}{
+		{
+			name:       "clean worktree",
+			build:      nil,
+			wantFields: []string{`"name"`, `"path"`, `"branch"`, `"commit"`, `"tracking_branch"`, `"status"`, `"ahead"`, `"behind"`, `"stash_count"`, `"recent_commits"`},
+			absentKeys: []string{`"changes"`},
+		},
+		{
+			name: "dirty worktree with changes",
+			build: func(o *contextOutput) {
+				o.Status = "dirty"
+				o.Changes = []string{"M internal/foo.go", "?? newfile.txt"}
+			},
+			wantFields: []string{`"changes"`},
+			absentKeys: nil,
+		},
+		{
+			name: "no tracking branch — field omitted",
+			build: func(o *contextOutput) {
+				o.TrackingBranch = ""
+			},
+			wantFields: nil,
+			absentKeys: []string{`"tracking_branch"`},
+		},
+		{
+			name: "detached HEAD",
+			build: func(o *contextOutput) {
+				o.Branch = "(detached HEAD at abc1234)"
+			},
+			wantFields: []string{`"(detached HEAD at abc1234)"`},
+			absentKeys: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := buildContextOutput(tc.build)
+			data, err := json.MarshalIndent(obj, "", "  ")
+			if err != nil {
+				t.Fatalf("MarshalIndent: %v", err)
+			}
+			js := string(data)
+
+			for _, want := range tc.wantFields {
+				if !strings.Contains(js, want) {
+					t.Errorf("expected %q in JSON, got:\n%s", want, js)
+				}
+			}
+			for _, absent := range tc.absentKeys {
+				if strings.Contains(js, absent) {
+					t.Errorf("expected %q to be absent from JSON, got:\n%s", absent, js)
+				}
+			}
+		})
+	}
+}
+
+// TestContextOutput_JSONRoundtrip verifies that JSON output can be decoded back
+// into a contextOutput with all fields intact.
+func TestContextOutput_JSONRoundtrip(t *testing.T) {
+	original := buildContextOutput(func(o *contextOutput) {
+		o.Status = "dirty"
+		o.Changes = []string{"M foo.go"}
+		o.StashCount = 3
+		o.Ahead = 1
+		o.Behind = 2
+	})
+
+	var buf bytes.Buffer
+	origStdout := bytes.Buffer{}
+	_ = origStdout // suppress unused warning
+
+	// Marshal via output.PrintJSON (which uses json.MarshalIndent).
+	// Capture by directly marshaling here since PrintJSON writes to os.Stdout.
+	data, err := json.MarshalIndent(original, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	_, _ = fmt.Fprintf(&buf, "%s", data)
+
+	var decoded contextOutput
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if decoded.Name != original.Name {
+		t.Errorf("Name: got %q, want %q", decoded.Name, original.Name)
+	}
+	if decoded.Status != original.Status {
+		t.Errorf("Status: got %q, want %q", decoded.Status, original.Status)
+	}
+	if decoded.StashCount != original.StashCount {
+		t.Errorf("StashCount: got %d, want %d", decoded.StashCount, original.StashCount)
+	}
+	if decoded.Ahead != original.Ahead {
+		t.Errorf("Ahead: got %d, want %d", decoded.Ahead, original.Ahead)
+	}
+	if decoded.Behind != original.Behind {
+		t.Errorf("Behind: got %d, want %d", decoded.Behind, original.Behind)
+	}
+	if len(decoded.Changes) != len(original.Changes) {
+		t.Errorf("Changes len: got %d, want %d", len(decoded.Changes), len(original.Changes))
+	}
+	if len(decoded.RecentCommits) != len(original.RecentCommits) {
+		t.Errorf("RecentCommits len: got %d, want %d", len(decoded.RecentCommits), len(original.RecentCommits))
+	}
+}
+
+// TestContextHumanOutput_CleanWorktree checks human output for a clean worktree.
+func TestContextHumanOutput_CleanWorktree(t *testing.T) {
+	var buf bytes.Buffer
+	w := cli.NewWriter(&buf, false)
+
+	// Render a minimal "clean" context manually (mirrors what contextCmd does).
+	cli.Header(w, "%s (%s)", "my-feature", "feat/my-feature")
+	cli.Label(w, "Path:      ", "/home/user/project-my-feature")
+	cli.Label(w, "Branch:    ", "feat/my-feature")
+	cli.Label(w, "Tracking:  ", "origin/feat/my-feature  ↑2 ↓0")
+	cli.Label(w, "Commit:    ", "abc1234 initial commit")
+	cli.Label(w, "Status:    ", "✓ clean")
+
+	out := buf.String()
+	checks := []string{"my-feature", "feat/my-feature", "abc1234", "initial commit", "✓ clean", "Tracking:"}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestContextHumanOutput_DirtyWorktree checks human output for a dirty worktree.
+func TestContextHumanOutput_DirtyWorktree(t *testing.T) {
+	var buf bytes.Buffer
+	w := cli.NewWriter(&buf, false)
+
+	cli.Header(w, "%s (%s)", "my-feature", "feat/my-feature")
+	cli.Label(w, "Status:    ", "● dirty")
+	cli.Faint(w, "           M internal/foo.go")
+
+	out := buf.String()
+	if !strings.Contains(out, "● dirty") {
+		t.Errorf("expected dirty status, got:\n%s", out)
+	}
+	if !strings.Contains(out, "internal/foo.go") {
+		t.Errorf("expected dirty file listed, got:\n%s", out)
+	}
+}
+
+// TestContextHumanOutput_NoTrackingBranch checks that omitting tracking branch
+// works (no "Tracking:" line when branch is empty).
+func TestContextHumanOutput_NoTrackingBranch(t *testing.T) {
+	var buf bytes.Buffer
+	w := cli.NewWriter(&buf, false)
+
+	// Simulate rendering without a tracking branch.
+	trackingBranch := ""
+	if trackingBranch != "" {
+		cli.Label(w, "Tracking:  ", trackingBranch)
+	}
+	cli.Label(w, "Status:    ", "✓ clean")
+
+	out := buf.String()
+	if strings.Contains(out, "Tracking:") {
+		t.Errorf("expected no Tracking line when no remote, got:\n%s", out)
+	}
+}
+
+// TestContextOutput_PrintJSON verifies output.PrintJSON produces valid JSON.
+func TestContextOutput_PrintJSON(t *testing.T) {
+	// Just verify the helper doesn't error on a valid struct.
+	obj := buildContextOutput(nil)
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	// Verify it's non-empty and valid JSON.
+	var probe map[string]interface{}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	// output.PrintJSON is a thin wrapper; verify the package is importable.
+	_ = output.PrintJSON // just ensure the import is used
+}

--- a/cmd/grove/commands/context_cmd_test.go
+++ b/cmd/grove/commands/context_cmd_test.go
@@ -41,6 +41,7 @@ func buildContextOutput(overrides func(*contextOutput)) contextOutput {
 			Message: "initial commit",
 		},
 		TrackingBranch: "origin/feat/my-feature",
+		HasRemote:      true,
 		Status:         "clean",
 		Ahead:          2,
 		Behind:         0,
@@ -68,7 +69,7 @@ func TestContextOutput_JSONSchema(t *testing.T) {
 		{
 			name:       "clean worktree",
 			build:      nil,
-			wantFields: []string{`"name"`, `"path"`, `"branch"`, `"commit"`, `"tracking_branch"`, `"status"`, `"ahead"`, `"behind"`, `"stash_count"`, `"recent_commits"`},
+			wantFields: []string{`"name"`, `"path"`, `"branch"`, `"commit"`, `"tracking_branch"`, `"has_remote"`, `"status"`, `"ahead"`, `"behind"`, `"stash_count"`, `"recent_commits"`},
 			absentKeys: []string{`"changes"`},
 		},
 		{
@@ -249,13 +250,16 @@ func TestContextOutput_PrintJSON(t *testing.T) {
 }
 
 // TestContextOutput_NoRemote_OmitsTrackingFields verifies that when hasRemote
-// is false, the JSON output omits tracking_branch and emits 0 for ahead/behind.
+// is false, the JSON output omits tracking_branch, emits has_remote: false,
+// and still includes ahead/behind as 0. Consumers can use has_remote to
+// distinguish "no remote" from "remote, perfectly in sync".
 // This mirrors the TUI's hasRemote contract in internal/tui/data.go.
 func TestContextOutput_NoRemote_OmitsTrackingFields(t *testing.T) {
 	// Simulate what contextCmd does when hasRemote=false: tracking_branch is
-	// left as zero value ("") so omitempty drops it; ahead/behind stay 0.
+	// left as zero value ("") so omitempty drops it; HasRemote=false; ahead/behind stay 0.
 	obj := buildContextOutput(func(o *contextOutput) {
 		o.TrackingBranch = ""
+		o.HasRemote = false
 		o.Ahead = 0
 		o.Behind = 0
 	})
@@ -268,6 +272,46 @@ func TestContextOutput_NoRemote_OmitsTrackingFields(t *testing.T) {
 
 	if strings.Contains(js, `"tracking_branch"`) {
 		t.Errorf("expected tracking_branch to be absent when no remote, got:\n%s", js)
+	}
+	if !strings.Contains(js, `"has_remote": false`) {
+		t.Errorf("expected has_remote: false in JSON when no remote, got:\n%s", js)
+	}
+	// ahead and behind are always present (0 is valid)
+	if !strings.Contains(js, `"ahead"`) {
+		t.Errorf("expected ahead field present even when no remote, got:\n%s", js)
+	}
+	if !strings.Contains(js, `"behind"`) {
+		t.Errorf("expected behind field present even when no remote, got:\n%s", js)
+	}
+}
+
+// TestContextOutput_HasRemote_AheadBehind verifies that when hasRemote is true,
+// has_remote: true and non-zero ahead/behind values are present in JSON output.
+func TestContextOutput_HasRemote_AheadBehind(t *testing.T) {
+	obj := buildContextOutput(func(o *contextOutput) {
+		o.HasRemote = true
+		o.TrackingBranch = "origin/feat/my-feature"
+		o.Ahead = 3
+		o.Behind = 1
+	})
+
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	js := string(data)
+
+	if !strings.Contains(js, `"has_remote": true`) {
+		t.Errorf("expected has_remote: true in JSON, got:\n%s", js)
+	}
+	if !strings.Contains(js, `"tracking_branch"`) {
+		t.Errorf("expected tracking_branch present when has_remote=true, got:\n%s", js)
+	}
+	if !strings.Contains(js, `"ahead": 3`) {
+		t.Errorf("expected ahead: 3 in JSON, got:\n%s", js)
+	}
+	if !strings.Contains(js, `"behind": 1`) {
+		t.Errorf("expected behind: 1 in JSON, got:\n%s", js)
 	}
 }
 

--- a/cmd/grove/commands/context_cmd_test.go
+++ b/cmd/grove/commands/context_cmd_test.go
@@ -247,3 +247,111 @@ func TestContextOutput_PrintJSON(t *testing.T) {
 	// output.PrintJSON is a thin wrapper; verify the package is importable.
 	_ = output.PrintJSON // just ensure the import is used
 }
+
+// TestContextOutput_NoRemote_OmitsTrackingFields verifies that when hasRemote
+// is false, the JSON output omits tracking_branch and emits 0 for ahead/behind.
+// This mirrors the TUI's hasRemote contract in internal/tui/data.go.
+func TestContextOutput_NoRemote_OmitsTrackingFields(t *testing.T) {
+	// Simulate what contextCmd does when hasRemote=false: tracking_branch is
+	// left as zero value ("") so omitempty drops it; ahead/behind stay 0.
+	obj := buildContextOutput(func(o *contextOutput) {
+		o.TrackingBranch = ""
+		o.Ahead = 0
+		o.Behind = 0
+	})
+
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	js := string(data)
+
+	if strings.Contains(js, `"tracking_branch"`) {
+		t.Errorf("expected tracking_branch to be absent when no remote, got:\n%s", js)
+	}
+}
+
+// TestContextOutput_EmptyRecentCommits_Omitted verifies that when the
+// recent_commits slice is nil/empty, the field is omitted from JSON output.
+func TestContextOutput_EmptyRecentCommits_Omitted(t *testing.T) {
+	obj := buildContextOutput(func(o *contextOutput) {
+		o.RecentCommits = nil
+	})
+
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	js := string(data)
+
+	if strings.Contains(js, `"recent_commits"`) {
+		t.Errorf("expected recent_commits to be absent when empty, got:\n%s", js)
+	}
+}
+
+// TestContextOutput_EmptyRecentCommitsSlice_Omitted verifies that an empty
+// (non-nil) slice is also omitted, since omitempty treats empty slices as zero.
+func TestContextOutput_EmptyRecentCommitsSlice_Omitted(t *testing.T) {
+	obj := buildContextOutput(func(o *contextOutput) {
+		o.RecentCommits = []contextRecentCommit{}
+	})
+
+	data, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	js := string(data)
+
+	if strings.Contains(js, `"recent_commits"`) {
+		t.Errorf("expected recent_commits to be absent for empty slice, got:\n%s", js)
+	}
+}
+
+// TestContextDirtyFileGuard verifies that the changes slice is populated from
+// DirtyFiles alone (no IsDirty check), mirroring the here.go convention.
+func TestContextDirtyFileGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		dirtyFiles  string
+		wantChanges []string
+	}{
+		{
+			name:        "dirty files present",
+			dirtyFiles:  "M internal/foo.go\n?? newfile.txt\n",
+			wantChanges: []string{"M internal/foo.go", "?? newfile.txt"},
+		},
+		{
+			name:        "empty dirty files",
+			dirtyFiles:  "",
+			wantChanges: nil,
+		},
+		{
+			name:        "only blank lines",
+			dirtyFiles:  "\n\n",
+			wantChanges: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reproduce the guard logic from context_cmd.go directly.
+			var changes []string
+			if tc.dirtyFiles != "" {
+				for _, f := range strings.Split(tc.dirtyFiles, "\n") {
+					if f != "" {
+						changes = append(changes, f)
+					}
+				}
+			}
+
+			if len(changes) != len(tc.wantChanges) {
+				t.Fatalf("changes len: got %d, want %d (got %v)", len(changes), len(tc.wantChanges), changes)
+			}
+			for i, want := range tc.wantChanges {
+				if changes[i] != want {
+					t.Errorf("changes[%d]: got %q, want %q", i, changes[i], want)
+				}
+			}
+		})
+	}
+}

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -18,6 +18,7 @@ This document provides exhaustive specifications for each grove command. Every b
    - [grove rm](#grove-rm)
    - [grove rename](#grove-rename)
    - [grove here](#grove-here)
+   - [grove context](#grove-context)
    - [grove last](#grove-last)
    - [grove join](#grove-join)
    - [grove which](#grove-which)
@@ -898,6 +899,115 @@ To create a new worktree: grove new <name>
 **Exit Codes:**
 - 0: Success (in a worktree)
 - 1: Not in a worktree
+
+---
+
+### grove context
+
+**Purpose:** Print full worktree context details — like the TUI sidebar, but for CLI/scripting use.
+
+**Usage:**
+```
+grove context [flags]
+
+Flags:
+  -j, --json     Output as JSON
+```
+
+**Behavior:**
+
+1. Require grove project context (exits non-zero if not in a grove project)
+2. Determine the current worktree from `$PWD`
+3. Gather: branch, HEAD commit, remote tracking/sync, working-tree status, stash count, recent commits
+4. Display in a human-readable format or emit structured JSON
+
+**Output (Default):**
+```
+my-feature (feat/my-feature)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Path:       ~/projects/myapp-my-feature
+Branch:     feat/my-feature
+Tracking:   origin/feat/my-feature  ↑2 ↓0
+Commit:     abc1234 Add authentication middleware
+Status:     ✓ clean
+Recent:
+  abc1234 Add authentication middleware
+  def5678 Scaffold user model
+  ghi9012 Initial commit
+```
+
+**Output (Dirty):**
+```
+my-feature (feat/my-feature)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Path:       ~/projects/myapp-my-feature
+Branch:     feat/my-feature
+Tracking:   origin/feat/my-feature  ↑1 ↓3
+Commit:     abc1234 Add authentication middleware
+Status:     ● dirty
+            M  internal/auth/handler.go
+            ?? internal/auth/token.go
+Stash:      2
+Recent:
+  abc1234 Add authentication middleware
+  def5678 Scaffold user model
+  ghi9012 Initial commit
+```
+
+**Output (--json):**
+```json
+{
+  "name": "my-feature",
+  "path": "/home/user/projects/myapp-my-feature",
+  "branch": "feat/my-feature",
+  "commit": {
+    "sha": "abc1234",
+    "message": "Add authentication middleware"
+  },
+  "tracking_branch": "origin/feat/my-feature",
+  "status": "clean",
+  "ahead": 2,
+  "behind": 0,
+  "stash_count": 0,
+  "recent_commits": [
+    {"sha": "abc1234", "message": "Add authentication middleware"},
+    {"sha": "def5678", "message": "Scaffold user model"},
+    {"sha": "ghi9012", "message": "Initial commit"}
+  ]
+}
+```
+
+**JSON Field Reference:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Short display name (without project prefix) |
+| `path` | string | Absolute path to the worktree |
+| `branch` | string | Current branch; `"(detached HEAD at <sha>)"` when detached |
+| `commit.sha` | string | 7-char short hash of HEAD |
+| `commit.message` | string | Subject line of HEAD commit |
+| `tracking_branch` | string | Remote tracking ref (field omitted when not set) |
+| `status` | string | `"clean"` or `"dirty"` |
+| `changes` | []string | Modified files from `git status --porcelain` (field omitted when clean) |
+| `ahead` | int | Commits ahead of remote (0 when no remote) |
+| `behind` | int | Commits behind remote (0 when no remote) |
+| `stash_count` | int | Number of stashes |
+| `recent_commits` | []object | Last 5 commits, each `{sha, message}` |
+
+**Edge Cases:**
+
+| Scenario | Behavior |
+|----------|----------|
+| No remote tracking branch | Omit `Tracking:` line in human output; omit `tracking_branch` key in JSON |
+| Detached HEAD | Branch shows `(detached HEAD at <sha>)` |
+| Dirty worktree | Shows modified files (up to 5 shown; remainder counted) |
+| No stashes | `Stash:` line omitted in human output; `stash_count: 0` in JSON |
+| No commits yet | Recent commits section omitted |
+| Not in grove project | Exit non-zero with "not a grove project" error |
+
+**Exit Codes:**
+- 0: Success
+- 10: Not in a grove project
 
 ---
 
@@ -2300,8 +2410,8 @@ Two command names surfaced during a documentation audit but were confirmed to **
 
 If a `grove browse` command is added in the future, it should be documented here and in README.md.
 
-### `grove context` (not implemented)
+### `grove context` (implemented in v0.8.0)
 
-`cmd/grove/commands/context.go` exists but contains the `GroveContext` struct and `RequireGroveContext` middleware helper — shared infrastructure used by nearly every command. There is no user-facing `grove context` cobra command.
+`cmd/grove/commands/context.go` contains the `GroveContext` struct and `RequireGroveContext` middleware helper — shared infrastructure used by nearly every command.
 
-If a `grove context` command is added in the future (e.g., to print current project/worktree context for scripting), it should be documented here and in README.md.
+The user-facing `grove context` command lives in `cmd/grove/commands/context_cmd.go` and is documented in [grove context](#grove-context) above.

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -965,6 +965,7 @@ Recent:
     "message": "Add authentication middleware"
   },
   "tracking_branch": "origin/feat/my-feature",
+  "has_remote": true,
   "status": "clean",
   "ahead": 2,
   "behind": 0,
@@ -987,10 +988,11 @@ Recent:
 | `commit.sha` | string | 7-char short hash of HEAD |
 | `commit.message` | string | Subject line of HEAD commit |
 | `tracking_branch` | string | Remote tracking ref (field omitted when not set) |
+| `has_remote` | bool | `true` when a remote tracking branch is configured; `ahead`/`behind` are meaningful only when `true` |
 | `status` | string | `"clean"` or `"dirty"` |
 | `changes` | []string | Modified files from `git status --porcelain` (field omitted when clean) |
-| `ahead` | int | Commits ahead of remote (0 when no remote) |
-| `behind` | int | Commits behind remote (0 when no remote) |
+| `ahead` | int | Commits ahead of remote (always present; interpret only when `has_remote: true`) |
+| `behind` | int | Commits behind remote (always present; interpret only when `has_remote: true`) |
 | `stash_count` | int | Number of stashes |
 | `recent_commits` | []object | Last 5 commits, each `{sha, message}` |
 
@@ -998,7 +1000,7 @@ Recent:
 
 | Scenario | Behavior |
 |----------|----------|
-| No remote tracking branch | Omit `Tracking:` line in human output; omit `tracking_branch` key in JSON |
+| No remote tracking branch | Omit `Tracking:` line in human output; omit `tracking_branch` key in JSON; emit `has_remote: false` |
 | Detached HEAD | Branch shows `(detached HEAD at <sha>)` |
 | Dirty worktree | Shows modified files (up to 5 shown; remainder counted) |
 | No stashes | `Stash:` line omitted in human output; `stash_count: 0` in JSON |

--- a/tests/integration/context_e2e_test.go
+++ b/tests/integration/context_e2e_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+// End-to-end tests for `grove context` and `grove context --json`.
+//
+// Scenarios:
+//   - Inside a valid grove worktree → human output includes key fields
+//   - Inside a valid grove worktree + --json → JSON output has correct schema
+//   - Outside any grove project → exit non-zero with error message
+package integration_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/testhelper"
+)
+
+// setupContextRepo creates a temp grove project with a linked worktree and
+// returns (repoPath, worktreePath).
+func setupContextRepo(t *testing.T) (string, string) {
+	t.Helper()
+	repo := testhelper.SetupRailsFixture(t)
+
+	wtPath := filepath.Join(filepath.Dir(repo), "rails-app-ctx-test")
+	testhelper.RunGit(t, repo, "worktree", "add", "-b", "ctx-test", wtPath)
+
+	// Minimal state.json so RequireGroveContext resolves cleanly.
+	groveDir := filepath.Join(repo, ".grove")
+	state := []byte(`{"version": 1, "worktrees": {}}`)
+	if err := os.WriteFile(filepath.Join(groveDir, "state.json"), state, 0644); err != nil {
+		t.Fatalf("write state.json: %v", err)
+	}
+
+	return repo, wtPath
+}
+
+// TestContextCmd_HumanOutput verifies that `grove context` running inside a
+// grove worktree produces human-readable output containing key fields.
+func TestContextCmd_HumanOutput(t *testing.T) {
+	_, wtPath := setupContextRepo(t)
+	binary := buildGroveBinary(t)
+
+	cmd := exec.Command(binary, "context")
+	cmd.Dir = wtPath
+	cmd.Env = testhelper.GitEnv()
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("grove context failed: %v\nstderr: %s\nstdout: %s", err, ee.Stderr, out)
+		}
+		t.Fatalf("grove context failed: %v", err)
+	}
+
+	text := string(out)
+
+	// Branch and display name must appear.
+	if !strings.Contains(text, "ctx-test") {
+		t.Errorf("expected 'ctx-test' in output, got:\n%s", text)
+	}
+	// Status must appear.
+	if !strings.Contains(text, "clean") && !strings.Contains(text, "dirty") {
+		t.Errorf("expected status (clean/dirty) in output, got:\n%s", text)
+	}
+	// Path must appear.
+	if !strings.Contains(text, wtPath) {
+		t.Errorf("expected worktree path %q in output, got:\n%s", wtPath, text)
+	}
+	// Recent commits section must appear.
+	if !strings.Contains(text, "Recent") {
+		t.Errorf("expected 'Recent' section in output, got:\n%s", text)
+	}
+}
+
+// TestContextCmd_JSONOutput verifies that `grove context --json` produces
+// valid JSON with the expected schema.
+func TestContextCmd_JSONOutput(t *testing.T) {
+	_, wtPath := setupContextRepo(t)
+	binary := buildGroveBinary(t)
+
+	cmd := exec.Command(binary, "context", "--json")
+	cmd.Dir = wtPath
+	cmd.Env = testhelper.GitEnv()
+
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("grove context --json failed: %v\nstderr: %s\nstdout: %s", err, ee.Stderr, out)
+		}
+		t.Fatalf("grove context --json failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw: %s", err, out)
+	}
+
+	// Required top-level keys.
+	for _, key := range []string{"name", "path", "branch", "commit", "status", "ahead", "behind", "stash_count", "recent_commits"} {
+		if _, ok := result[key]; !ok {
+			t.Errorf("expected key %q in JSON output, got keys: %v", key, jsonKeys(result))
+		}
+	}
+
+	// Sanity: name should be non-empty.
+	if name, _ := result["name"].(string); name == "" {
+		t.Errorf("expected non-empty 'name' in JSON output")
+	}
+
+	// status must be "clean" or "dirty".
+	if status, _ := result["status"].(string); status != "clean" && status != "dirty" {
+		t.Errorf("expected status 'clean' or 'dirty', got %q", status)
+	}
+
+	// commit must be an object with sha and message.
+	commit, ok := result["commit"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected 'commit' to be an object, got %T", result["commit"])
+	}
+	if _, ok := commit["sha"]; !ok {
+		t.Error("expected 'commit.sha' in JSON output")
+	}
+	if _, ok := commit["message"]; !ok {
+		t.Error("expected 'commit.message' in JSON output")
+	}
+
+	// recent_commits must be an array.
+	if _, ok := result["recent_commits"].([]interface{}); !ok {
+		t.Errorf("expected 'recent_commits' to be an array, got %T", result["recent_commits"])
+	}
+}
+
+// TestContextCmd_OutsideGroveProject verifies that running `grove context`
+// outside a grove project exits non-zero with a meaningful error.
+func TestContextCmd_OutsideGroveProject(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	// Use a plain tempdir with no git repo.
+	emptyDir := t.TempDir()
+
+	cmd := exec.Command(binary, "context")
+	cmd.Dir = emptyDir
+	cmd.Env = testhelper.GitEnv()
+
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got success\noutput: %s", out)
+	}
+
+	// Output should mention that we're not in a grove project.
+	text := string(out)
+	if !strings.Contains(strings.ToLower(text), "grove") {
+		t.Errorf("expected grove-related error message, got: %s", text)
+	}
+}
+
+// jsonKeys returns all keys from a map for error messages.
+func jsonKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## Summary

- Adds `grove context` command that prints comprehensive worktree context for CLI/scripting use — superset of `grove here`
- Includes branch, HEAD commit, remote tracking branch, ahead/behind sync, working-tree status + dirty-file list, stash count, and last 5 recent commits
- `--json` flag emits structured machine-readable output with snake_case field names
- `RequireGroveContext` middleware handles the outside-grove-project error case automatically (exit 10)
- Data-fetching functions are inlined in `context_cmd.go` using the same `cmdexec` pattern as `internal/tui/data.go` — no TUI package import from CLI

Closes #16

## File placement

- `cmd/grove/commands/context_cmd.go` — new command (existing `context.go` untouched; `GroveContext` struct and `RequireGroveContext` signatures unchanged)
- `cmd/grove/commands/context_cmd_test.go` — unit tests for JSON schema, roundtrip, and human-output rendering
- `tests/integration/context_e2e_test.go` — integration tests: human output, `--json`, outside-grove-project error

## Human output sample

```
my-feature (feat/my-feature)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Path:       /home/user/projects/myapp-my-feature
Branch:     feat/my-feature
Tracking:   origin/feat/my-feature  ↑2 ↓0
Commit:     abc1234 Add authentication middleware
Status:     ✓ clean
Recent:
  abc1234 Add authentication middleware
  def5678 Scaffold user model
  ghi9012 Initial commit
```

## --json output sample

```json
{
  "name": "my-feature",
  "path": "/home/user/projects/myapp-my-feature",
  "branch": "feat/my-feature",
  "commit": {
    "sha": "abc1234",
    "message": "Add authentication middleware"
  },
  "tracking_branch": "origin/feat/my-feature",
  "status": "clean",
  "ahead": 2,
  "behind": 0,
  "stash_count": 0,
  "recent_commits": [
    {"sha": "abc1234", "message": "Add authentication middleware"},
    {"sha": "def5678", "message": "Scaffold user model"},
    {"sha": "ghi9012", "message": "Initial commit"}
  ]
}
```

## Test plan

- [x] `make lint test` passes (all existing tests green)
- [x] Integration tests pass: `go test -v -tags=integration ./tests/integration/ -run TestContextCmd`
  - human output contains branch name, path, status, recent commits
  - `--json` parses as valid JSON with all required keys
  - outside grove project → exit non-zero with error