### PR TITLE
feat(version): annotate output when newer release cached

### DIFF
--- a/cmd/grove/commands/version.go
+++ b/cmd/grove/commands/version.go
@@ -2,10 +2,8 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/lost-in-the/grove/internal/updatecheck"
 	"github.com/lost-in-the/grove/internal/version"
@@ -22,7 +20,12 @@ var versionCmd = &cobra.Command{
 		} else {
 			output = version.GetVersion()
 		}
-		if term.IsTerminal(int(os.Stdout.Fd())) {
+		// Annotate only when we'd otherwise notify the user about updates.
+		// Skip honors CI/non-TTY/dev-version/opt-out env vars (NO_UPDATE_NOTIFIER,
+		// GROVE_NO_UPDATE_NOTIFIER, GROVE_AGENT_MODE, GROVE_NONINTERACTIVE).
+		// We pass false for the --no-update-notifier flag because the version cmd
+		// doesn't accept it; the env-var path covers the user-level opt-outs.
+		if !updatecheck.Skip(false, version.Version) {
 			output += updatecheck.CachedUpdateAnnotation(version.Version)
 		}
 		fmt.Println(output)

--- a/cmd/grove/commands/version.go
+++ b/cmd/grove/commands/version.go
@@ -2,9 +2,12 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
+	"github.com/lost-in-the/grove/internal/updatecheck"
 	"github.com/lost-in-the/grove/internal/version"
 )
 
@@ -13,11 +16,16 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Long:  `Print the version number of grove along with build information.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var output string
 		if verbose, _ := cmd.Flags().GetBool("verbose"); verbose {
-			fmt.Println(version.GetFullVersion())
+			output = version.GetFullVersion()
 		} else {
-			fmt.Println(version.GetVersion())
+			output = version.GetVersion()
 		}
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			output += updatecheck.CachedUpdateAnnotation(version.Version)
+		}
+		fmt.Println(output)
 	},
 }
 

--- a/internal/updatecheck/check.go
+++ b/internal/updatecheck/check.go
@@ -38,6 +38,27 @@ func renderUpdateBox(w io.Writer, currentVersion, latestVersion, latestURL strin
 	return true
 }
 
+// CachedUpdateAnnotation returns a parenthetical annotation like
+// " (update available: 0.7.0)" when the cache indicates a newer version is
+// available. Returns "" otherwise (no cache, equal or older version).
+//
+// Use case: annotating `grove version` output so users see at a glance
+// whether their installed binary is behind.
+func CachedUpdateAnnotation(currentVersion string) string {
+	return cachedUpdateAnnotationFromPath(currentVersion, DefaultCachePath())
+}
+
+func cachedUpdateAnnotationFromPath(currentVersion, path string) string {
+	c, err := ReadCacheFromPath(path)
+	if err != nil || c.LatestVersion == "" {
+		return ""
+	}
+	if CompareSemver(currentVersion, c.LatestVersion) == SeverityNone {
+		return ""
+	}
+	return " (update available: " + c.LatestVersion + ")"
+}
+
 // CheckInterval is the default minimum gap between two refreshes.
 const CheckInterval = 24 * time.Hour
 

--- a/internal/updatecheck/check_test.go
+++ b/internal/updatecheck/check_test.go
@@ -178,3 +178,47 @@ func TestCheckNow_FetchFailureReturnsError(t *testing.T) {
 		t.Error("expected error on fetch failure")
 	}
 }
+
+func TestCachedUpdateAnnotation_NewerCachedVersionReturnsAnnotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{LatestVersion: "0.7.0", LatestURL: "https://x"})
+
+	got := cachedUpdateAnnotationFromPath("0.6.0", path)
+	want := " (update available: 0.7.0)"
+	if got != want {
+		t.Errorf("annotation = %q, want %q", got, want)
+	}
+}
+
+func TestCachedUpdateAnnotation_EqualVersionReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{LatestVersion: "0.6.0"})
+
+	got := cachedUpdateAnnotationFromPath("0.6.0", path)
+	if got != "" {
+		t.Errorf("expected empty for equal version, got %q", got)
+	}
+}
+
+func TestCachedUpdateAnnotation_MissingCacheReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.json")
+
+	got := cachedUpdateAnnotationFromPath("0.6.0", path)
+	if got != "" {
+		t.Errorf("expected empty for missing cache, got %q", got)
+	}
+}
+
+func TestCachedUpdateAnnotation_OlderCachedVersionReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{LatestVersion: "0.5.0"})
+
+	got := cachedUpdateAnnotationFromPath("0.6.0", path)
+	if got != "" {
+		t.Errorf("expected empty for older cached version, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Annotates `grove version` output when the update-check cache (populated by #35 / PR #76) shows a newer release is available.

- Before: `grove 0.6.0 darwin/arm64`
- After (when cache shows 0.7.0): `grove 0.6.0 darwin/arm64 (update available: 0.7.0)`

Annotation is only added when stdout is a TTY, so scripted use like `version=$(grove version)` keeps clean output.

## Changes

- `internal/updatecheck/check.go`: new `CachedUpdateAnnotation` (public) + `cachedUpdateAnnotationFromPath` (testable core) — reads cache, returns `" (update available: X.Y.Z)"` only when cache has a strictly newer version (uses `CompareSemver` / `SeverityNone`); otherwise returns `""`.
- `cmd/grove/commands/version.go`: appends annotation to both default and `-v` output when stdout is a TTY (`golang.org/x/term`).
- `internal/updatecheck/check_test.go`: 4 new test cases (newer / equal / missing / older) — written first, RED → GREEN.

## Test plan

- [x] `go test ./internal/updatecheck/ -run TestCachedUpdateAnnotation -v` — 4/4 pass
- [x] `make lint test` — 0 lint issues, all packages pass
- [x] `go run ./cmd/grove version` — prints `grove 0.7.0-dev darwin/arm64` (no annotation; stdout not TTY in capture, which is the intended scripted behavior)
- [x] `go run ./cmd/grove version -v` — full version still works

Closes #78