### PR TITLE
chore: post-#77 cleanup + Skip parity + doc audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: go mod download
 
       - name: Run integration tests
-        run: make test-integration-docker
+        run: make test-integration
 
   lint:
     name: Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- TUI now shows a passive `↑ X.Y.Z → X.Y+1.Z press u` footer badge when a newer grove release is available, plus a richer modal (opened via `u`) showing the install command and changelog link. Reuses the existing `~/.grove/update-check.json` cache. Suppressed in CI / non-TTY / via `GROVE_NO_UPDATE_NOTIFIER`.
+- TUI now shows a passive `↑ X.Y.Z → X.Y+1.Z press u` footer badge when a newer grove release is available, plus a richer modal (opened via `u`) showing all install methods (Brew, Go install, binary) and the changelog link. Reuses the existing `~/.grove/update-check.json` cache. Suppressed in CI / non-TTY / via `GROVE_NO_UPDATE_NOTIFIER` etc. — same opt-outs as the CLI box.
+- `grove version` output now appends `(update available: X.Y.Z)` when a newer release is cached. Suppressed in non-TTY contexts and when update-notifier opt-outs are set.
 - Per-developer config overlay at `.grove/config.local.toml` (gitignored). Overrides values from the committed `.grove/config.toml` for individual developers — e.g., `[tmux] mode = "off"` for someone who prefers no tmux without changing team defaults. Precedence: defaults → global → `.grove/config.toml` → `.grove/config.local.toml` → env vars (closes #79).
 - Optional update-available notification on command exit when a newer grove release is published. Checks at most once per 24 hours, in a detached background process — never blocks command execution. Suppressed in CI, non-TTY contexts, and when `NO_UPDATE_NOTIFIER`, `GROVE_NO_UPDATE_NOTIFIER`, `GROVE_AGENT_MODE`, or `GROVE_NONINTERACTIVE` env vars are set, or when `--no-update-notifier` is passed. Use `--check-update` to force a synchronous check at any time.
 - `grove context` command — prints full worktree context (branch, commit, remote tracking/sync, status, stash count, recent commits) for CLI/scripting use; `--json` flag emits structured machine-readable output (closes #16); JSON includes `has_remote` boolean to distinguish "no remote" from "remote, in sync" (0/0 ahead/behind)
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/grove.IsWorktreeInState` — shared helper for state.json drift detection
 
 ### Changed
+- Update notification now uses contextual labels: `Run:` for shell commands (Brew, `go install`), `Download:` for the binary URL fallback. Previously rendered `Run: Visit https://...` which read awkwardly.
 - **Behavior change:** `grove test` now passes `--no-deps` to `compose run` by default. Tests that rely on dependency services starting (e.g., a database) need either `[test] include_deps = true` in config or the `--with-deps` flag.
 - When `grove test` exits non-zero with a connection-refused or DNS error (e.g. "connection refused", "no such host") and the user has not opted into `include_deps`, grove appends a hint pointing at `--with-deps` and `[test] include_deps = true`.
 - **Behavior change:** `grove up` against an external stack tolerates failures of services listed in `non_blocking_services` — the command no longer exits non-zero when only one-shot init services failed.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Edge builds may include breaking changes that haven't been documented yet. Pin t
 | Release binary | Re-download from the [releases page](https://github.com/lost-in-the/grove/releases) |
 | Build from source | `git pull && make build && sudo make install` |
 
-`grove version` shows the currently installed version. Subscribe to [release notifications](https://github.com/lost-in-the/grove/releases.atom) (Atom feed) or watch the repo for releases on GitHub to be notified of new versions.
+`grove version` shows the currently installed version. Grove also checks for newer releases automatically on each invocation (at most once per 24h, in a detached background process), surfacing a notification on command exit or in the TUI footer when an update is available. Set `GROVE_NO_UPDATE_NOTIFIER=1` to opt out, or use `grove --check-update` for a manual check. See [`docs/CONFIGURATION_REFERENCE.md`](docs/CONFIGURATION_REFERENCE.md) for the full opt-out matrix. To watch for releases externally, the GitHub repo's [Atom feed](https://github.com/lost-in-the/grove/releases.atom) and Watch → Custom → Releases work too.
 
 **Requirements:** Git 2.30+, tmux 3.0+ (optional), `gh` CLI (optional for GitHub features), zsh or bash.
 

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -2313,7 +2313,29 @@ Generates the shell integration snippet for a given shell (`grove install zsh`, 
 
 ### grove version
 
-Prints the grove version string. See `grove version --help`.
+Print version information.
+
+**Usage:**
+
+    grove version [flags]
+
+**Flags:**
+
+- `-v`, `--verbose` — include build metadata (commit, build date, Go runtime)
+- `--check-update` (persistent) — force a synchronous update check; prints either an update box or "grove is up to date (X.Y.Z)"
+- `--no-update-notifier` (persistent) — suppress the update annotation on this run
+
+**Output:**
+
+Default:
+
+    grove 0.7.0 darwin/arm64
+
+When the update-check cache shows a newer release and stdout is a TTY:
+
+    grove 0.7.0 darwin/arm64 (update available: 0.8.0)
+
+The annotation honors the same opt-outs as `grove`'s other update surfaces (env vars, non-TTY stdout, dev/unknown versions). Use `grove --check-update` for a synchronous check that bypasses these opt-outs.
 
 ---
 

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -808,6 +808,8 @@ Per-run flags:
 
 The check runs in a detached background process and never delays command execution. Notifications are only printed when a newer stable release is available and stdout is a TTY.
 
+The opt-out env vars (`NO_UPDATE_NOTIFIER`, `GROVE_NO_UPDATE_NOTIFIER`, `GROVE_AGENT_MODE`, `GROVE_NONINTERACTIVE`) and the `--no-update-notifier` flag suppress every update surface uniformly: the CLI box on command exit, the `grove version` annotation, the TUI footer badge, and the `u`-keybind modal. Use `grove --check-update` to force a synchronous check that bypasses opt-outs.
+
 ---
 
 ## Example Configurations

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -71,6 +71,20 @@ Selecting a worktree updates the detail panel with:
 
 A compact hint bar at the bottom shows essential keybindings. Press `?` to open a scrollable, context-sensitive help overlay with the full reference for the current view.
 
+### Update available indicator
+
+When grove's update-check cache (`~/.grove/update-check.json`) shows a newer
+release, the dashboard footer renders a passive badge:
+
+    ↑ 0.7.0 → 0.8.0  press u
+
+Pressing `u` opens an `UpdateOverlay` modal showing all install methods
+(Brew, `go install`, binary download) and a changelog link. The modal closes
+on `esc` or `u`.
+
+The badge and modal are silenced by the same opt-outs as other grove update
+surfaces — `GROVE_NO_UPDATE_NOTIFIER=1` and friends suppress all of them.
+
 ### Toast Notifications
 
 Short-lived notifications appear in the top-right corner of the header after operations complete. They auto-dismiss after 3 seconds and fade as they expire.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -158,7 +158,15 @@ func NewModel(mgr *worktree.Manager, stateMgr *state.Manager, projectRoot string
 	// Read update-check cache once at startup. Empty strings if no update is
 	// available (which is the common case). Reading from disk here instead of
 	// on every render keeps the hot path allocation-free.
-	latest, latestURL, _ := updatecheck.CachedRelease(version.Version)
+	//
+	// Honor Skip for the in-TUI update surfaces (badge + u-keybind modal),
+	// matching the CLI box and `grove version` annotation. Users who set
+	// GROVE_NO_UPDATE_NOTIFIER, GROVE_AGENT_MODE, etc. get no update UI anywhere.
+	// Use `grove --check-update` to force a synchronous check.
+	var latest, latestURL string
+	if !updatecheck.Skip(false, version.Version) {
+		latest, latestURL, _ = updatecheck.CachedRelease(version.Version)
+	}
 
 	return Model{
 		worktreeMgr:         mgr,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1881,10 +1881,15 @@ func (m Model) compositeActiveOverlay(content string) string {
 	return content
 }
 
-// updateAvailable reports whether the cached release info shows a newer
-// grove version is available than the running binary.
+// updateAvailable reports whether the cached release info shows a strictly
+// newer grove version is available than the running binary. Uses semver
+// comparison rather than string inequality so a downgrade or unparseable
+// cache value won't accidentally surface a badge.
 func (m Model) updateAvailable() bool {
-	return m.updateLatestVersion != "" && m.updateLatestVersion != version.Version
+	if m.updateLatestVersion == "" {
+		return false
+	}
+	return updatecheck.CompareSemver(version.Version, m.updateLatestVersion) != updatecheck.SeverityNone
 }
 
 // appendUpdateBadge appends a passive update-available badge to the given

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1889,15 +1889,16 @@ func (m Model) compositeActiveOverlay(content string) string {
 	return content
 }
 
-// updateAvailable reports whether the cached release info shows a strictly
-// newer grove version is available than the running binary. Uses semver
-// comparison rather than string inequality so a downgrade or unparseable
-// cache value won't accidentally surface a badge.
+// updateAvailable reports whether the cached release info shows a newer
+// grove version is available than the running binary.
+//
+// String inequality is sufficient because the only path that populates
+// updateLatestVersion is NewModel → updatecheck.CachedRelease, which already
+// applies CompareSemver and only returns a value when the cache is strictly
+// newer. Re-running CompareSemver here would be redundant AND would break
+// dev/test builds where version.Version is unparseable as semver.
 func (m Model) updateAvailable() bool {
-	if m.updateLatestVersion == "" {
-		return false
-	}
-	return updatecheck.CompareSemver(version.Version, m.updateLatestVersion) != updatecheck.SeverityNone
+	return m.updateLatestVersion != "" && m.updateLatestVersion != version.Version
 }
 
 // appendUpdateBadge appends a passive update-available badge to the given

--- a/internal/tui/program_test.go
+++ b/internal/tui/program_test.go
@@ -130,7 +130,9 @@ func TestProgram_UpdateOverlay_OpensOnUWhenAvailable(t *testing.T) {
 	mgr, stateMgr := newTestManagers(t, repo)
 	m := NewModel(mgr, stateMgr, repo)
 	// Inject a fake update so the overlay gate passes regardless of the
-	// real ~/.grove/update-check.json contents on the test host.
+	// real ~/.grove/update-check.json contents on the test host. With the
+	// Skip-honoring gate in NewModel, a non-TTY test run produces empty
+	// fields by design, so direct injection is the canonical seam.
 	m.updateLatestVersion = "99.0.0"
 	m.updateLatestURL = "https://github.com/lost-in-the/grove/releases/tag/v99.0.0"
 
@@ -155,6 +157,25 @@ func TestProgram_UpdateOverlay_OpensOnUWhenAvailable(t *testing.T) {
 	tm.Send(tea.KeyPressMsg{Code: tea.KeyEscape})
 	tm.Send(tea.KeyPressMsg{Code: 'q', Text: "q"})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}
+
+// TestProgram_UpdateOverlay_GateRespectsSkip verifies NewModel honors
+// updatecheck.Skip — when the env-var opt-out is set, NewModel must produce
+// a model with an empty updateLatestVersion regardless of cache contents.
+// This is the parity guarantee with the CLI box and `grove version`.
+func TestProgram_UpdateOverlay_GateRespectsSkip(t *testing.T) {
+	t.Setenv("GROVE_NO_UPDATE_NOTIFIER", "1")
+
+	repo := setupRailsFixture(t)
+	mgr, stateMgr := newTestManagers(t, repo)
+	m := NewModel(mgr, stateMgr, repo)
+
+	if m.updateLatestVersion != "" {
+		t.Fatalf("expected updateLatestVersion to be empty when Skip returns true, got %q", m.updateLatestVersion)
+	}
+	if m.updateLatestURL != "" {
+		t.Fatalf("expected updateLatestURL to be empty when Skip returns true, got %q", m.updateLatestURL)
+	}
 }
 
 func TestProgram_CreateWizard(t *testing.T) {

--- a/internal/updatecheck/install_test.go
+++ b/internal/updatecheck/install_test.go
@@ -14,7 +14,7 @@ func TestDetectInstallFromPath(t *testing.T) {
 	}{
 		{"homebrew apple silicon", "/opt/homebrew/Cellar/grove/0.6.0/bin/grove", InstallBrew},
 		{"homebrew intel", "/usr/local/Cellar/grove/0.6.0/bin/grove", InstallBrew},
-		{"go install", "/Users/leah/go/bin/grove", InstallGoInstall},
+		{"go install", "/Users/example/go/bin/grove", InstallGoInstall},
 		{"binary download", "/usr/local/bin/grove", InstallBinary},
 		{"empty", "", InstallUnknown},
 	}


### PR DESCRIPTION
## Summary

Post-#77 polish in four threads:

1. **`updateAvailable()` reasoning made explicit (NOT semver-tightened).** Earlier reviewer feedback proposed switching from string inequality to `CompareSemver`. Tried it; broke under `go test` because `version.Version` is `"0.7.0-dev"` (unparseable). String inequality is sufficient because the only path that populates `updateLatestVersion` is `NewModel → CachedRelease`, which already applies `CompareSemver` and only returns a value when strictly newer. Comment now explains the invariant so it stays explicit.

2. **Generic placeholder in test fixture path.** `internal/updatecheck/install_test.go`'s go-install detection test value was a personal home path. Replaced with a generic placeholder — same heuristic (`$HOME/go/bin/...`), no personal path. Pre-existing from #35.

3. **TUI badge + modal honor `Skip` (closes #84).** Gates `updateLatestVersion`/`URL` population in `NewModel` on `updatecheck.Skip`, so the TUI footer badge and `u`-keybind modal respect the same opt-outs as the CLI box and `grove version` annotation. `GROVE_NO_UPDATE_NOTIFIER=1`, `GROVE_AGENT_MODE=1`, etc. now suppress every update surface uniformly. `grove --check-update` still forces a synchronous check.

4. **Doc audit across update-notification surfaces.** Covers the recent stream (#35/#76/#77/#80/#81/#82/#84):
   - `CHANGELOG.md` — adds entries for `grove version` annotation (#80) and contextual Run/Download label (#82); reframes TUI badge entry to call out opt-out parity.
   - `docs/CONFIGURATION_REFERENCE.md` — explicit note that opt-out env vars and `--no-update-notifier` suppress every update surface.
   - `docs/COMMAND_SPECIFICATIONS.md` — replaces one-line `grove version` stub with full spec.
   - `docs/TUI.md` — documents footer badge + `u`-keybind modal and opt-out parity.
   - `README.md` — points at the in-tool update check.

5. **CI gap fix.** "Integration Tests" check ran `make test-integration-docker`, skipping the TUI integration suite. Switched to `make test-integration` (parent target). This is the gap that initially let the broken-`updateAvailable` regression land — TUI tests passed locally on PR #82 but the regression on this branch wasn't caught because TUI tests weren't actually running in CI.

## Test plan

- [x] `make lint` clean
- [x] `make test` clean (incl. updatecheck + tui)
- [x] `TestProgram_UpdateOverlay_OpensOnUWhenAvailable` passes after the `updateAvailable()` revert
- [x] `TestProgram_UpdateOverlay_GateRespectsSkip` (new) asserts `NewModel` produces empty `updateLatestVersion` when `GROVE_NO_UPDATE_NOTIFIER=1`
- [x] CI's "Integration Tests" check now runs `make test-integration` so future TUI regressions are caught

Closes #84.