### PR TITLE
refactor(docker): share run+translate helper across strategies; fix agent strategy error translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compose `--env-file` is honored when reading the active-worktree env var (previously hardcoded to `.env`)
 
 ### Fixed
+- Agent docker strategy now applies the same error translation as local and external strategies — dependency-failure rewrites and `--with-deps` hints now surface for users on the agent strategy (closes #72)
 - `teeBuffer` (Docker compose stderr capture) now correctly caps single writes larger than the 8KB sliding window — the previous path stored the full oversized chunk before trimming, briefly exceeding the cap
 - `grove test` now translates `compose run` "service didn't complete successfully" errors into actionable grove-styled messages
 - `grove up` no longer silently swallows compose-up failures when the post-up health probe returns no statuses

--- a/plugins/docker/agent_external.go
+++ b/plugins/docker/agent_external.go
@@ -217,10 +217,7 @@ func (s *agentExternalStrategy) Run(worktreePath string, service string, command
 	}
 
 	cmd := agentComposeCommand(ac.composePath, ac.templatePaths, ac.projectName, env, "run", "--rm", service, "bash", "-cil", command)
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
-	return cmd.Run()
+	return runWithErrorTranslation(cmd, s.cfg.Test.IncludeDepsValue())
 }
 
 // Exec runs a command in an already-running agent container.

--- a/plugins/docker/external.go
+++ b/plugins/docker/external.go
@@ -164,14 +164,7 @@ func (s *externalStrategy) Run(worktreePath string, service string, command stri
 	args := buildRunArgs(s.cfg, worktreePath, service, command)
 
 	cmd := composeCommand(s.composePath(), s.ext.EnvFileName(), env, args...)
-	cmd.Stdout = os.Stderr
-	stderrBuf := &teeBuffer{w: os.Stderr}
-	cmd.Stderr = stderrBuf
-	cmd.Stdin = os.Stdin
-	if err := cmd.Run(); err != nil {
-		return translateRunError(stderrBuf.String(), err, s.cfg.Test.IncludeDepsValue())
-	}
-	return nil
+	return runWithErrorTranslation(cmd, s.cfg.Test.IncludeDepsValue())
 }
 
 // Exec runs a command in an already-running container of the external compose.

--- a/plugins/docker/local.go
+++ b/plugins/docker/local.go
@@ -128,14 +128,7 @@ func (s *localStrategy) Run(worktreePath string, service string, command string)
 
 	args := buildRunArgs(s.cfg, worktreePath, service, command)
 	cmd := composeCommand(worktreePath, "", nil, args...)
-	cmd.Stdout = os.Stderr
-	stderrBuf := &teeBuffer{w: os.Stderr}
-	cmd.Stderr = stderrBuf
-	cmd.Stdin = os.Stdin
-	if err := cmd.Run(); err != nil {
-		return translateRunError(stderrBuf.String(), err, s.cfg.Test.IncludeDepsValue())
-	}
-	return nil
+	return runWithErrorTranslation(cmd, s.cfg.Test.IncludeDepsValue())
 }
 
 // Exec runs a command in an already-running container (compose exec).

--- a/plugins/docker/run_helpers.go
+++ b/plugins/docker/run_helpers.go
@@ -1,0 +1,25 @@
+package docker
+
+import (
+	"os"
+	"os/exec"
+)
+
+// runWithErrorTranslation runs cmd, mirroring its output to os.Stderr while
+// capturing the last 8KB of stderr in a teeBuffer. On non-nil exit, the
+// captured stderr is fed to translateRunError(stderr, err, includeDeps) for
+// dependency-failure rewriting and --no-deps hint detection. Stdin is wired
+// through so interactive commands work.
+//
+// All three docker strategies (local, external, agent) call this so error
+// translation stays consistent across them.
+func runWithErrorTranslation(cmd *exec.Cmd, includeDeps bool) error {
+	cmd.Stdout = os.Stderr
+	stderrBuf := &teeBuffer{w: os.Stderr}
+	cmd.Stderr = stderrBuf
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		return translateRunError(stderrBuf.String(), err, includeDeps)
+	}
+	return nil
+}

--- a/plugins/docker/run_helpers_test.go
+++ b/plugins/docker/run_helpers_test.go
@@ -1,0 +1,76 @@
+package docker
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRunWithErrorTranslation_Success verifies that a zero-exit command returns nil.
+func TestRunWithErrorTranslation_Success(t *testing.T) {
+	cmd := exec.Command("true")
+	if err := runWithErrorTranslation(cmd, false); err != nil {
+		t.Fatalf("expected nil for zero-exit cmd, got: %v", err)
+	}
+}
+
+// TestRunWithErrorTranslation_FailureEmptyStderr verifies that a non-zero exit with no
+// stderr output passes the original error through unchanged.
+func TestRunWithErrorTranslation_FailureEmptyStderr(t *testing.T) {
+	cmd := exec.Command("false")
+	err := runWithErrorTranslation(cmd, false)
+	if err == nil {
+		t.Fatal("expected non-nil error for non-zero exit")
+	}
+	// translateRunError returns original on empty stderr, so error text should
+	// not include any grove hint.
+	if strings.Contains(err.Error(), "--with-deps") {
+		t.Errorf("unexpected hint in error for empty-stderr case: %v", err)
+	}
+	if strings.Contains(err.Error(), "dependency") {
+		t.Errorf("unexpected dependency rewrite for empty-stderr case: %v", err)
+	}
+}
+
+// TestRunWithErrorTranslation_ConnectionRefused_NoIncludeDeps verifies that a
+// connection-refused stderr produces the --with-deps hint when includeDeps=false.
+func TestRunWithErrorTranslation_ConnectionRefused_NoIncludeDeps(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo 'connection refused' >&2; exit 1")
+	err := runWithErrorTranslation(cmd, false)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !strings.Contains(err.Error(), "--with-deps") {
+		t.Errorf("expected --with-deps hint, got: %v", err)
+	}
+}
+
+// TestRunWithErrorTranslation_ConnectionRefused_IncludeDeps verifies that the
+// --with-deps hint is suppressed when includeDeps=true.
+func TestRunWithErrorTranslation_ConnectionRefused_IncludeDeps(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo 'connection refused' >&2; exit 1")
+	err := runWithErrorTranslation(cmd, true)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if strings.Contains(err.Error(), "--with-deps") {
+		t.Errorf("expected no --with-deps hint when includeDeps=true, got: %v", err)
+	}
+}
+
+// TestRunWithErrorTranslation_DependencyFailure verifies that a compose
+// "didn't complete successfully" stderr triggers the dependency-failure rewrite.
+func TestRunWithErrorTranslation_DependencyFailure(t *testing.T) {
+	cmd := exec.Command("sh", "-c", `echo 'service "postgres" didn'"'"'t complete successfully: exit 1' >&2; exit 1`)
+	err := runWithErrorTranslation(cmd, false)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "postgres") {
+		t.Errorf("expected service name 'postgres' in rewritten error, got: %v", err)
+	}
+	if !strings.Contains(msg, "unrelated") {
+		t.Errorf("expected 'unrelated' in rewritten dependency-failure message, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts `runWithErrorTranslation` helper in `plugins/docker/run_helpers.go` — wires `teeBuffer` capture, `translateRunError` dispatch, and stdin/stdout routing in one place
- Migrates `localStrategy.Run` and `externalStrategy.Run` to call the helper (net -12 lines of duplication removed)
- Fixes `agentExternalStrategy.Run` which was calling `cmd.Run()` directly, bypassing all error translation — dependency-failure rewrites and `--with-deps` hints now surface for agent-strategy users

## Test plan

- [ ] `plugins/docker/run_helpers_test.go` — 5 new tests covering: zero-exit nil return, empty-stderr passthrough, connection-refused with hint, connection-refused hint suppressed when `includeDeps=true`, dependency-failure rewrite
- [ ] All existing `run_error_test.go` tests pass unchanged (they test `translateRunError` directly)
- [ ] `make lint test` green

closes #72