### PR TITLE
feat(tui): rich update-available UX (footer badge + u-keybind modal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- TUI now shows a passive `↑ X.Y.Z → X.Y+1.Z press u` footer badge when a newer grove release is available, plus a richer modal (opened via `u`) showing the install command and changelog link. Reuses the existing `~/.grove/update-check.json` cache. Suppressed in CI / non-TTY / via `GROVE_NO_UPDATE_NOTIFIER`.
 - Per-developer config overlay at `.grove/config.local.toml` (gitignored). Overrides values from the committed `.grove/config.toml` for individual developers — e.g., `[tmux] mode = "off"` for someone who prefers no tmux without changing team defaults. Precedence: defaults → global → `.grove/config.toml` → `.grove/config.local.toml` → env vars (closes #79).
 - Optional update-available notification on command exit when a newer grove release is published. Checks at most once per 24 hours, in a detached background process — never blocks command execution. Suppressed in CI, non-TTY contexts, and when `NO_UPDATE_NOTIFIER`, `GROVE_NO_UPDATE_NOTIFIER`, `GROVE_AGENT_MODE`, or `GROVE_NONINTERACTIVE` env vars are set, or when `--no-update-notifier` is passed. Use `--check-update` to force a synchronous check at any time.
 - `grove context` command — prints full worktree context (branch, commit, remote tracking/sync, status, stash count, recent commits) for CLI/scripting use; `--json` flag emits structured machine-readable output (closes #16); JSON includes `has_remote` boolean to distinguish "no remote" from "remote, in sync" (0/0 ahead/behind)

--- a/internal/tui/help_v2.go
+++ b/internal/tui/help_v2.go
@@ -196,6 +196,19 @@ func (h *HelpFooter) CompactHeight(view ActiveView, width int) int {
 	return strings.Count(rendered, "\n") + 1
 }
 
+// RenderUpdateBadge returns a muted "↑ current → latest  press u" badge string
+// suitable for appending to a footer. Returns "" when no update is available
+// (zero strings) — caller should handle the empty case.
+func RenderUpdateBadge(currentVersion, latestVersion string) string {
+	if currentVersion == "" || latestVersion == "" {
+		return ""
+	}
+	mutedStyle := lipgloss.NewStyle().Foreground(Colors.TextMuted)
+	keyStyle := lipgloss.NewStyle().Foreground(Colors.Primary).Bold(true)
+	return mutedStyle.Render("↑ "+currentVersion+" → "+latestVersion+"  press ") +
+		keyStyle.Render("u")
+}
+
 // RenderCompactWithHints renders a one- or two-line footer with the given hints
 // (instead of looking up hints by view). Used for context-specific hint sets
 // like detail-focused mode.

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -49,6 +49,9 @@ type KeyMap struct {
 	Config   key.Binding
 	Rename   key.Binding
 	Checkout key.Binding
+
+	// Update modal
+	Update key.Binding
 }
 
 // ShortHelp returns keybindings for the short help view (help.KeyMap interface).
@@ -181,6 +184,10 @@ func DefaultKeyMap() KeyMap {
 		Checkout: key.NewBinding(
 			key.WithKeys("b"),
 			key.WithHelp("b", "branch"),
+		),
+		Update: key.NewBinding(
+			key.WithKeys("u"),
+			key.WithHelp("u", "update"),
 		),
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -20,6 +20,8 @@ import (
 	"github.com/lost-in-the/grove/internal/state"
 	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/tuilog"
+	"github.com/lost-in-the/grove/internal/updatecheck"
+	"github.com/lost-in-the/grove/internal/version"
 	"github.com/lost-in-the/grove/internal/worktree"
 )
 
@@ -59,10 +61,16 @@ type Model struct {
 	help    help.Model
 
 	// V2 components
-	header      Header
-	toast       *ToastModel
-	helpFooter  *HelpFooter
-	helpOverlay *HelpOverlay
+	header        Header
+	toast         *ToastModel
+	helpFooter    *HelpFooter
+	helpOverlay   *HelpOverlay
+	updateOverlay *UpdateOverlay
+
+	// Cached update-available info, populated once at startup so we
+	// don't read the cache file on every render. Empty strings = no update.
+	updateLatestVersion string
+	updateLatestURL     string
 
 	// Keys
 	keys KeyMap
@@ -147,25 +155,33 @@ func NewModel(mgr *worktree.Manager, stateMgr *state.Manager, projectRoot string
 		pm = pluginMgr[0]
 	}
 
+	// Read update-check cache once at startup. Empty strings if no update is
+	// available (which is the common case). Reading from disk here instead of
+	// on every render keeps the hot path allocation-free.
+	latest, latestURL, _ := updatecheck.CachedRelease(version.Version)
+
 	return Model{
-		worktreeMgr:  mgr,
-		stateMgr:     stateMgr,
-		pluginMgr:    pm,
-		projectRoot:  projectRoot,
-		projectName:  mgr.GetProjectName(),
-		cfg:          cfg,
-		cfgLoadErr:   cfgErr,
-		keys:         keys,
-		list:         l,
-		listDelegate: v1Delegate,
-		compactMode:  compact,
-		spinner:      s,
-		help:         h,
-		toast:        NewToastModel(),
-		helpFooter:   NewHelpFooter(),
-		helpOverlay:  NewHelpOverlay(),
-		activeView:   ViewDashboard,
-		loading:      true,
+		worktreeMgr:         mgr,
+		stateMgr:            stateMgr,
+		pluginMgr:           pm,
+		projectRoot:         projectRoot,
+		projectName:         mgr.GetProjectName(),
+		cfg:                 cfg,
+		cfgLoadErr:          cfgErr,
+		keys:                keys,
+		list:                l,
+		listDelegate:        v1Delegate,
+		compactMode:         compact,
+		spinner:             s,
+		help:                h,
+		toast:               NewToastModel(),
+		helpFooter:          NewHelpFooter(),
+		helpOverlay:         NewHelpOverlay(),
+		updateOverlay:       NewUpdateOverlay(),
+		updateLatestVersion: latest,
+		updateLatestURL:     latestURL,
+		activeView:          ViewDashboard,
+		loading:             true,
 	}
 }
 
@@ -838,10 +854,27 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
+	// Update overlay intercepts all keys when active. Mirrors HelpOverlay's
+	// pattern from #54: both the trigger key (u) and esc close the modal.
+	if m.updateOverlay != nil && m.updateOverlay.Active {
+		if key.Matches(msg, m.keys.Update) || key.Matches(msg, m.keys.Escape) {
+			m.updateOverlay.Close()
+			return m, nil
+		}
+		return m, nil
+	}
+
 	// ? opens help for views without text input
 	// Views with active text inputs (Create, Rename, Checkout, Fork) pass ? through
 	if key.Matches(msg, m.keys.Help) && !m.viewHasTextInput() {
 		m.helpOverlay.Open(m.activeView, m.width, m.height)
+		return m, nil
+	}
+
+	// u opens the update modal when an update is available and no text input
+	// is focused. Same gating as ?-for-help.
+	if key.Matches(msg, m.keys.Update) && !m.viewHasTextInput() && m.updateAvailable() {
+		m.updateOverlay.Open(version.Version, m.updateLatestVersion, m.updateLatestURL)
 		return m, nil
 	}
 
@@ -1835,11 +1868,53 @@ func (m Model) viewForActiveView() string {
 
 // compositeHelpOverlay renders the help overlay on top of the given content if active.
 func (m Model) compositeHelpOverlay(content string) string {
+	if m.updateOverlay != nil && m.updateOverlay.Active {
+		panel := m.updateOverlay.View(m.width, m.height)
+		return centerOverlay(content, panel, m.width, m.height)
+	}
 	if m.helpOverlay.Active {
 		helpPanel := m.helpOverlay.View(m.width, m.height)
 		return centerOverlay(content, helpPanel, m.width, m.height)
 	}
 	return content
+}
+
+// updateAvailable reports whether the cached release info shows a newer
+// grove version is available than the running binary.
+func (m Model) updateAvailable() bool {
+	return m.updateLatestVersion != "" && m.updateLatestVersion != version.Version
+}
+
+// appendUpdateBadge appends a passive update-available badge to the given
+// footer when an update is cached. Returns footer unchanged otherwise.
+// The badge is appended on the same line if it fits within the width
+// budget (m.width-4), or on a new line below otherwise.
+func (m Model) appendUpdateBadge(footer string) string {
+	if !m.updateAvailable() {
+		return footer
+	}
+	badge := RenderUpdateBadge(version.Version, m.updateLatestVersion)
+	if badge == "" {
+		return footer
+	}
+
+	// Find the longest line in the footer. If the badge fits beside it with
+	// a separator, append inline; otherwise add as a new line.
+	maxLineWidth := 0
+	for _, line := range strings.Split(footer, "\n") {
+		if w := lipgloss.Width(line); w > maxLineWidth {
+			maxLineWidth = w
+		}
+	}
+	sep := Styles.HelpSep.Render("  ·  ")
+	budget := m.width - 4
+	if maxLineWidth+lipgloss.Width(sep)+lipgloss.Width(badge) <= budget {
+		// Append to the last line of the footer.
+		lines := strings.Split(footer, "\n")
+		lines[len(lines)-1] = lines[len(lines)-1] + sep + badge
+		return strings.Join(lines, "\n")
+	}
+	return footer + "\n  " + badge
 }
 
 // viewHasTextInput returns true if the active view has a focused text input
@@ -1870,6 +1945,7 @@ func (m Model) renderDashboard() string {
 	} else {
 		footer = m.helpFooter.RenderCompact(ViewDashboard, m.width-4)
 	}
+	footer = m.appendUpdateBadge(footer)
 
 	statusBar = m.applyToastToHeader(statusBar)
 
@@ -2197,6 +2273,7 @@ func RunPRs(mgr *worktree.Manager, stateMgr *state.Manager, projectRoot string, 
 	tuilog.Init()
 	defer tuilog.Close()
 
+	maybeRefreshUpdateCache()
 	model := NewModel(mgr, stateMgr, projectRoot, pluginMgr...).ConfigureForPRs()
 	return runModel(model)
 }
@@ -2206,6 +2283,7 @@ func RunIssues(mgr *worktree.Manager, stateMgr *state.Manager, projectRoot strin
 	tuilog.Init()
 	defer tuilog.Close()
 
+	maybeRefreshUpdateCache()
 	model := NewModel(mgr, stateMgr, projectRoot, pluginMgr...).ConfigureForIssues()
 	return runModel(model)
 }
@@ -2215,8 +2293,21 @@ func Run(mgr *worktree.Manager, stateMgr *state.Manager, projectRoot string, plu
 	tuilog.Init()
 	defer tuilog.Close()
 
+	maybeRefreshUpdateCache()
 	model := NewModel(mgr, stateMgr, projectRoot, pluginMgr...)
 	return runModel(model)
+}
+
+// maybeRefreshUpdateCache triggers an async refresh of the update-check cache
+// from the TUI startup path, honoring the same Skip rules as the CLI surface
+// (CI, GROVE_AGENT_MODE, GROVE_NO_UPDATE_NOTIFIER, non-TTY, dev/unknown
+// versions). The 24h interval inside RefreshAsync prevents repeated network
+// hits.
+func maybeRefreshUpdateCache() {
+	if updatecheck.Skip(false, version.Version) {
+		return
+	}
+	updatecheck.RefreshAsync()
 }
 
 // handleTmuxSwitch creates/switches to the tmux session for the target worktree.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1787,7 +1787,7 @@ func (m Model) viewContent() string {
 	if result == "" {
 		result = m.renderDashboard()
 	}
-	return m.compositeHelpOverlay(result)
+	return m.compositeActiveOverlay(result)
 }
 
 func (m Model) viewNotReady() string {
@@ -1866,8 +1866,10 @@ func (m Model) viewForActiveView() string {
 	return ""
 }
 
-// compositeHelpOverlay renders the help overlay on top of the given content if active.
-func (m Model) compositeHelpOverlay(content string) string {
+// compositeActiveOverlay renders whichever overlay (update or help) is active
+// on top of the given content. The update overlay takes precedence when both
+// are active. Returns content unchanged when no overlay is active.
+func (m Model) compositeActiveOverlay(content string) string {
 	if m.updateOverlay != nil && m.updateOverlay.Active {
 		panel := m.updateOverlay.View(m.width, m.height)
 		return centerOverlay(content, panel, m.width, m.height)

--- a/internal/tui/program_test.go
+++ b/internal/tui/program_test.go
@@ -125,6 +125,38 @@ func TestProgram_HelpOverlay_QuestionMarkToggles(t *testing.T) {
 // that TestProgram_HelpOverlay_QuestionMarkToggles verifies the overlay's
 // open/closed state machine end-to-end.
 
+func TestProgram_UpdateOverlay_OpensOnUWhenAvailable(t *testing.T) {
+	repo := setupRailsFixture(t)
+	mgr, stateMgr := newTestManagers(t, repo)
+	m := NewModel(mgr, stateMgr, repo)
+	// Inject a fake update so the overlay gate passes regardless of the
+	// real ~/.grove/update-check.json contents on the test host.
+	m.updateLatestVersion = "99.0.0"
+	m.updateLatestURL = "https://github.com/lost-in-the/grove/releases/tag/v99.0.0"
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 40))
+
+	// Wait for dashboard
+	teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
+		s := stripANSI(string(bts))
+		return regexp.MustCompile(`(?i)rails-app`).MatchString(s)
+	}, teatest.WithDuration(5*time.Second))
+
+	// Press u — modal should open with "Update available" and the latest version.
+	tm.Send(tea.KeyPressMsg{Code: 'u', Text: "u"})
+
+	teatest.WaitFor(t, tm.Output(), func(bts []byte) bool {
+		s := stripANSI(string(bts))
+		return regexp.MustCompile(`Update available`).MatchString(s) &&
+			regexp.MustCompile(`99\.0\.0`).MatchString(s)
+	}, teatest.WithDuration(5*time.Second))
+
+	// esc closes (mirroring HelpOverlay close-keys)
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEscape})
+	tm.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}
+
 func TestProgram_CreateWizard(t *testing.T) {
 	repo := setupRailsFixture(t)
 	tm := newTestProgram(t, repo)

--- a/internal/tui/update_overlay.go
+++ b/internal/tui/update_overlay.go
@@ -88,12 +88,9 @@ func (u *UpdateOverlay) View(width, height int) string {
 
 	footerRule := lipgloss.NewStyle().Foreground(Colors.SurfaceBorder).
 		Render(strings.Repeat("─", textWidth))
-	// Group both keys with a single action label, matching the project's
-	// other overlay footers (help_overlay.go).
+	// Group both keys with a single action label.
 	footerKeys := "  " +
-		Styles.HelpKey.Render("esc") +
-		Styles.HelpSep.Render(" · ") +
-		Styles.HelpKey.Render("u") + "   " + Styles.HelpDesc.Render("close")
+		Styles.HelpKey.Render("esc/u") + "   " + Styles.HelpDesc.Render("close")
 
 	parts := []string{
 		title,

--- a/internal/tui/update_overlay.go
+++ b/internal/tui/update_overlay.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/lost-in-the/grove/internal/updatecheck"
+)
+
+// UpdateOverlay renders an informational modal showing release update details.
+// It's purely informational — no auto-update functionality. The user runs the
+// suggested install command in their shell to upgrade.
+type UpdateOverlay struct {
+	Active bool
+
+	// Cached at open-time so View() doesn't repeatedly read the cache file.
+	currentVersion string
+	latestVersion  string
+	latestURL      string
+	updateCommand  string
+}
+
+// NewUpdateOverlay creates an inactive UpdateOverlay.
+func NewUpdateOverlay() *UpdateOverlay {
+	return &UpdateOverlay{}
+}
+
+// Open activates the overlay populated from the supplied release info.
+// The caller is responsible for verifying that an update is actually available
+// (typically via updatecheck.CachedRelease) before calling Open.
+func (u *UpdateOverlay) Open(currentVersion, latestVersion, latestURL string) {
+	u.Active = true
+	u.currentVersion = currentVersion
+	u.latestVersion = latestVersion
+	u.latestURL = latestURL
+	u.updateCommand = updatecheck.UpdateCommand(updatecheck.DetectInstall())
+}
+
+// Close deactivates the overlay.
+func (u *UpdateOverlay) Close() {
+	u.Active = false
+}
+
+// View renders the overlay panel centered to the given terminal dimensions.
+func (u *UpdateOverlay) View(width, height int) string {
+	w, _ := calcUpdateOverlaySize(width, height)
+
+	// Width() in lipgloss includes border + padding + text. The OverlayBorderInfo
+	// uses Border (2) + Padding(1,2) (4 horizontal) — same accounting as HelpOverlay.
+	textWidth := w - 6
+	if textWidth < 30 {
+		textWidth = 30
+	}
+
+	title := Styles.OverlayTitle.Render("↑ Update available")
+
+	labelStyle := lipgloss.NewStyle().Foreground(Colors.TextMuted)
+	valueStyle := lipgloss.NewStyle().Foreground(Colors.TextNormal)
+	emphStyle := lipgloss.NewStyle().Bold(true).Foreground(Colors.TextBright)
+	cmdStyle := lipgloss.NewStyle().Foreground(Colors.Primary)
+	urlStyle := lipgloss.NewStyle().Foreground(Colors.Info).Underline(true)
+
+	current := labelStyle.Render("Current:  ") + valueStyle.Render(u.currentVersion)
+	latest := labelStyle.Render("Latest:   ") + emphStyle.Render(u.latestVersion)
+
+	runLine := labelStyle.Render("Run:        ") + cmdStyle.Render(u.updateCommand)
+	var changelogLine string
+	if u.latestURL != "" {
+		changelogLine = labelStyle.Render("Changelog:  ") + urlStyle.Render(u.latestURL)
+	}
+
+	footerRule := lipgloss.NewStyle().Foreground(Colors.SurfaceBorder).
+		Render(strings.Repeat("─", textWidth))
+	footerKeys := "  " +
+		Styles.HelpKey.Render("esc") + " " + Styles.HelpDesc.Render("close") +
+		Styles.HelpSep.Render(" · ") +
+		Styles.HelpKey.Render("u") + " " + Styles.HelpDesc.Render("close")
+
+	parts := []string{
+		title,
+		"",
+		current,
+		latest,
+		"",
+		runLine,
+	}
+	if changelogLine != "" {
+		parts = append(parts, changelogLine)
+	}
+	parts = append(parts, "", footerRule, footerKeys)
+
+	content := strings.Join(parts, "\n")
+
+	return Styles.OverlayBorderInfo.
+		Width(w).
+		Render(content)
+}
+
+// calcUpdateOverlaySize sizes the overlay relative to the terminal.
+// Tighter bounds than the help overlay because the modal is short.
+func calcUpdateOverlaySize(termW, termH int) (w, h int) {
+	w = clamp(termW*60/100, 50, 80)
+	h = clamp(termH*40/100, 11, 16)
+	return
+}

--- a/internal/tui/update_overlay.go
+++ b/internal/tui/update_overlay.go
@@ -18,8 +18,6 @@ type UpdateOverlay struct {
 	currentVersion string
 	latestVersion  string
 	latestURL      string
-	updateCommand  string
-	updateLabel    string
 }
 
 // NewUpdateOverlay creates an inactive UpdateOverlay.
@@ -35,9 +33,6 @@ func (u *UpdateOverlay) Open(currentVersion, latestVersion, latestURL string) {
 	u.currentVersion = currentVersion
 	u.latestVersion = latestVersion
 	u.latestURL = latestURL
-	method := updatecheck.DetectInstall()
-	u.updateCommand = updatecheck.UpdateCommand(method)
-	u.updateLabel = updatecheck.UpdateLabel(method)
 }
 
 // Close deactivates the overlay.
@@ -64,29 +59,41 @@ func (u *UpdateOverlay) View(width, height int) string {
 	cmdStyle := lipgloss.NewStyle().Foreground(Colors.Primary)
 	urlStyle := lipgloss.NewStyle().Foreground(Colors.Info).Underline(true)
 
-	current := labelStyle.Render("Current:  ") + valueStyle.Render(u.currentVersion)
-	latest := labelStyle.Render("Latest:   ") + emphStyle.Render(u.latestVersion)
-
-	// Pad the command label so the value column aligns with "Changelog:".
-	// "Changelog: " is 11 chars + 1 space → values start at column 12.
+	// Align all values at the same column. "Changelog:" is 10 chars; pad
+	// labels so values start at column 12 (matches the previous layout).
 	const valueColumn = 12
-	cmdLabelText := u.updateLabel + ":"
-	cmdPad := valueColumn - len(cmdLabelText)
-	if cmdPad < 1 {
-		cmdPad = 1
+	pad := func(label string) string {
+		text := label + ":"
+		n := valueColumn - len(text)
+		if n < 1 {
+			n = 1
+		}
+		return labelStyle.Render(text + strings.Repeat(" ", n))
 	}
-	runLine := labelStyle.Render(cmdLabelText+strings.Repeat(" ", cmdPad)) + cmdStyle.Render(u.updateCommand)
+
+	current := pad("Current") + valueStyle.Render(u.currentVersion)
+	latest := pad("Latest") + emphStyle.Render(u.latestVersion)
+
+	// Always show all three install methods. The user picks whichever applies
+	// to their setup. The CLI box (render.go) still uses DetectInstall to pick
+	// a single method for its space-constrained one-liner.
+	brewLine := pad("Brew") + cmdStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallBrew))
+	goLine := pad("Go") + cmdStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallGoInstall))
+	binaryLine := pad("Binary") + urlStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallBinary))
+
 	var changelogLine string
 	if u.latestURL != "" {
-		changelogLine = labelStyle.Render("Changelog:  ") + urlStyle.Render(u.latestURL)
+		changelogLine = pad("Changelog") + urlStyle.Render(u.latestURL)
 	}
 
 	footerRule := lipgloss.NewStyle().Foreground(Colors.SurfaceBorder).
 		Render(strings.Repeat("─", textWidth))
+	// Group both keys with a single action label, matching the project's
+	// other overlay footers (help_overlay.go).
 	footerKeys := "  " +
-		Styles.HelpKey.Render("esc") + " " + Styles.HelpDesc.Render("close") +
+		Styles.HelpKey.Render("esc") +
 		Styles.HelpSep.Render(" · ") +
-		Styles.HelpKey.Render("u") + " " + Styles.HelpDesc.Render("close")
+		Styles.HelpKey.Render("u") + "   " + Styles.HelpDesc.Render("close")
 
 	parts := []string{
 		title,
@@ -94,25 +101,57 @@ func (u *UpdateOverlay) View(width, height int) string {
 		current,
 		latest,
 		"",
-		runLine,
+		brewLine,
+		goLine,
+		binaryLine,
 	}
 	if changelogLine != "" {
-		parts = append(parts, changelogLine)
+		parts = append(parts, "", changelogLine)
 	}
 	parts = append(parts, "", footerRule, footerKeys)
 
 	content := strings.Join(parts, "\n")
 
+	// Size Height to the actual content so the box hugs its rows instead of
+	// padding the bottom. OverlayBorderInfo adds 2 (border) + 2 (vertical
+	// padding) = 4 rows of overhead beyond the content lines. Cap at the
+	// terminal-derived max so very short terminals still clip gracefully.
+	contentLines := strings.Count(content, "\n") + 1
+	const borderOverhead = 4
+	desiredH := contentLines + borderOverhead
+	if desiredH > ht {
+		desiredH = ht
+	}
+
 	return Styles.OverlayBorderInfo.
 		Width(w).
-		Height(ht).
+		Height(desiredH).
 		Render(content)
 }
 
 // calcUpdateOverlaySize sizes the overlay relative to the terminal.
-// Tighter bounds than the help overlay because the modal is short.
+// h is the maximum allowed height; the overlay shrinks to its content
+// when shorter, and clips on tiny terminals. w is sized to fit the
+// longest install command without wrapping when possible.
 func calcUpdateOverlaySize(termW, termH int) (w, h int) {
-	w = clamp(termW*60/100, 50, 80)
-	h = clamp(termH*40/100, 11, 16)
+	// Target 74 cols so `go install github.com/lost-in-the/grove/cmd/grove@latest`
+	// (56 chars) fits on a single line with the 12-char label column and
+	// 6-char border+padding overhead. Cap at 80 (standard terminal) and at
+	// the terminal width itself to avoid horizontal overrun on tiny screens.
+	want := 74
+	if termW*70/100 > want {
+		want = termW * 70 / 100
+	}
+	if want > 80 {
+		want = 80
+	}
+	if want > termW {
+		want = termW
+	}
+	w = want
+	// Content is up to ~17 lines (title + blank + 2 versions + blank + 3
+	// methods + blank + changelog + blank + rule + footer + border/pad).
+	// 22 gives headroom; floor 14 prevents micro-boxes on tiny terminals.
+	h = clamp(termH*60/100, 14, 22)
 	return
 }

--- a/internal/tui/update_overlay.go
+++ b/internal/tui/update_overlay.go
@@ -44,7 +44,7 @@ func (u *UpdateOverlay) Close() {
 
 // View renders the overlay panel centered to the given terminal dimensions.
 func (u *UpdateOverlay) View(width, height int) string {
-	w, _ := calcUpdateOverlaySize(width, height)
+	w, ht := calcUpdateOverlaySize(width, height)
 
 	// Width() in lipgloss includes border + padding + text. The OverlayBorderInfo
 	// uses Border (2) + Padding(1,2) (4 horizontal) — same accounting as HelpOverlay.
@@ -94,6 +94,7 @@ func (u *UpdateOverlay) View(width, height int) string {
 
 	return Styles.OverlayBorderInfo.
 		Width(w).
+		Height(ht).
 		Render(content)
 }
 

--- a/internal/tui/update_overlay.go
+++ b/internal/tui/update_overlay.go
@@ -19,6 +19,7 @@ type UpdateOverlay struct {
 	latestVersion  string
 	latestURL      string
 	updateCommand  string
+	updateLabel    string
 }
 
 // NewUpdateOverlay creates an inactive UpdateOverlay.
@@ -34,7 +35,9 @@ func (u *UpdateOverlay) Open(currentVersion, latestVersion, latestURL string) {
 	u.currentVersion = currentVersion
 	u.latestVersion = latestVersion
 	u.latestURL = latestURL
-	u.updateCommand = updatecheck.UpdateCommand(updatecheck.DetectInstall())
+	method := updatecheck.DetectInstall()
+	u.updateCommand = updatecheck.UpdateCommand(method)
+	u.updateLabel = updatecheck.UpdateLabel(method)
 }
 
 // Close deactivates the overlay.
@@ -64,7 +67,15 @@ func (u *UpdateOverlay) View(width, height int) string {
 	current := labelStyle.Render("Current:  ") + valueStyle.Render(u.currentVersion)
 	latest := labelStyle.Render("Latest:   ") + emphStyle.Render(u.latestVersion)
 
-	runLine := labelStyle.Render("Run:        ") + cmdStyle.Render(u.updateCommand)
+	// Pad the command label so the value column aligns with "Changelog:".
+	// "Changelog: " is 11 chars + 1 space → values start at column 12.
+	const valueColumn = 12
+	cmdLabelText := u.updateLabel + ":"
+	cmdPad := valueColumn - len(cmdLabelText)
+	if cmdPad < 1 {
+		cmdPad = 1
+	}
+	runLine := labelStyle.Render(cmdLabelText+strings.Repeat(" ", cmdPad)) + cmdStyle.Render(u.updateCommand)
 	var changelogLine string
 	if u.latestURL != "" {
 		changelogLine = labelStyle.Render("Changelog:  ") + urlStyle.Render(u.latestURL)

--- a/internal/tui/update_overlay_test.go
+++ b/internal/tui/update_overlay_test.go
@@ -36,6 +36,9 @@ func TestUpdateOverlayOpen(t *testing.T) {
 	if u.updateCommand == "" {
 		t.Error("expected updateCommand to be populated after Open")
 	}
+	if u.updateLabel == "" {
+		t.Error("expected updateLabel to be populated after Open")
+	}
 }
 
 func TestUpdateOverlayClose(t *testing.T) {
@@ -58,13 +61,19 @@ func TestUpdateOverlayViewContent(t *testing.T) {
 
 	plain := stripUpdateView(view)
 
+	// Label is contextual: "Run" for brew/go-install, "Download" for binary.
+	// In tests the running binary lives under go test cache → InstallBinary →
+	// "Download". Just check that one or the other is present.
+	if !strings.Contains(stripUpdateView(view), "Run") && !strings.Contains(stripUpdateView(view), "Download") {
+		t.Errorf("expected View to contain command label (Run or Download)\n--- plain ---\n%s", stripUpdateView(view))
+	}
+
 	wantSubstrings := []string{
 		"Update available",
 		"Current",
 		"Latest",
 		"0.6.0",
 		"0.7.0",
-		"Run",
 		"Changelog",
 		"close",
 	}

--- a/internal/tui/update_overlay_test.go
+++ b/internal/tui/update_overlay_test.go
@@ -33,11 +33,8 @@ func TestUpdateOverlayOpen(t *testing.T) {
 	if u.latestVersion != "99.0.0" {
 		t.Errorf("latestVersion = %q, want %q", u.latestVersion, "99.0.0")
 	}
-	if u.updateCommand == "" {
-		t.Error("expected updateCommand to be populated after Open")
-	}
-	if u.updateLabel == "" {
-		t.Error("expected updateLabel to be populated after Open")
+	if u.latestURL != "https://github.com/lost-in-the/grove/releases/tag/v99.0.0" {
+		t.Errorf("latestURL = %q, want full release tag URL", u.latestURL)
 	}
 }
 
@@ -61,19 +58,17 @@ func TestUpdateOverlayViewContent(t *testing.T) {
 
 	plain := stripUpdateView(view)
 
-	// Label is contextual: "Run" for brew/go-install, "Download" for binary.
-	// In tests the running binary lives under go test cache → InstallBinary →
-	// "Download". Just check that one or the other is present.
-	if !strings.Contains(stripUpdateView(view), "Run") && !strings.Contains(stripUpdateView(view), "Download") {
-		t.Errorf("expected View to contain command label (Run or Download)\n--- plain ---\n%s", stripUpdateView(view))
-	}
-
 	wantSubstrings := []string{
 		"Update available",
 		"Current",
 		"Latest",
 		"0.6.0",
 		"0.7.0",
+		// All three install methods are always shown; user picks the one
+		// matching their setup.
+		"Brew",
+		"Go",
+		"Binary",
 		"Changelog",
 		"close",
 	}
@@ -83,15 +78,32 @@ func TestUpdateOverlayViewContent(t *testing.T) {
 		}
 	}
 
-	// URL may wrap onto multiple cells (and across the border glyph). Strip
-	// border glyphs + whitespace before checking continuity.
+	// Verify the actual install commands are rendered. The URL/command may
+	// wrap onto multiple cells (and across the border glyph). Strip border
+	// glyphs + whitespace before checking continuity.
 	flattened := plain
 	for _, r := range []string{"│", "╭", "╮", "╰", "╯", "─"} {
 		flattened = strings.ReplaceAll(flattened, r, "")
 	}
 	flattened = strings.Join(strings.Fields(flattened), "")
-	if !strings.Contains(flattened, "github.com/lost-in-the/grove/releases/tag/v0.7.0") {
-		t.Errorf("expected View to contain release URL\n--- plain ---\n%s", plain)
+
+	wantFlattened := []string{
+		"github.com/lost-in-the/grove/releases/tag/v0.7.0",
+		"brewupgradelost-in-the/tap/grove",
+		"goinstallgithub.com/lost-in-the/grove/cmd/grove@latest",
+		"github.com/lost-in-the/grove/releases",
+	}
+	for _, s := range wantFlattened {
+		if !strings.Contains(flattened, s) {
+			t.Errorf("expected flattened View to contain %q\n--- plain ---\n%s", s, plain)
+		}
+	}
+
+	// Footer should combine both keys with a single "close" action label —
+	// not have "close" written twice.
+	closeCount := strings.Count(plain, "close")
+	if closeCount != 1 {
+		t.Errorf("expected footer to render the word \"close\" exactly once, got %d\n--- plain ---\n%s", closeCount, plain)
 	}
 }
 
@@ -122,12 +134,14 @@ func TestCalcUpdateOverlaySize_Bounds(t *testing.T) {
 		wantW              int
 		wantHMin, wantHMax int
 	}{
-		// Floor
-		{40, 10, 50, 11, 11},
-		// Mid-range
-		{120, 40, 72, 16, 16},
+		// Tiny terminal — w clamps to termW so it doesn't overflow.
+		{40, 10, 40, 14, 14},
+		// Standard 80x24 — target 74 to fit go-install command without wrap.
+		{80, 24, 74, 14, 14},
+		// Mid-range — target stays 74 until termW*70/100 exceeds it.
+		{120, 40, 80, 22, 22},
 		// Ceiling
-		{300, 100, 80, 16, 16},
+		{300, 100, 80, 22, 22},
 	}
 	for _, tt := range tests {
 		w, h := calcUpdateOverlaySize(tt.termW, tt.termH)

--- a/internal/tui/update_overlay_test.go
+++ b/internal/tui/update_overlay_test.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// stripANSIUpdate removes ANSI escape codes for substring assertions.
+var stripANSIUpdate = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripUpdateView(s string) string {
+	return stripANSIUpdate.ReplaceAllString(s, "")
+}
+
+func TestNewUpdateOverlay(t *testing.T) {
+	u := NewUpdateOverlay()
+	if u.Active {
+		t.Error("expected Active to be false on new overlay")
+	}
+}
+
+func TestUpdateOverlayOpen(t *testing.T) {
+	u := NewUpdateOverlay()
+	u.Open("0.7.0-dev", "99.0.0", "https://github.com/lost-in-the/grove/releases/tag/v99.0.0")
+
+	if !u.Active {
+		t.Error("expected Active to be true after Open")
+	}
+	if u.currentVersion != "0.7.0-dev" {
+		t.Errorf("currentVersion = %q, want %q", u.currentVersion, "0.7.0-dev")
+	}
+	if u.latestVersion != "99.0.0" {
+		t.Errorf("latestVersion = %q, want %q", u.latestVersion, "99.0.0")
+	}
+	if u.updateCommand == "" {
+		t.Error("expected updateCommand to be populated after Open")
+	}
+}
+
+func TestUpdateOverlayClose(t *testing.T) {
+	u := NewUpdateOverlay()
+	u.Open("0.7.0", "0.8.0", "https://x")
+	u.Close()
+	if u.Active {
+		t.Error("expected Active to be false after Close")
+	}
+}
+
+func TestUpdateOverlayViewContent(t *testing.T) {
+	u := NewUpdateOverlay()
+	u.Open("0.6.0", "0.7.0", "https://github.com/lost-in-the/grove/releases/tag/v0.7.0")
+
+	view := u.View(120, 40)
+	if view == "" {
+		t.Fatal("expected non-empty View output")
+	}
+
+	plain := stripUpdateView(view)
+
+	wantSubstrings := []string{
+		"Update available",
+		"Current",
+		"Latest",
+		"0.6.0",
+		"0.7.0",
+		"Run",
+		"Changelog",
+		"close",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(plain, s) {
+			t.Errorf("expected View to contain %q\n--- plain ---\n%s", s, plain)
+		}
+	}
+
+	// URL may wrap onto multiple cells (and across the border glyph). Strip
+	// border glyphs + whitespace before checking continuity.
+	flattened := plain
+	for _, r := range []string{"│", "╭", "╮", "╰", "╯", "─"} {
+		flattened = strings.ReplaceAll(flattened, r, "")
+	}
+	flattened = strings.Join(strings.Fields(flattened), "")
+	if !strings.Contains(flattened, "github.com/lost-in-the/grove/releases/tag/v0.7.0") {
+		t.Errorf("expected View to contain release URL\n--- plain ---\n%s", plain)
+	}
+}
+
+func TestUpdateOverlayViewOmitsChangelogWhenURLEmpty(t *testing.T) {
+	u := NewUpdateOverlay()
+	u.Open("0.6.0", "0.7.0", "")
+
+	view := stripUpdateView(u.View(120, 40))
+	if strings.Contains(view, "Changelog") {
+		t.Errorf("expected View to omit Changelog row when URL empty\n--- view ---\n%s", view)
+	}
+}
+
+func TestUpdateOverlayViewMultipleWidths(t *testing.T) {
+	u := NewUpdateOverlay()
+	u.Open("0.6.0", "0.7.0", "https://x")
+	for _, w := range []int{60, 80, 120, 200} {
+		view := u.View(w, 40)
+		if view == "" {
+			t.Errorf("View at width %d returned empty", w)
+		}
+	}
+}
+
+func TestCalcUpdateOverlaySize_Bounds(t *testing.T) {
+	tests := []struct {
+		termW, termH       int
+		wantW              int
+		wantHMin, wantHMax int
+	}{
+		// Floor
+		{40, 10, 50, 11, 11},
+		// Mid-range
+		{120, 40, 72, 16, 16},
+		// Ceiling
+		{300, 100, 80, 16, 16},
+	}
+	for _, tt := range tests {
+		w, h := calcUpdateOverlaySize(tt.termW, tt.termH)
+		if w != tt.wantW {
+			t.Errorf("calcUpdateOverlaySize(%d,%d) w = %d, want %d", tt.termW, tt.termH, w, tt.wantW)
+		}
+		if h < tt.wantHMin || h > tt.wantHMax {
+			t.Errorf("calcUpdateOverlaySize(%d,%d) h = %d, want in [%d,%d]", tt.termW, tt.termH, h, tt.wantHMin, tt.wantHMax)
+		}
+	}
+}

--- a/internal/tui/update_overlay_test.go
+++ b/internal/tui/update_overlay_test.go
@@ -100,10 +100,13 @@ func TestUpdateOverlayViewContent(t *testing.T) {
 	}
 
 	// Footer should combine both keys with a single "close" action label —
-	// not have "close" written twice.
+	// rendered as "esc/u   close" (slash convention for compound keys).
 	closeCount := strings.Count(plain, "close")
 	if closeCount != 1 {
 		t.Errorf("expected footer to render the word \"close\" exactly once, got %d\n--- plain ---\n%s", closeCount, plain)
+	}
+	if !strings.Contains(plain, "esc/u") {
+		t.Errorf("expected footer to render compound close keys as \"esc/u\"\n--- plain ---\n%s", plain)
 	}
 }
 

--- a/internal/updatecheck/check.go
+++ b/internal/updatecheck/check.go
@@ -59,6 +59,25 @@ func cachedUpdateAnnotationFromPath(currentVersion, path string) string {
 	return " (update available: " + c.LatestVersion + ")"
 }
 
+// CachedRelease returns the cached LatestVersion + LatestURL when a newer
+// release is available, or zero strings when there's nothing to surface.
+// Used by UI surfaces (TUI footer badge, modal, version annotation) that
+// need both fields without re-implementing the cache+compare flow.
+func CachedRelease(currentVersion string) (latest, url string, available bool) {
+	return cachedReleaseFromPath(currentVersion, DefaultCachePath())
+}
+
+func cachedReleaseFromPath(currentVersion, path string) (latest, url string, available bool) {
+	c, err := ReadCacheFromPath(path)
+	if err != nil || c.LatestVersion == "" {
+		return "", "", false
+	}
+	if CompareSemver(currentVersion, c.LatestVersion) == SeverityNone {
+		return "", "", false
+	}
+	return c.LatestVersion, c.LatestURL, true
+}
+
 // CheckInterval is the default minimum gap between two refreshes.
 const CheckInterval = 24 * time.Hour
 

--- a/internal/updatecheck/check.go
+++ b/internal/updatecheck/check.go
@@ -34,7 +34,7 @@ func renderUpdateBox(w io.Writer, currentVersion, latestVersion, latestURL strin
 		return false
 	}
 	method := DetectInstall()
-	_, _ = io.WriteString(w, RenderBox(currentVersion, latestVersion, latestURL, UpdateCommand(method), severity))
+	_, _ = io.WriteString(w, RenderBox(currentVersion, latestVersion, latestURL, UpdateLabel(method), UpdateCommand(method), severity))
 	return true
 }
 

--- a/internal/updatecheck/check_test.go
+++ b/internal/updatecheck/check_test.go
@@ -222,3 +222,58 @@ func TestCachedUpdateAnnotation_OlderCachedVersionReturnsEmpty(t *testing.T) {
 		t.Errorf("expected empty for older cached version, got %q", got)
 	}
 }
+
+func TestCachedRelease_NewerCachedVersionReturnsBoth(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{
+		LatestVersion: "0.7.0",
+		LatestURL:     "https://github.com/lost-in-the/grove/releases/tag/v0.7.0",
+	})
+
+	latest, url, available := cachedReleaseFromPath("0.6.0", path)
+	if !available {
+		t.Fatal("expected available=true for newer cached version")
+	}
+	if latest != "0.7.0" {
+		t.Errorf("latest = %q, want %q", latest, "0.7.0")
+	}
+	if url != "https://github.com/lost-in-the/grove/releases/tag/v0.7.0" {
+		t.Errorf("url = %q, want release URL", url)
+	}
+}
+
+func TestCachedRelease_EqualVersionUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{LatestVersion: "0.6.0", LatestURL: "https://x"})
+
+	latest, url, available := cachedReleaseFromPath("0.6.0", path)
+	if available {
+		t.Error("expected available=false for equal version")
+	}
+	if latest != "" || url != "" {
+		t.Errorf("expected zero values, got latest=%q url=%q", latest, url)
+	}
+}
+
+func TestCachedRelease_MissingCacheUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "missing.json")
+
+	_, _, available := cachedReleaseFromPath("0.6.0", path)
+	if available {
+		t.Error("expected available=false for missing cache")
+	}
+}
+
+func TestCachedRelease_OlderCachedVersionUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{LatestVersion: "0.5.0", LatestURL: "https://x"})
+
+	_, _, available := cachedReleaseFromPath("0.6.0", path)
+	if available {
+		t.Error("expected available=false when current is newer than cached")
+	}
+}

--- a/internal/updatecheck/check_test.go
+++ b/internal/updatecheck/check_test.go
@@ -277,3 +277,24 @@ func TestCachedRelease_OlderCachedVersionUnavailable(t *testing.T) {
 		t.Error("expected available=false when current is newer than cached")
 	}
 }
+
+// TestCachedRelease_DevVersionUnavailable locks the contract that pre-release
+// or otherwise unparseable currentVersion strings (e.g. "0.7.0-dev") never
+// surface an update. CompareSemver returns SeverityNone for unparseable inputs,
+// which intentionally suppresses the badge/modal for development builds.
+func TestCachedRelease_DevVersionUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{
+		LatestVersion: "0.8.0",
+		LatestURL:     "https://github.com/lost-in-the/grove/releases/tag/v0.8.0",
+	})
+
+	latest, url, available := cachedReleaseFromPath("0.7.0-dev", path)
+	if available {
+		t.Errorf("dev version should not show update available, got latest=%q url=%q", latest, url)
+	}
+	if latest != "" || url != "" {
+		t.Errorf("expected zero values for dev version, got latest=%q url=%q", latest, url)
+	}
+}

--- a/internal/updatecheck/install.go
+++ b/internal/updatecheck/install.go
@@ -68,6 +68,17 @@ func UpdateCommand(m InstallMethod) string {
 	case InstallGoInstall:
 		return "go install github.com/lost-in-the/grove/cmd/grove@latest"
 	default:
-		return "Visit https://github.com/lost-in-the/grove/releases for the latest binary"
+		return "https://github.com/lost-in-the/grove/releases"
+	}
+}
+
+// UpdateLabel returns the verb that pairs with UpdateCommand for the given
+// install method. "Run" for shell commands; "Download" for the URL fallback.
+func UpdateLabel(m InstallMethod) string {
+	switch m {
+	case InstallBrew, InstallGoInstall:
+		return "Run"
+	default:
+		return "Download"
 	}
 }

--- a/internal/updatecheck/install_test.go
+++ b/internal/updatecheck/install_test.go
@@ -66,13 +66,32 @@ func TestUpdateCommand(t *testing.T) {
 	}{
 		{InstallBrew, "brew upgrade lost-in-the/tap/grove"},
 		{InstallGoInstall, "go install github.com/lost-in-the/grove/cmd/grove@latest"},
-		{InstallBinary, "Visit https://github.com/lost-in-the/grove/releases for the latest binary"},
-		{InstallUnknown, "Visit https://github.com/lost-in-the/grove/releases for the latest binary"},
+		{InstallBinary, "https://github.com/lost-in-the/grove/releases"},
+		{InstallUnknown, "https://github.com/lost-in-the/grove/releases"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.method.String(), func(t *testing.T) {
 			if got := UpdateCommand(tc.method); got != tc.want {
 				t.Errorf("UpdateCommand(%v) = %q, want %q", tc.method, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateLabel(t *testing.T) {
+	cases := []struct {
+		method InstallMethod
+		want   string
+	}{
+		{InstallBrew, "Run"},
+		{InstallGoInstall, "Run"},
+		{InstallBinary, "Download"},
+		{InstallUnknown, "Download"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method.String(), func(t *testing.T) {
+			if got := UpdateLabel(tc.method); got != tc.want {
+				t.Errorf("UpdateLabel(%v) = %q, want %q", tc.method, got, tc.want)
 			}
 		})
 	}

--- a/internal/updatecheck/render.go
+++ b/internal/updatecheck/render.go
@@ -64,14 +64,14 @@ func CompareSemver(current, latest string) Severity {
 
 // RenderBox returns the formatted box notification as a string.
 // When NO_COLOR is set, the output is plain ASCII (no ANSI escapes).
-func RenderBox(currentVersion, latestVersion, latestURL, updateCmd string, severity Severity) string {
+func RenderBox(currentVersion, latestVersion, latestURL, updateLabel, updateCmd string, severity Severity) string {
 	arrow := "→"
 	if os.Getenv("NO_COLOR") != "" {
 		arrow = "->"
 	}
 	body := []string{
 		fmt.Sprintf("Update available  %s  %s  %s", currentVersion, arrow, latestVersion),
-		"Run: " + updateCmd,
+		updateLabel + ": " + updateCmd,
 		"Changelog: " + latestURL,
 	}
 	if os.Getenv("NO_COLOR") != "" {

--- a/internal/updatecheck/render_test.go
+++ b/internal/updatecheck/render_test.go
@@ -55,6 +55,7 @@ func TestRenderBox_Plain(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	out := RenderBox("0.5.0", "0.6.0",
 		"https://github.com/lost-in-the/grove/releases/tag/v0.6.0",
+		"Run",
 		"brew upgrade lost-in-the/tap/grove",
 		SeverityMinor,
 	)
@@ -65,14 +66,28 @@ func TestRenderBox_Plain(t *testing.T) {
 	mustContain(t, out, "Update available")
 	mustContain(t, out, "0.5.0")
 	mustContain(t, out, "0.6.0")
-	mustContain(t, out, "brew upgrade lost-in-the/tap/grove")
+	mustContain(t, out, "Run: brew upgrade lost-in-the/tap/grove")
 	mustContain(t, out, "github.com/lost-in-the/grove/releases/tag/v0.6.0")
+}
+
+func TestRenderBox_PlainBinaryUsesDownloadLabel(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	out := RenderBox("0.5.0", "0.6.0",
+		"https://github.com/lost-in-the/grove/releases/tag/v0.6.0",
+		"Download",
+		"https://github.com/lost-in-the/grove/releases",
+		SeverityMinor,
+	)
+	mustContain(t, out, "Download: https://github.com/lost-in-the/grove/releases")
+	if strings.Contains(out, "Run:") {
+		t.Errorf("expected no \"Run:\" label in binary-install output, got:\n%s", out)
+	}
 }
 
 func TestRenderBox_ColoredEmitsAnsi(t *testing.T) {
 	t.Setenv("NO_COLOR", "")
 	t.Setenv("CLICOLOR_FORCE", "1") // hint to lipgloss to render colors even when not a TTY
-	out := RenderBox("0.5.0", "1.0.0", "https://x", "brew upgrade x", SeverityMajor)
+	out := RenderBox("0.5.0", "1.0.0", "https://x", "Run", "brew upgrade x", SeverityMajor)
 	if !strings.Contains(out, "\x1b[") {
 		t.Errorf("expected ANSI escape sequences in colored output, got: %q", out)
 	}
@@ -82,6 +97,7 @@ func TestRenderBox_PlainPaddingAlignsForUTF8(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	out := RenderBox("0.5.0", "0.6.0",
 		"https://x",
+		"Run",
 		"brew upgrade x",
 		SeverityMinor,
 	)


### PR DESCRIPTION
Closes #77.

## Summary

Adds a passive footer badge and a richer informational modal to the TUI dashboard for surfacing newer grove releases. Reuses the existing `~/.grove/update-check.json` cache populated by the on-exit notifier — no new network paths.

## Components

- `updatecheck.CachedRelease(currentVersion) -> (latest, url, available)` — small helper so UI surfaces (TUI footer badge, modal) consume the cache+compare contract without re-implementing it.
- `internal/tui/update_overlay.go` — new `UpdateOverlay` component, mirroring the structure of `HelpOverlay`. Modal shows current/latest version, install command (from `updatecheck.UpdateCommand(DetectInstall())`), and the changelog URL.
- `HelpFooter.RenderUpdateBadge` — produces the muted `↑ X.Y.Z → Y.Y.Y press u` string. Model splices it onto the dashboard footer (inline if it fits, new line otherwise).
- `Update` keybind (`u`) — opens the modal when an update is available and no text input is focused (same gating as `?`-for-help). `esc` and `u` both close, mirroring the close-keys for `HelpOverlay` (per #54).
- `maybeRefreshUpdateCache()` — wired into all three TUI entry points (`Run`, `RunPRs`, `RunIssues`). Honors `updatecheck.Skip(false, version.Version)` so CI / `GROVE_AGENT_MODE` / `GROVE_NO_UPDATE_NOTIFIER` / non-TTY all suppress the refresh, and the 24h interval gate inside `RefreshAsync` prevents repeat hits.

## Out of scope (deliberately)

- No auto-update — `u` only opens the informational modal.
- No in-modal refresh — modal is read-only against the cache.
- No animation / spinner — refresh is silent and detached.
- No change to `MaybeNotify` — the on-exit CLI box continues to print as before.

## Performance

- Cache file is read once during `NewModel`, then stored on the Model. `View()` does no disk I/O.
- Modal content (install command, etc.) is computed at `Open()` time, not per render.

## Tests

- 4 unit tests for `CachedRelease` (newer / equal / missing / older).
- 6 unit tests for `UpdateOverlay` (constructor, open, close, view content, omits-changelog-when-empty, multi-width render, size-bounds).
- `teatest` integration test (`TestProgram_UpdateOverlay_OpensOnUWhenAvailable`) verifies that pressing `u` opens the modal when `updateLatestVersion` is set.

## Visual verification

The badge / modal are gated on `updatecheck.CompareSemver` returning a non-zero severity, which means **dev builds (`0.7.0-dev`) won't see anything** — `parseSemver` rejects the `-dev` suffix. To verify visually, build a release-flavored binary so version is parseable:

```sh
# Seed a cache with a fake newer version
mkdir -p ~/.grove
cat > ~/.grove/update-check.json <<EOF2
{"last_checked_at":"$(date -u +%FT%TZ)","latest_version":"99.0.0","latest_url":"https://github.com/lost-in-the/grove/releases/tag/v99.0.0"}
EOF2

# Build with overridden version so semver parses
go build -ldflags "-X github.com/lost-in-the/grove/internal/version.Version=0.7.0" \
    -o /tmp/grove ./cmd/grove

/tmp/grove

# Look for: footer badge "↑ 0.7.0 → 99.0.0  press u"
# Press 'u' to open the modal
# Press 'u' or esc to close
# When done, remove the seeded cache:
rm ~/.grove/update-check.json
```

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all packages)
- [x] `make test-integration` passes
- [ ] Visual verification by reviewer using the seeded-cache repro above