### PR TITLE
refactor: extract worktree-info helpers to shared package

### DIFF
--- a/cmd/grove/commands/context_cmd.go
+++ b/cmd/grove/commands/context_cmd.go
@@ -1,26 +1,18 @@
 package commands
 
 import (
-	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/lost-in-the/grove/internal/cli"
-	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/output"
 	"github.com/lost-in-the/grove/internal/worktree"
+	"github.com/lost-in-the/grove/internal/worktreeinfo"
 )
 
 var contextJSON bool
-
-// contextRecentCommit holds a short SHA and commit message for JSON output.
-type contextRecentCommit struct {
-	SHA     string `json:"sha"`
-	Message string `json:"message"`
-}
 
 // contextOutput is the JSON schema for grove context.
 //
@@ -39,89 +31,23 @@ type contextRecentCommit struct {
 //	stash_count       - number of stashes (0 when none)
 //	recent_commits    - last 3–5 commits [{sha, message}, ...]
 type contextOutput struct {
-	Name           string                `json:"name"`
-	Path           string                `json:"path"`
-	Branch         string                `json:"branch"`
-	Commit         contextCommitInfo     `json:"commit"`
-	TrackingBranch string                `json:"tracking_branch,omitempty"`
-	HasRemote      bool                  `json:"has_remote"`
-	Status         string                `json:"status"`
-	Changes        []string              `json:"changes,omitempty"`
-	Ahead          int                   `json:"ahead"`
-	Behind         int                   `json:"behind"`
-	StashCount     int                   `json:"stash_count"`
-	RecentCommits  []contextRecentCommit `json:"recent_commits,omitempty"`
+	Name           string                      `json:"name"`
+	Path           string                      `json:"path"`
+	Branch         string                      `json:"branch"`
+	Commit         contextCommitInfo           `json:"commit"`
+	TrackingBranch string                      `json:"tracking_branch,omitempty"`
+	HasRemote      bool                        `json:"has_remote"`
+	Status         string                      `json:"status"`
+	Changes        []string                    `json:"changes,omitempty"`
+	Ahead          int                         `json:"ahead"`
+	Behind         int                         `json:"behind"`
+	StashCount     int                         `json:"stash_count"`
+	RecentCommits  []worktreeinfo.RecentCommit `json:"recent_commits,omitempty"`
 }
 
 type contextCommitInfo struct {
 	SHA     string `json:"sha"`
 	Message string `json:"message"`
-}
-
-// ctxUpstreamInfo returns ahead/behind counts, whether a remote is configured,
-// and the tracking branch name. Mirrors the signature of getUpstreamInfo in
-// internal/tui/data.go: hasRemote is false whenever no upstream is configured
-// or the rev-list output is malformed, so callers can distinguish "no remote"
-// from "0 ahead, 0 behind with a remote".
-func ctxUpstreamInfo(worktreePath string) (ahead, behind int, hasRemote bool, trackingBranch string) {
-	ctx := context.TODO()
-	out, err := cmdexec.Output(ctx, "git",
-		[]string{"rev-list", "--count", "--left-right", "@{upstream}...HEAD"},
-		worktreePath, cmdexec.GitLocal)
-	if err != nil {
-		return 0, 0, false, ""
-	}
-	parts := strings.Fields(strings.TrimSpace(string(out)))
-	if len(parts) != 2 {
-		return 0, 0, false, ""
-	}
-	b, _ := strconv.Atoi(parts[0])
-	a, _ := strconv.Atoi(parts[1])
-
-	tbOut, tbErr := cmdexec.Output(ctx, "git",
-		[]string{"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"},
-		worktreePath, cmdexec.GitLocal)
-	if tbErr == nil {
-		trackingBranch = strings.TrimSpace(string(tbOut))
-	}
-	return a, b, true, trackingBranch
-}
-
-// ctxRecentCommits returns the last n commits as (short-sha, subject) pairs.
-func ctxRecentCommits(worktreePath string, n int) []contextRecentCommit {
-	out, err := cmdexec.Output(context.TODO(), "git",
-		[]string{"log", fmt.Sprintf("-%d", n), "--format=%h %s"},
-		worktreePath, cmdexec.GitLocal)
-	if err != nil {
-		return nil
-	}
-	raw := strings.TrimSpace(string(out))
-	if raw == "" {
-		return nil
-	}
-	lines := strings.Split(raw, "\n")
-	commits := make([]contextRecentCommit, 0, len(lines))
-	for _, line := range lines {
-		if sha, msg, ok := strings.Cut(line, " "); ok {
-			commits = append(commits, contextRecentCommit{SHA: sha, Message: msg})
-		}
-	}
-	return commits
-}
-
-// ctxStashCount returns the number of stashes in the worktree.
-func ctxStashCount(worktreePath string) int {
-	out, err := cmdexec.Output(context.TODO(), "git",
-		[]string{"stash", "list"},
-		worktreePath, cmdexec.GitLocal)
-	if err != nil {
-		return 0
-	}
-	raw := strings.TrimSpace(string(out))
-	if raw == "" {
-		return 0
-	}
-	return len(strings.Split(raw, "\n"))
 }
 
 var contextCmd = &cobra.Command{
@@ -160,9 +86,9 @@ JSON schema:
 		}
 
 		displayName := tree.DisplayName()
-		ahead, behind, hasRemote, trackingBranch := ctxUpstreamInfo(tree.Path)
-		stashCount := ctxStashCount(tree.Path)
-		recentCommits := ctxRecentCommits(tree.Path, 5)
+		ahead, behind, hasRemote, trackingBranch := worktreeinfo.UpstreamInfo(tree.Path)
+		stashCount := worktreeinfo.StashCount(tree.Path)
+		recentCommits := worktreeinfo.RecentCommits(tree.Path, 5)
 
 		var changes []string
 		// Mirror here.go convention: only check DirtyFiles, not IsDirty.

--- a/cmd/grove/commands/context_cmd_test.go
+++ b/cmd/grove/commands/context_cmd_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/output"
+	"github.com/lost-in-the/grove/internal/worktreeinfo"
 )
 
 // TestContextCmd_Registration verifies the command is wired up correctly.
@@ -46,7 +47,7 @@ func buildContextOutput(overrides func(*contextOutput)) contextOutput {
 		Ahead:          2,
 		Behind:         0,
 		StashCount:     0,
-		RecentCommits: []contextRecentCommit{
+		RecentCommits: []worktreeinfo.RecentCommit{
 			{SHA: "abc1234", Message: "initial commit"},
 			{SHA: "def5678", Message: "second commit"},
 		},
@@ -337,7 +338,7 @@ func TestContextOutput_EmptyRecentCommits_Omitted(t *testing.T) {
 // (non-nil) slice is also omitted, since omitempty treats empty slices as zero.
 func TestContextOutput_EmptyRecentCommitsSlice_Omitted(t *testing.T) {
 	obj := buildContextOutput(func(o *contextOutput) {
-		o.RecentCommits = []contextRecentCommit{}
+		o.RecentCommits = []worktreeinfo.RecentCommit{}
 	})
 
 	data, err := json.MarshalIndent(obj, "", "  ")

--- a/internal/tui/data.go
+++ b/internal/tui/data.go
@@ -1,20 +1,18 @@
 package tui
 
 import (
-	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/config"
 	"github.com/lost-in-the/grove/internal/plugins"
 	"github.com/lost-in-the/grove/internal/state"
 	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/tuilog"
 	"github.com/lost-in-the/grove/internal/worktree"
+	"github.com/lost-in-the/grove/internal/worktreeinfo"
 )
 
 // PRInfo holds lightweight PR metadata for display in the detail panel.
@@ -23,12 +21,6 @@ type PRInfo struct {
 	Title          string
 	URL            string
 	ReviewDecision string // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", ""
-}
-
-// RecentCommit holds a short SHA and subject for display.
-type RecentCommit struct {
-	SHA     string // 7-char short hash
-	Message string // first line of commit message
 }
 
 // WorktreeItem holds enriched worktree data for the TUI.
@@ -47,15 +39,15 @@ type WorktreeItem struct {
 	IsEnvironment  bool
 	IsProtected    bool
 	IsPrunable     bool
-	TmuxStatus     string         // "attached", "detached", "none"
-	HasRemote      bool           // true if branch has upstream tracking
-	TrackingBranch string         // e.g., "origin/feat/ux-polish" (empty if no upstream)
-	AheadCount     int            // commits ahead of upstream
-	BehindCount    int            // commits behind upstream
-	CommitCount    int            // commits ahead of default branch
-	RecentCommits  []RecentCommit // last 3 commits
-	StashCount     int            // number of stashes in this worktree
-	AssociatedPR   *PRInfo        // PR linked to this branch (nil if none)
+	TmuxStatus     string                      // "attached", "detached", "none"
+	HasRemote      bool                        // true if branch has upstream tracking
+	TrackingBranch string                      // e.g., "origin/feat/ux-polish" (empty if no upstream)
+	AheadCount     int                         // commits ahead of upstream
+	BehindCount    int                         // commits behind upstream
+	CommitCount    int                         // commits ahead of default branch
+	RecentCommits  []worktreeinfo.RecentCommit // last 3 commits
+	StashCount     int                         // number of stashes in this worktree
+	AssociatedPR   *PRInfo                     // PR linked to this branch (nil if none)
 	LastAccessed   time.Time
 	PluginStatuses []plugins.StatusEntry // status entries from plugins
 }
@@ -103,75 +95,6 @@ func (w *WorktreeItem) AgeText() string {
 		return ""
 	}
 	return Styles.DetailDim.Render(w.CommitAge)
-}
-
-// getUpstreamInfo returns upstream tracking info in a single git call.
-// If no upstream is configured, hasRemote is false and counts are 0.
-func getUpstreamInfo(worktreePath string) (ahead, behind int, hasRemote bool, trackingBranch string) {
-	out, err := cmdexec.Output(context.TODO(), "git", []string{"rev-list", "--count", "--left-right", "@{upstream}...HEAD"}, worktreePath, cmdexec.GitLocal)
-	if err != nil {
-		return 0, 0, false, ""
-	}
-
-	parts := strings.Fields(strings.TrimSpace(string(out)))
-	if len(parts) != 2 {
-		return 0, 0, false, ""
-	}
-
-	b, _ := strconv.Atoi(parts[0])
-	a, _ := strconv.Atoi(parts[1])
-
-	// Get the tracking branch name
-	tbOut, tbErr := cmdexec.Output(context.TODO(), "git", []string{"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"}, worktreePath, cmdexec.GitLocal)
-	if tbErr == nil {
-		trackingBranch = strings.TrimSpace(string(tbOut))
-	}
-
-	return a, b, true, trackingBranch
-}
-
-// getCommitCountAhead returns the number of commits a worktree branch is ahead
-// of the default branch. Returns 0 if on the default branch or on error.
-func getCommitCountAhead(worktreePath, defaultBranch string) int {
-	out, err := cmdexec.Output(context.TODO(), "git", []string{"rev-list", "--count", defaultBranch + "..HEAD"}, worktreePath, cmdexec.GitLocal)
-	if err != nil {
-		return 0
-	}
-	count, _ := strconv.Atoi(strings.TrimSpace(string(out)))
-	return count
-}
-
-// getRecentCommits returns the last n commits (SHA + subject) for a worktree.
-func getRecentCommits(worktreePath string, n int) []RecentCommit {
-	out, err := cmdexec.Output(context.TODO(), "git", []string{"log", fmt.Sprintf("-%d", n), "--format=%h %s"}, worktreePath, cmdexec.GitLocal)
-	if err != nil {
-		return nil
-	}
-	raw := strings.TrimSpace(string(out))
-	if raw == "" {
-		return nil
-	}
-	lines := strings.Split(raw, "\n")
-	commits := make([]RecentCommit, 0, len(lines))
-	for _, line := range lines {
-		if sha, msg, ok := strings.Cut(line, " "); ok {
-			commits = append(commits, RecentCommit{SHA: sha, Message: msg})
-		}
-	}
-	return commits
-}
-
-// getStashCount returns the number of stashes in a worktree.
-func getStashCount(worktreePath string) int {
-	out, err := cmdexec.Output(context.TODO(), "git", []string{"stash", "list"}, worktreePath, cmdexec.GitLocal)
-	if err != nil {
-		return 0
-	}
-	raw := strings.TrimSpace(string(out))
-	if raw == "" {
-		return 0
-	}
-	return len(strings.Split(raw, "\n"))
 }
 
 // fetchContext holds preloaded data used when enriching worktree items.
@@ -280,14 +203,14 @@ func (fc *fetchContext) enrichGitInfo(item *WorktreeItem, treePath, branch strin
 		}
 	}
 
-	item.AheadCount, item.BehindCount, item.HasRemote, item.TrackingBranch = getUpstreamInfo(treePath)
+	item.AheadCount, item.BehindCount, item.HasRemote, item.TrackingBranch = worktreeinfo.UpstreamInfo(treePath)
 
 	if branch != fc.defaultBranch {
-		item.CommitCount = getCommitCountAhead(treePath, fc.defaultBranch)
+		item.CommitCount = worktreeinfo.CommitCountAhead(treePath, fc.defaultBranch)
 	}
 
-	item.RecentCommits = getRecentCommits(treePath, 3)
-	item.StashCount = getStashCount(treePath)
+	item.RecentCommits = worktreeinfo.RecentCommits(treePath, 3)
+	item.StashCount = worktreeinfo.StashCount(treePath)
 }
 
 // FetchWorktrees gathers all enriched worktree data for display.

--- a/internal/tui/detail_v2_test.go
+++ b/internal/tui/detail_v2_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/lost-in-the/grove/internal/worktreeinfo"
 )
 
 func TestRenderDetailV2_NilItem(t *testing.T) {
@@ -239,7 +241,7 @@ func TestRenderDetailV2_RecentCommits(t *testing.T) {
 	item := &WorktreeItem{
 		ShortName: "test",
 		Branch:    "main",
-		RecentCommits: []RecentCommit{
+		RecentCommits: []worktreeinfo.RecentCommit{
 			{SHA: "abc1234", Message: "fix: resolve bug"},
 			{SHA: "def5678", Message: "feat: add login"},
 			{SHA: "ghi9012", Message: "chore: update deps"},
@@ -414,7 +416,7 @@ func TestRenderDetailV2_CommitSHAStyle(t *testing.T) {
 	item := &WorktreeItem{
 		ShortName: "test",
 		Branch:    "main",
-		RecentCommits: []RecentCommit{
+		RecentCommits: []worktreeinfo.RecentCommit{
 			{SHA: "abc1234", Message: "test msg"},
 		},
 	}

--- a/internal/tui/integration_helpers_test.go
+++ b/internal/tui/integration_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/lost-in-the/grove/internal/testhelper"
+	"github.com/lost-in-the/grove/internal/worktreeinfo"
 )
 
 // gitEnv returns environment variables for isolated git operations.
@@ -54,9 +55,9 @@ func writeFile(t *testing.T, path, content string) {
 	testhelper.WriteFile(t, path, content)
 }
 
-// getUpstreamCounts is a thin test-only wrapper around getUpstreamInfo
+// getUpstreamCounts is a thin test-only wrapper around worktreeinfo.UpstreamInfo
 // that returns just the (ahead, behind) counts for assertion simplicity.
 func getUpstreamCounts(worktreePath string) (ahead, behind int) {
-	a, b, _, _ := getUpstreamInfo(worktreePath)
+	a, b, _, _ := worktreeinfo.UpstreamInfo(worktreePath)
 	return a, b
 }

--- a/internal/tui/sync_status_test.go
+++ b/internal/tui/sync_status_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/lost-in-the/grove/internal/worktreeinfo"
 )
 
 // syncStatusText returns a compact sync status string for testing.
@@ -149,14 +151,14 @@ func TestRenderDetailV2_SyncWithHasRemote(t *testing.T) {
 }
 
 func TestGetUpstreamInfo_InvalidPath(t *testing.T) {
-	ahead, behind, hasRemote, trackingBranch := getUpstreamInfo("/nonexistent/path")
+	ahead, behind, hasRemote, trackingBranch := worktreeinfo.UpstreamInfo("/nonexistent/path")
 	if hasRemote {
-		t.Error("getUpstreamInfo() should return hasRemote=false for nonexistent path")
+		t.Error("UpstreamInfo() should return hasRemote=false for nonexistent path")
 	}
 	if ahead != 0 || behind != 0 {
-		t.Errorf("getUpstreamInfo() = (%d, %d, _, _), want (0, 0, _, _)", ahead, behind)
+		t.Errorf("UpstreamInfo() = (%d, %d, _, _), want (0, 0, _, _)", ahead, behind)
 	}
 	if trackingBranch != "" {
-		t.Errorf("getUpstreamInfo() trackingBranch = %q, want empty", trackingBranch)
+		t.Errorf("UpstreamInfo() trackingBranch = %q, want empty", trackingBranch)
 	}
 }

--- a/internal/worktreeinfo/info.go
+++ b/internal/worktreeinfo/info.go
@@ -1,0 +1,102 @@
+// Package worktreeinfo provides shared git data-fetching helpers used by
+// multiple grove commands and the TUI to read per-worktree state.
+package worktreeinfo
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/lost-in-the/grove/internal/cmdexec"
+)
+
+// RecentCommit holds a short SHA and subject line for a single commit.
+type RecentCommit struct {
+	SHA     string `json:"sha"`
+	Message string `json:"message"`
+}
+
+// UpstreamInfo returns upstream tracking information for the worktree at
+// worktreePath. hasRemote is false whenever no upstream is configured or
+// the rev-list output is malformed; in that case ahead, behind are 0 and
+// trackingBranch is empty.
+func UpstreamInfo(worktreePath string) (ahead, behind int, hasRemote bool, trackingBranch string) {
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"rev-list", "--count", "--left-right", "@{upstream}...HEAD"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return 0, 0, false, ""
+	}
+
+	parts := strings.Fields(strings.TrimSpace(string(out)))
+	if len(parts) != 2 {
+		return 0, 0, false, ""
+	}
+
+	b, _ := strconv.Atoi(parts[0])
+	a, _ := strconv.Atoi(parts[1])
+
+	tbOut, tbErr := cmdexec.Output(context.TODO(), "git",
+		[]string{"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"},
+		worktreePath, cmdexec.GitLocal)
+	if tbErr == nil {
+		trackingBranch = strings.TrimSpace(string(tbOut))
+	}
+
+	return a, b, true, trackingBranch
+}
+
+// CommitCountAhead returns the number of commits the worktree branch is ahead
+// of defaultBranch. Returns 0 if on the default branch, if defaultBranch does
+// not exist, or on any git error.
+func CommitCountAhead(worktreePath, defaultBranch string) int {
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"rev-list", "--count", defaultBranch + "..HEAD"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return 0
+	}
+	count, _ := strconv.Atoi(strings.TrimSpace(string(out)))
+	return count
+}
+
+// RecentCommits returns the last n commits (short SHA + subject) for the
+// worktree at worktreePath. Returns nil on error, on an empty repository,
+// or when n produces no output.
+func RecentCommits(worktreePath string, n int) []RecentCommit {
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"log", fmt.Sprintf("-%d", n), "--format=%h %s"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return nil
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil
+	}
+	lines := strings.Split(raw, "\n")
+	commits := make([]RecentCommit, 0, len(lines))
+	for _, line := range lines {
+		if sha, msg, ok := strings.Cut(line, " "); ok {
+			commits = append(commits, RecentCommit{SHA: sha, Message: msg})
+		}
+	}
+	return commits
+}
+
+// StashCount returns the number of stashes in the worktree at worktreePath.
+// Returns 0 on error or when there are no stashes.
+func StashCount(worktreePath string) int {
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"stash", "list"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return 0
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return 0
+	}
+	return len(strings.Split(raw, "\n"))
+}

--- a/internal/worktreeinfo/info_test.go
+++ b/internal/worktreeinfo/info_test.go
@@ -1,0 +1,408 @@
+package worktreeinfo_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/worktreeinfo"
+)
+
+// setupRepo initializes a bare git repo in a temp dir, configures user
+// identity, and makes one empty initial commit on the given branch.
+// Returns the repo path.
+func setupRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("setup: %s: %v\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@example.com")
+	run("git", "config", "user.name", "Test User")
+	run("git", "commit", "--allow-empty", "-m", "initial commit")
+
+	return dir
+}
+
+// gitRun runs a git command in dir and fails the test on error.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecentCommit JSON tags
+// ---------------------------------------------------------------------------
+
+func TestRecentCommit_JSONTags(t *testing.T) {
+	rc := worktreeinfo.RecentCommit{SHA: "abc1234", Message: "hello world"}
+	data, err := json.Marshal(rc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if _, ok := m["sha"]; !ok {
+		t.Errorf("expected JSON key 'sha', got keys: %v", m)
+	}
+	if _, ok := m["message"]; !ok {
+		t.Errorf("expected JSON key 'message', got keys: %v", m)
+	}
+	if v, _ := m["sha"].(string); v != "abc1234" {
+		t.Errorf("sha = %q, want abc1234", v)
+	}
+	if v, _ := m["message"].(string); v != "hello world" {
+		t.Errorf("message = %q, want hello world", v)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpstreamInfo
+// ---------------------------------------------------------------------------
+
+func TestUpstreamInfo_NoUpstream(t *testing.T) {
+	dir := setupRepo(t)
+	ahead, behind, hasRemote, trackingBranch := worktreeinfo.UpstreamInfo(dir)
+	if hasRemote {
+		t.Errorf("hasRemote = true, want false (no upstream configured)")
+	}
+	if ahead != 0 || behind != 0 {
+		t.Errorf("ahead=%d behind=%d, want 0 0", ahead, behind)
+	}
+	if trackingBranch != "" {
+		t.Errorf("trackingBranch = %q, want empty", trackingBranch)
+	}
+}
+
+func TestUpstreamInfo_InSync(t *testing.T) {
+	// Create a "remote" (bare clone) and a local clone tracking it.
+	bare := t.TempDir()
+	gitRun(t, bare, "init", "--bare", "-b", "main")
+
+	// Seed the bare repo with one commit via a temporary clone.
+	seed := t.TempDir()
+	gitRun(t, seed, "clone", bare, ".")
+	gitRun(t, seed, "config", "user.email", "test@example.com")
+	gitRun(t, seed, "config", "user.name", "Test User")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "initial commit")
+	gitRun(t, seed, "push", "origin", "main")
+
+	// Main working clone.
+	local := t.TempDir()
+	gitRun(t, local, "clone", bare, ".")
+	gitRun(t, local, "config", "user.email", "test@example.com")
+	gitRun(t, local, "config", "user.name", "Test User")
+
+	ahead, behind, hasRemote, trackingBranch := worktreeinfo.UpstreamInfo(local)
+	if !hasRemote {
+		t.Errorf("hasRemote = false, want true")
+	}
+	if ahead != 0 || behind != 0 {
+		t.Errorf("ahead=%d behind=%d, want 0 0", ahead, behind)
+	}
+	if trackingBranch == "" {
+		t.Errorf("trackingBranch is empty, want non-empty")
+	}
+}
+
+func TestUpstreamInfo_AheadByN(t *testing.T) {
+	bare := t.TempDir()
+	gitRun(t, bare, "init", "--bare", "-b", "main")
+
+	seed := t.TempDir()
+	gitRun(t, seed, "clone", bare, ".")
+	gitRun(t, seed, "config", "user.email", "test@example.com")
+	gitRun(t, seed, "config", "user.name", "Test User")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "initial commit")
+	gitRun(t, seed, "push", "origin", "main")
+
+	local := t.TempDir()
+	gitRun(t, local, "clone", bare, ".")
+	gitRun(t, local, "config", "user.email", "test@example.com")
+	gitRun(t, local, "config", "user.name", "Test User")
+
+	// Add 2 local commits not pushed.
+	gitRun(t, local, "commit", "--allow-empty", "-m", "local commit 1")
+	gitRun(t, local, "commit", "--allow-empty", "-m", "local commit 2")
+
+	ahead, behind, hasRemote, _ := worktreeinfo.UpstreamInfo(local)
+	if !hasRemote {
+		t.Errorf("hasRemote = false, want true")
+	}
+	if ahead != 2 {
+		t.Errorf("ahead = %d, want 2", ahead)
+	}
+	if behind != 0 {
+		t.Errorf("behind = %d, want 0", behind)
+	}
+}
+
+func TestUpstreamInfo_BehindByM(t *testing.T) {
+	bare := t.TempDir()
+	gitRun(t, bare, "init", "--bare", "-b", "main")
+
+	seed := t.TempDir()
+	gitRun(t, seed, "clone", bare, ".")
+	gitRun(t, seed, "config", "user.email", "test@example.com")
+	gitRun(t, seed, "config", "user.name", "Test User")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "initial commit")
+	gitRun(t, seed, "push", "origin", "main")
+
+	local := t.TempDir()
+	gitRun(t, local, "clone", bare, ".")
+	gitRun(t, local, "config", "user.email", "test@example.com")
+	gitRun(t, local, "config", "user.name", "Test User")
+
+	// Push 3 more commits via seed so local is behind.
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "remote commit 1")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "remote commit 2")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "remote commit 3")
+	gitRun(t, seed, "push", "origin", "main")
+
+	// Fetch but don't merge.
+	gitRun(t, local, "fetch", "origin")
+
+	ahead, behind, hasRemote, _ := worktreeinfo.UpstreamInfo(local)
+	if !hasRemote {
+		t.Errorf("hasRemote = false, want true")
+	}
+	if behind != 3 {
+		t.Errorf("behind = %d, want 3", behind)
+	}
+	if ahead != 0 {
+		t.Errorf("ahead = %d, want 0", ahead)
+	}
+}
+
+func TestUpstreamInfo_AheadAndBehind(t *testing.T) {
+	bare := t.TempDir()
+	gitRun(t, bare, "init", "--bare", "-b", "main")
+
+	seed := t.TempDir()
+	gitRun(t, seed, "clone", bare, ".")
+	gitRun(t, seed, "config", "user.email", "test@example.com")
+	gitRun(t, seed, "config", "user.name", "Test User")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "initial commit")
+	gitRun(t, seed, "push", "origin", "main")
+
+	local := t.TempDir()
+	gitRun(t, local, "clone", bare, ".")
+	gitRun(t, local, "config", "user.email", "test@example.com")
+	gitRun(t, local, "config", "user.name", "Test User")
+
+	// Local adds 1 commit.
+	gitRun(t, local, "commit", "--allow-empty", "-m", "local commit")
+
+	// Remote adds 2 commits.
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "remote commit 1")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "remote commit 2")
+	gitRun(t, seed, "push", "origin", "main")
+
+	// Fetch remote changes (but don't merge; local is diverged).
+	gitRun(t, local, "fetch", "origin")
+
+	ahead, behind, hasRemote, _ := worktreeinfo.UpstreamInfo(local)
+	if !hasRemote {
+		t.Errorf("hasRemote = false, want true")
+	}
+	if ahead != 1 {
+		t.Errorf("ahead = %d, want 1", ahead)
+	}
+	if behind != 2 {
+		t.Errorf("behind = %d, want 2", behind)
+	}
+}
+
+func TestUpstreamInfo_NonexistentPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+	ahead, behind, hasRemote, trackingBranch := worktreeinfo.UpstreamInfo(dir)
+	if hasRemote {
+		t.Errorf("hasRemote = true, want false for nonexistent path")
+	}
+	if ahead != 0 || behind != 0 {
+		t.Errorf("ahead=%d behind=%d, want 0 0", ahead, behind)
+	}
+	if trackingBranch != "" {
+		t.Errorf("trackingBranch = %q, want empty", trackingBranch)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CommitCountAhead
+// ---------------------------------------------------------------------------
+
+func TestCommitCountAhead_OnDefaultBranch(t *testing.T) {
+	dir := setupRepo(t)
+	count := worktreeinfo.CommitCountAhead(dir, "main")
+	if count != 0 {
+		t.Errorf("count = %d, want 0 (on default branch)", count)
+	}
+}
+
+func TestCommitCountAhead_ThreeAhead(t *testing.T) {
+	dir := setupRepo(t)
+	gitRun(t, dir, "checkout", "-b", "feature")
+	gitRun(t, dir, "commit", "--allow-empty", "-m", "feat 1")
+	gitRun(t, dir, "commit", "--allow-empty", "-m", "feat 2")
+	gitRun(t, dir, "commit", "--allow-empty", "-m", "feat 3")
+
+	count := worktreeinfo.CommitCountAhead(dir, "main")
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+}
+
+func TestCommitCountAhead_NonexistentDefaultBranch(t *testing.T) {
+	dir := setupRepo(t)
+	count := worktreeinfo.CommitCountAhead(dir, "nonexistent-branch")
+	if count != 0 {
+		t.Errorf("count = %d, want 0 (nonexistent branch)", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecentCommits
+// ---------------------------------------------------------------------------
+
+func TestRecentCommits_FiveCommitsGetThree(t *testing.T) {
+	dir := setupRepo(t)
+	messages := []string{"commit two", "commit three", "commit four", "commit five"}
+	for _, msg := range messages {
+		gitRun(t, dir, "commit", "--allow-empty", "-m", msg)
+	}
+
+	commits := worktreeinfo.RecentCommits(dir, 3)
+	if len(commits) != 3 {
+		t.Fatalf("len(commits) = %d, want 3", len(commits))
+	}
+
+	// Most recent first.
+	if commits[0].Message != "commit five" {
+		t.Errorf("commits[0].Message = %q, want 'commit five'", commits[0].Message)
+	}
+	if commits[1].Message != "commit four" {
+		t.Errorf("commits[1].Message = %q, want 'commit four'", commits[1].Message)
+	}
+	if commits[2].Message != "commit three" {
+		t.Errorf("commits[2].Message = %q, want 'commit three'", commits[2].Message)
+	}
+
+	// SHA should be non-empty (short hash).
+	for i, c := range commits {
+		if c.SHA == "" {
+			t.Errorf("commits[%d].SHA is empty", i)
+		}
+	}
+}
+
+func TestRecentCommits_EmptyRepo(t *testing.T) {
+	// Repo with no commits at all (orphan).
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "-b", "main")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	// Configure identity but make NO commits.
+	gitRunUnconfigured := func(args ...string) {
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		c.CombinedOutput() //nolint:errcheck
+	}
+	gitRunUnconfigured("config", "user.email", "test@example.com")
+	gitRunUnconfigured("config", "user.name", "Test User")
+
+	commits := worktreeinfo.RecentCommits(dir, 3)
+	if commits != nil {
+		t.Errorf("commits = %v, want nil for empty repo", commits)
+	}
+}
+
+func TestRecentCommits_NEqualsZero(t *testing.T) {
+	dir := setupRepo(t)
+	commits := worktreeinfo.RecentCommits(dir, 0)
+	// n=0 passes -0 to git log; git treats it as "no limit" — but
+	// our implementation returns nil/empty because git -0 outputs nothing.
+	// Either nil or empty slice is acceptable; we just verify no panic.
+	_ = commits
+}
+
+func TestRecentCommits_MultiWordMessage(t *testing.T) {
+	dir := setupRepo(t)
+	msg := "fix: handle the edge case with spaces in message"
+	gitRun(t, dir, "commit", "--allow-empty", "-m", msg)
+
+	commits := worktreeinfo.RecentCommits(dir, 1)
+	if len(commits) == 0 {
+		t.Fatal("expected 1 commit, got 0")
+	}
+	if commits[0].Message != msg {
+		t.Errorf("message = %q, want %q", commits[0].Message, msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StashCount
+// ---------------------------------------------------------------------------
+
+func TestStashCount_NoStashes(t *testing.T) {
+	dir := setupRepo(t)
+	count := worktreeinfo.StashCount(dir)
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+}
+
+func TestStashCount_TwoStashes(t *testing.T) {
+	dir := setupRepo(t)
+
+	// Create and commit a tracked file.
+	f := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(f, []byte("initial content"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	gitRun(t, dir, "add", "file.txt")
+	gitRun(t, dir, "commit", "-m", "add file.txt")
+
+	// Stash 1: change to "stash-one".
+	if err := os.WriteFile(f, []byte("stash-one"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	gitRun(t, dir, "stash")
+
+	// Restore a different base so stash 2 has different content.
+	if err := os.WriteFile(f, []byte("between stashes"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	gitRun(t, dir, "add", "file.txt")
+	gitRun(t, dir, "commit", "-m", "update file between stashes")
+
+	// Stash 2: change to "stash-two".
+	if err := os.WriteFile(f, []byte("stash-two"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	gitRun(t, dir, "stash")
+
+	count := worktreeinfo.StashCount(dir)
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `internal/worktreeinfo` with four public helpers (`UpstreamInfo`, `CommitCountAhead`, `RecentCommits`, `StashCount`) and a shared `RecentCommit` struct with JSON tags
- Deletes duplicate private implementations from `internal/tui/data.go` and `cmd/grove/commands/context_cmd.go`
- Migrates all call sites and test references to the new package

Closes #73

## TDD audit trail

Two commits tell the story:

1. **RED** -- all 16 tests written first, confirmed failing with "no non-test Go files" before any production code existed. Tests cover: JSON tags, 6 UpstreamInfo scenarios (no-remote, in-sync, ahead, behind, both, nonexistent path), 3 CommitCountAhead scenarios, 4 RecentCommits scenarios, and 2 StashCount scenarios.

2. **GREEN + migration** -- minimal implementation to pass the tests, then consumers migrated. `make lint`, `make test`, and `make test-integration` all pass.

## Schema stability

`contextOutput.RecentCommits` field type changed from local `contextRecentCommit` to `worktreeinfo.RecentCommit` -- both carry identical json tags. JSON output of `grove context --json` is byte-identical.

## Test plan

- [ ] `make lint` -- 0 issues
- [ ] `make test` -- all packages pass including new `internal/worktreeinfo`
- [ ] `make test-integration` -- TUI integration tests pass