### PR TITLE
feat(config): per-developer config overlay (.grove/config.local.toml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ docs/plans/
 .grove/state.lock
 .grove/ui_prefs.json
 .grove/.envrc
+.grove/config.local.toml
 
 # Auto Claude data directory
 .auto-claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Per-developer config overlay at `.grove/config.local.toml` (gitignored). Overrides values from the committed `.grove/config.toml` for individual developers — e.g., `[tmux] mode = "off"` for someone who prefers no tmux without changing team defaults. Precedence: defaults → global → `.grove/config.toml` → `.grove/config.local.toml` → env vars (closes #79).
 - Optional update-available notification on command exit when a newer grove release is published. Checks at most once per 24 hours, in a detached background process — never blocks command execution. Suppressed in CI, non-TTY contexts, and when `NO_UPDATE_NOTIFIER`, `GROVE_NO_UPDATE_NOTIFIER`, `GROVE_AGENT_MODE`, or `GROVE_NONINTERACTIVE` env vars are set, or when `--no-update-notifier` is passed. Use `--check-update` to force a synchronous check at any time.
 - `grove context` command — prints full worktree context (branch, commit, remote tracking/sync, status, stash count, recent commits) for CLI/scripting use; `--json` flag emits structured machine-readable output (closes #16); JSON includes `has_remote` boolean to distinguish "no remote" from "remote, in sync" (0/0 ahead/behind)
 - `grove adopt [path]` command — bootstraps a git worktree that grove doesn't know about (config symlink, state registration, post-create hooks)

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -13,18 +13,42 @@ Single source of truth for all Grove configuration options. For command behavior
 | `~/.config/grove/config.toml` | Global config — applies to all projects |
 | `~/.config/grove/hooks.toml` | Global hooks — run in every project |
 | `.grove/config.toml` | Project config — overrides global |
+| `.grove/config.local.toml` | Per-developer overlay — overrides project config (gitignored) |
 | `.grove/hooks.toml` | Project hooks — merged with (or replaces) global hooks |
 | `.grove/state.json` | Per-project runtime state managed by grove — do not edit |
 
-**Load order:** defaults → global config → project config → environment variable overrides.
+**Load order:** defaults → global config → project config → project local overlay → environment variable overrides.
 
-Project settings override global settings for all scalar fields. For `[protection]` lists,
-project entries are unioned with global entries (global protections always apply).
+Each layer overrides the one before it for scalar fields. For `[protection]` lists,
+later entries are unioned with earlier ones (earlier protections always apply).
 
 **`GROVE_CONFIG`** overrides the global config file path at runtime:
 ```sh
 GROVE_CONFIG=~/work/shared-grove.toml grove ls
 ```
+
+### Per-developer overlay (`.grove/config.local.toml`)
+
+`.grove/config.local.toml` is an optional, gitignored overlay that lets a single
+developer override values committed to `.grove/config.toml` without touching the
+team baseline. The file is missing for most users — there's no harm in not
+having one.
+
+Example: the repo commits `[tmux] mode = "auto"` for the team, but you don't
+want grove to manage tmux for you. Create `.grove/config.local.toml`:
+
+```toml
+[tmux]
+mode = "off"
+```
+
+Your grove invocations now see `mode = "off"`. Other developers, who don't have
+the file, still see the committed `auto`. The file matches the same schema as
+`.grove/config.toml` — only the fields you set are overridden, everything else
+falls through.
+
+Add `.grove/config.local.toml` to your project's `.gitignore` (grove's own
+`.gitignore` already does this).
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,7 +170,8 @@ func Load() (*Config, error) {
 		return cfg, err
 	}
 
-	return loadFromPaths(cfg, globalPath, projectPath)
+	localPath := localOverlayPathFor(projectPath)
+	return loadFromPaths(cfg, globalPath, projectPath, localPath)
 }
 
 // LoadFromGroveDir loads config using an explicit .grove directory path
@@ -194,11 +195,22 @@ func LoadFromGroveDir(groveDir string) (*Config, error) {
 	}
 	globalPath := filepath.Join(homeDir, ".config", "grove", "config.toml")
 
-	return loadFromPaths(cfg, globalPath, projectPath)
+	localPath := filepath.Join(groveDir, "config.local.toml")
+	return loadFromPaths(cfg, globalPath, projectPath, localPath)
+}
+
+// localOverlayPathFor returns the per-developer overlay path that sits next to
+// the given project config (.grove/config.toml → .grove/config.local.toml).
+// Returns empty string when projectPath is empty.
+func localOverlayPathFor(projectPath string) string {
+	if projectPath == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(projectPath), "config.local.toml")
 }
 
 // loadFromPaths is the shared config loading logic.
-func loadFromPaths(cfg *Config, globalPath, projectPath string) (*Config, error) {
+func loadFromPaths(cfg *Config, globalPath, projectPath, localPath string) (*Config, error) {
 
 	// GROVE_CONFIG overrides the global config path
 	if envConfig := os.Getenv("GROVE_CONFIG"); envConfig != "" {
@@ -227,6 +239,21 @@ func loadFromPaths(cfg *Config, globalPath, projectPath string) (*Config, error)
 			return nil, err
 		}
 		cfg = mergeConfigs(cfg, projectCfg)
+	}
+
+	// Load per-developer local overlay if it exists (overrides project).
+	// Missing file is silent; a present-but-corrupt file is a hard error.
+	if localPath != "" {
+		localCfg, err := LoadConfigFromPath(localPath)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("config.local.toml: %w", err)
+		}
+		if localCfg != nil {
+			if err := resolveProjectPaths(localCfg, projectRootFor(localPath)); err != nil {
+				return nil, fmt.Errorf("config.local.toml: %w", err)
+			}
+			cfg = mergeConfigs(cfg, localCfg)
+		}
 	}
 
 	// Apply environment variable overrides for runtime settings

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1325,6 +1325,175 @@ func TestIsExternalDockerMode(t *testing.T) {
 	}
 }
 
+func TestLoadFromGroveDir_LocalOverlay_Absent(t *testing.T) {
+	groveDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(`
+[tmux]
+mode = "auto"
+prefix = "team-"
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	// Force GROVE_CONFIG to point at a non-existent path so HOME-based global
+	// config doesn't pollute the test.
+	t.Setenv("GROVE_CONFIG", filepath.Join(groveDir, "no-such-global.toml"))
+
+	cfg, err := LoadFromGroveDir(groveDir)
+	if err != nil {
+		t.Fatalf("LoadFromGroveDir: %v", err)
+	}
+	if cfg.Tmux.Mode != "auto" {
+		t.Errorf("Tmux.Mode: got %q want %q", cfg.Tmux.Mode, "auto")
+	}
+	if cfg.Tmux.Prefix != "team-" {
+		t.Errorf("Tmux.Prefix: got %q want %q", cfg.Tmux.Prefix, "team-")
+	}
+}
+
+func TestLoadFromGroveDir_LocalOverlay_OverridesProject(t *testing.T) {
+	groveDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(`
+[tmux]
+mode = "auto"
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(groveDir, "config.local.toml"), []byte(`
+[tmux]
+mode = "off"
+`), 0o644); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	t.Setenv("GROVE_CONFIG", filepath.Join(groveDir, "no-such-global.toml"))
+
+	cfg, err := LoadFromGroveDir(groveDir)
+	if err != nil {
+		t.Fatalf("LoadFromGroveDir: %v", err)
+	}
+	if cfg.Tmux.Mode != "off" {
+		t.Errorf("Tmux.Mode: got %q want %q (local overlay should win)", cfg.Tmux.Mode, "off")
+	}
+}
+
+func TestLoadFromGroveDir_LocalOverlay_PartialOverridePreservesUntouched(t *testing.T) {
+	groveDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(`
+[tmux]
+mode = "auto"
+prefix = "team-"
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(groveDir, "config.local.toml"), []byte(`
+[tmux]
+mode = "off"
+`), 0o644); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	t.Setenv("GROVE_CONFIG", filepath.Join(groveDir, "no-such-global.toml"))
+
+	cfg, err := LoadFromGroveDir(groveDir)
+	if err != nil {
+		t.Fatalf("LoadFromGroveDir: %v", err)
+	}
+	if cfg.Tmux.Mode != "off" {
+		t.Errorf("Tmux.Mode: got %q want %q", cfg.Tmux.Mode, "off")
+	}
+	if cfg.Tmux.Prefix != "team-" {
+		t.Errorf("Tmux.Prefix: got %q want %q (untouched fields must survive overlay)", cfg.Tmux.Prefix, "team-")
+	}
+}
+
+func TestLoadFromGroveDir_LocalOverlay_EmptyFile(t *testing.T) {
+	groveDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(`
+[tmux]
+mode = "auto"
+prefix = "team-"
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(groveDir, "config.local.toml"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	t.Setenv("GROVE_CONFIG", filepath.Join(groveDir, "no-such-global.toml"))
+
+	cfg, err := LoadFromGroveDir(groveDir)
+	if err != nil {
+		t.Fatalf("LoadFromGroveDir: %v", err)
+	}
+	if cfg.Tmux.Mode != "auto" {
+		t.Errorf("Tmux.Mode: got %q want %q (empty overlay must be a no-op)", cfg.Tmux.Mode, "auto")
+	}
+	if cfg.Tmux.Prefix != "team-" {
+		t.Errorf("Tmux.Prefix: got %q want %q", cfg.Tmux.Prefix, "team-")
+	}
+}
+
+func TestLoadFromGroveDir_LocalOverlay_CorruptFile(t *testing.T) {
+	groveDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(`
+[tmux]
+mode = "auto"
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(groveDir, "config.local.toml"), []byte(`
+[tmux
+mode = "off
+`), 0o644); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	t.Setenv("GROVE_CONFIG", filepath.Join(groveDir, "no-such-global.toml"))
+
+	_, err := LoadFromGroveDir(groveDir)
+	if err == nil {
+		t.Fatal("expected error for corrupt config.local.toml, got nil")
+	}
+	if !strings.Contains(err.Error(), "config.local.toml") {
+		t.Errorf("error should mention config.local.toml, got: %v", err)
+	}
+}
+
+func TestLoadFromGroveDir_LocalOverlay_OverridesTestSection(t *testing.T) {
+	groveDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(`
+[test]
+command = "bin/rspec"
+service = "app"
+include_deps = true
+`), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(groveDir, "config.local.toml"), []byte(`
+[test]
+include_deps = false
+`), 0o644); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	t.Setenv("GROVE_CONFIG", filepath.Join(groveDir, "no-such-global.toml"))
+
+	cfg, err := LoadFromGroveDir(groveDir)
+	if err != nil {
+		t.Fatalf("LoadFromGroveDir: %v", err)
+	}
+	if cfg.Test.IncludeDepsValue() {
+		t.Error("Test.IncludeDeps: local overlay false should win over project true")
+	}
+	if cfg.Test.Command != "bin/rspec" {
+		t.Errorf("Test.Command: got %q want %q (untouched)", cfg.Test.Command, "bin/rspec")
+	}
+	if cfg.Test.Service != "app" {
+		t.Errorf("Test.Service: got %q want %q (untouched)", cfg.Test.Service, "app")
+	}
+}
+
 func TestLoadConfig_ExternalNonBlockingServices(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "config.toml")

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -242,7 +242,7 @@ services = ["app"]
 		t.Fatal(err)
 	}
 
-	cfg, err := loadFromPaths(LoadDefaults(), "/nonexistent/global.toml", configPath)
+	cfg, err := loadFromPaths(LoadDefaults(), "/nonexistent/global.toml", configPath, "")
 	if err != nil {
 		t.Fatalf("loadFromPaths() error = %v", err)
 	}


### PR DESCRIPTION
Closes #79.

## Summary

Adds a per-developer overlay file at `.grove/config.local.toml` that overrides values from the committed `.grove/config.toml`. The file is gitignored, so individual developers can deviate from the team baseline without churning the shared config.

**Precedence (lowest to highest):**

1. Code defaults (`internal/config/defaults.go`)
2. Global config (`~/.config/grove/config.toml` or `GROVE_CONFIG`)
3. `.grove/config.toml` (committed, team baseline)
4. **`.grove/config.local.toml` (gitignored, per-developer)** — new
5. Env vars (`GROVE_AGENT_MODE`, `GROVE_NONINTERACTIVE`, etc.)

**Use case:** repo commits `[tmux] mode = "auto"`; one dev creates `.grove/config.local.toml` with `[tmux] mode = "off"` and no longer gets tmux sessions, without touching anyone else's config.

## Behavior

- **Missing overlay file:** silent — most users won't have one.
- **Empty overlay file:** no-op.
- **Corrupt overlay file:** hard error, mentions `config.local.toml` in the message.
- Overlay is merged through the existing `mergeConfigs` / per-section merge functions, so every field that could be set in `.grove/config.toml` can be overridden the same way.
- Overlay goes through the same `resolveProjectPaths` and `Validate` passes as the project config.

## Files

- `internal/config/config.go` — `loadFromPaths` now takes a `localPath`; new `localOverlayPathFor` helper for the `Load()` path; both `Load()` and `LoadFromGroveDir` thread the overlay path through. Missing-file path is `os.IsNotExist`-silent; everything else wraps with `config.local.toml: %w`.
- `internal/config/config_test.go` — six new TDD-driven tests covering: absent overlay, full override, partial override (untouched fields survive), empty overlay, corrupt overlay (error mentions filename), section override (`[test]` `include_deps` flipped).
- `internal/config/paths_test.go` — updated existing `loadFromPaths` call site for the new signature.
- `.gitignore` — adds `.grove/config.local.toml`.
- `docs/CONFIGURATION_REFERENCE.md` — file table entry, updated load-order line, new "Per-developer overlay" subsection with the tmux example.
- `CHANGELOG.md` — `[Unreleased] ### Added` entry.

## Test plan

- [x] `make lint test` passes (lint clean, all config tests pass).
- [x] Smoke test with both `config.toml` and `config.local.toml` present (`grove ls` works).
- [x] Smoke test with corrupt `config.local.toml` (clear error mentioning filename).
- [x] Confirmed missing overlay is fully silent.