### PR TITLE
perf: reduce worktree fetch overhead (~6.7s → ~2.4s on 38-worktree repo)

### DIFF
--- a/cmd/grove/commands/apply.go
+++ b/cmd/grove/commands/apply.go
@@ -70,16 +70,17 @@ Examples:
 			return fmt.Errorf("failed to initialize worktree manager: %w", err)
 		}
 
-		// Get current worktree (target)
-		currentTree, err := mgr.GetCurrent()
+		// Get current worktree (target). Only path + display name are needed
+		// downstream — skip GetCurrent's commit/dirty enrichment.
+		currentPath, err := mgr.CurrentPath()
 		if err != nil {
 			return fmt.Errorf("failed to get current worktree: %w", err)
 		}
-		if currentTree == nil {
-			return fmt.Errorf("could not determine current worktree")
+		currentTree := &worktree.Worktree{
+			Path: currentPath,
 		}
 
-		targetName := currentTree.DisplayName()
+		targetName := mgr.DisplayNameForPath(currentPath)
 
 		// Check if target is immutable
 		if cfg.IsImmutable(targetName) {

--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -74,12 +74,9 @@ Examples:
 
 		cfg := ctx.Config
 
-		// Get current worktree
-		currentTree, _ := mgr.GetCurrent()
-		var currentPath string
-		if currentTree != nil {
-			currentPath = currentTree.Path
-		}
+		// CurrentPath avoids the porcelain listing + per-worktree dirty
+		// check that GetCurrent would do — clean only needs the path.
+		currentPath, _ := mgr.CurrentPath()
 
 		// List all worktrees
 		trees, err := mgr.List()

--- a/cmd/grove/commands/fetch.go
+++ b/cmd/grove/commands/fetch.go
@@ -70,10 +70,13 @@ func setupFetchedWorktree(ctx *GroveContext, mgr *worktree.Manager, w *cli.Write
 		}
 	}
 
-	currentTree, _ := mgr.GetCurrent()
-	if currentTree != nil {
-		if err := ctx.State.SetLastWorktree(currentTree.DisplayName()); err != nil {
-			log.Printf("failed to set last worktree %q: %v", currentTree.DisplayName(), err)
+	// Display-name-only path: skips the GetCurrent enrichment.
+	if currentPath, err := mgr.CurrentPath(); err == nil {
+		prevName := mgr.DisplayNameForPath(currentPath)
+		if prevName != "" {
+			if err := ctx.State.SetLastWorktree(prevName); err != nil {
+				log.Printf("failed to set last worktree %q: %v", prevName, err)
+			}
 		}
 	}
 

--- a/cmd/grove/commands/fork.go
+++ b/cmd/grove/commands/fork.go
@@ -283,38 +283,41 @@ Examples:
 			return output.PrintJSON(result)
 		}
 
-		// Switch to new worktree unless --no-switch
+		// Switch to new worktree unless --no-switch.
+		// Batch the SetLastWorktree + TouchWorktree pair into a single state save.
 		if !forkNoSwitch {
-			// Update last_worktree before switching
-			if err := ctx.State.SetLastWorktree(parentName); err != nil {
-				log.Printf("failed to set last worktree %q: %v", parentName, err)
-			}
+			var tmuxSwitched bool
+			_ = ctx.State.Batch(func() error {
+				if err := ctx.State.SetLastWorktree(parentName); err != nil {
+					log.Printf("failed to set last worktree %q: %v", parentName, err)
+				}
 
-			// Store current session as last if inside tmux
-			if tmux.IsInsideTmux() {
-				currentSession, err := tmux.GetCurrentSession()
-				if err == nil {
-					if err := tmux.StoreLastSession(currentSession); err != nil {
-						log.Printf("failed to store last session %q: %v", currentSession, err)
+				// Store current session as last if inside tmux
+				if tmux.IsInsideTmux() {
+					currentSession, err := tmux.GetCurrentSession()
+					if err == nil {
+						if err := tmux.StoreLastSession(currentSession); err != nil {
+							log.Printf("failed to store last session %q: %v", currentSession, err)
+						}
 					}
 				}
-			}
 
-			// Switch tmux session
-			var tmuxSwitched bool
-			if tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
-				sessionName := worktree.TmuxSessionName(projectName, name)
-				if err := tmux.SwitchSession(sessionName); err != nil {
-					cli.Warning(w, "Failed to switch session: %v", err)
-				} else {
-					tmuxSwitched = true
+				// Switch tmux session
+				if tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
+					sessionName := worktree.TmuxSessionName(projectName, name)
+					if err := tmux.SwitchSession(sessionName); err != nil {
+						cli.Warning(w, "Failed to switch session: %v", err)
+					} else {
+						tmuxSwitched = true
+					}
 				}
-			}
 
-			// Update last_accessed_at for target worktree
-			if err := ctx.State.TouchWorktree(name); err != nil {
-				log.Printf("failed to touch worktree %q: %v", name, err)
-			}
+				// Update last_accessed_at for target worktree
+				if err := ctx.State.TouchWorktree(name); err != nil {
+					log.Printf("failed to touch worktree %q: %v", name, err)
+				}
+				return nil
+			})
 
 			// Skip cd directive when tmux switch already moved the user
 			if !tmuxSwitched {

--- a/cmd/grove/commands/fork.go
+++ b/cmd/grove/commands/fork.go
@@ -287,7 +287,7 @@ Examples:
 		// Batch the SetLastWorktree + TouchWorktree pair into a single state save.
 		if !forkNoSwitch {
 			var tmuxSwitched bool
-			_ = ctx.State.Batch(func() error {
+			batchErr := ctx.State.Batch(func() error {
 				if err := ctx.State.SetLastWorktree(parentName); err != nil {
 					log.Printf("failed to set last worktree %q: %v", parentName, err)
 				}
@@ -318,6 +318,9 @@ Examples:
 				}
 				return nil
 			})
+			if batchErr != nil {
+				log.Printf("state save failed: %v", batchErr)
+			}
 
 			// Skip cd directive when tmux switch already moved the user
 			if !tmuxSwitched {

--- a/cmd/grove/commands/helpers.go
+++ b/cmd/grove/commands/helpers.go
@@ -115,9 +115,18 @@ type worktreeSetupOpts struct {
 // setupCreatedWorktree runs the shared post-create sequence: find the worktree,
 // symlink config, register state, execute hooks, and auto-start Docker.
 func setupCreatedWorktree(ctx *GroveContext, mgr *worktree.Manager, name, branchName string, opts worktreeSetupOpts, w *cli.Writer) (*worktree.Worktree, error) {
-	wt, err := mgr.Find(name)
-	if err != nil || wt == nil {
-		return nil, fmt.Errorf("failed to find created worktree: %w", err)
+	// Compute the canonical path directly. The worktree was just created by
+	// the caller at the standard location, so re-running List() to find it
+	// would only burn another N parallel git status calls.
+	wtPath := mgr.PathForName(name)
+	if _, err := os.Stat(wtPath); err != nil {
+		return nil, fmt.Errorf("created worktree not found at %s: %w", wtPath, err)
+	}
+	wt := &worktree.Worktree{
+		Name:      filepath.Base(wtPath),
+		Path:      wtPath,
+		Branch:    branchName,
+		ShortName: name,
 	}
 
 	if !opts.JSONOutput {

--- a/cmd/grove/commands/last.go
+++ b/cmd/grove/commands/last.go
@@ -56,40 +56,46 @@ var lastCmd = &cobra.Command{
 			return fmt.Errorf("last worktree '%s' not found", lastWorktree)
 		}
 
-		// Get current worktree for state update
-		currentTree, _ := mgr.GetCurrent()
-		if currentTree != nil {
-			// Update last_worktree in state before switching
-			if err := ctx.State.SetLastWorktree(currentTree.DisplayName()); err != nil {
-				log.Printf("failed to set last worktree %q: %v", currentTree.DisplayName(), err)
-			}
-		}
-
-		// Store current session as last if inside tmux
-		if tmux.IsInsideTmux() {
-			currentSession, err := tmux.GetCurrentSession()
-			if err == nil {
-				if err := tmux.StoreLastSession(currentSession); err != nil {
-					log.Printf("failed to store last session %q: %v", currentSession, err)
+		// Batch the SetLastWorktree + TouchWorktree pair so the state file
+		// is written once instead of twice.
+		projectName := mgr.GetProjectName()
+		var tmuxSwitched bool
+		if batchErr := ctx.State.Batch(func() error {
+			if currentPath, err := mgr.CurrentPath(); err == nil {
+				prevName := mgr.DisplayNameForPath(currentPath)
+				if prevName != "" {
+					if err := ctx.State.SetLastWorktree(prevName); err != nil {
+						log.Printf("failed to set last worktree %q: %v", prevName, err)
+					}
 				}
 			}
-		}
 
-		projectName := mgr.GetProjectName()
-
-		// Switch to session
-		var tmuxSwitched bool
-		if tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
-			sessionName := worktree.TmuxSessionName(projectName, lastWorktree)
-			if err := tmux.SwitchSession(sessionName); err != nil {
-				return fmt.Errorf("failed to switch session: %w", err)
+			// Store current session as last if inside tmux
+			if tmux.IsInsideTmux() {
+				currentSession, err := tmux.GetCurrentSession()
+				if err == nil {
+					if err := tmux.StoreLastSession(currentSession); err != nil {
+						log.Printf("failed to store last session %q: %v", currentSession, err)
+					}
+				}
 			}
-			tmuxSwitched = true
-		}
 
-		// Update last_accessed_at for target worktree
-		if err := ctx.State.TouchWorktree(targetTree.DisplayName()); err != nil {
-			log.Printf("failed to touch worktree %q: %v", targetTree.DisplayName(), err)
+			// Switch to session
+			if tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
+				sessionName := worktree.TmuxSessionName(projectName, lastWorktree)
+				if err := tmux.SwitchSession(sessionName); err != nil {
+					return fmt.Errorf("failed to switch session: %w", err)
+				}
+				tmuxSwitched = true
+			}
+
+			// Update last_accessed_at for target worktree
+			if err := ctx.State.TouchWorktree(targetTree.DisplayName()); err != nil {
+				log.Printf("failed to touch worktree %q: %v", targetTree.DisplayName(), err)
+			}
+			return nil
+		}); batchErr != nil {
+			return batchErr
 		}
 
 		// JSON output mode

--- a/cmd/grove/commands/ls.go
+++ b/cmd/grove/commands/ls.go
@@ -94,8 +94,18 @@ var lsCmd = &cobra.Command{
 		// Get project name for tmux session naming
 		projectName := mgr.GetProjectName()
 
-		// Get current worktree to mark it
-		currentTree, _ := mgr.GetCurrent()
+		// Resolve current worktree from the trees we already fetched, rather
+		// than calling GetCurrent (which re-runs List with N parallel git
+		// status calls).
+		var currentTree *worktree.Worktree
+		if currentPath, err := mgr.CurrentPath(); err == nil {
+			for _, t := range trees {
+				if t.Path == currentPath {
+					currentTree = t
+					break
+				}
+			}
+		}
 
 		// Get tmux sessions for status
 		tmuxAvailable := tmux.IsTmuxAvailable()

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -83,8 +83,10 @@ Examples:
 			return fmt.Errorf("failed to initialize worktree manager: %w", err)
 		}
 
-		// Check if worktree already exists
-		if existingWt, _ := mgr.Find(name); existingWt != nil {
+		// Quick path-based existence check — avoids List() with N parallel
+		// dirty checks. If a non-standard or prunable worktree owns the name,
+		// the eventual git worktree add will surface it.
+		if mgr.PathExists(name) {
 			return fmt.Errorf("worktree '%s' already exists\n\nOptions:\n  • Switch to it: grove to %s\n  • Remove it first: grove rm %s\n  • Use different name: grove new %s-v2",
 				name, name, name, name)
 		}
@@ -190,46 +192,52 @@ Examples:
 			return nil
 		}
 
-		// Determine current worktree name for state tracking
+		// Determine current worktree name for state tracking. CurrentPath +
+		// DisplayNameForPath skips the List()-with-N-dirty-checks that
+		// GetCurrent would trigger.
 		currentWorktreeName := ""
-		if currentWt, _ := mgr.GetCurrent(); currentWt != nil {
-			currentWorktreeName = currentWt.DisplayName()
+		if currentPath, err := mgr.CurrentPath(); err == nil {
+			currentWorktreeName = mgr.DisplayNameForPath(currentPath)
 		}
 
-		// Switch to new worktree unless --no-switch
+		// Switch to new worktree unless --no-switch.
+		// Batch the SetLastWorktree + TouchWorktree pair so the state file is
+		// flock-merged-renamed once instead of twice.
 		if !newNoSwitch {
-			// Update last_worktree before switching
-			if currentWorktreeName != "" {
-				if err := ctx.State.SetLastWorktree(currentWorktreeName); err != nil {
-					log.Printf("failed to set last worktree %q: %v", currentWorktreeName, err)
-				}
-			}
-
-			// Store current session as last if inside tmux
-			if tmux.IsInsideTmux() {
-				currentSession, err := tmux.GetCurrentSession()
-				if err == nil {
-					if err := tmux.StoreLastSession(currentSession); err != nil {
-						log.Printf("failed to store last session %q: %v", currentSession, err)
+			var tmuxSwitched bool
+			_ = ctx.State.Batch(func() error {
+				if currentWorktreeName != "" {
+					if err := ctx.State.SetLastWorktree(currentWorktreeName); err != nil {
+						log.Printf("failed to set last worktree %q: %v", currentWorktreeName, err)
 					}
 				}
-			}
 
-			// Switch tmux session if inside tmux (skip in agent mode)
-			var tmuxSwitched bool
-			if !ctx.Config.AgentMode && tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
-				sessionName := worktree.TmuxSessionName(projectName, name)
-				if err := tmux.SwitchSession(sessionName); err != nil {
-					cli.Warning(w, "Failed to switch session: %v", err)
-				} else {
-					tmuxSwitched = true
+				// Store current session as last if inside tmux
+				if tmux.IsInsideTmux() {
+					currentSession, err := tmux.GetCurrentSession()
+					if err == nil {
+						if err := tmux.StoreLastSession(currentSession); err != nil {
+							log.Printf("failed to store last session %q: %v", currentSession, err)
+						}
+					}
 				}
-			}
 
-			// Update last_accessed_at for target worktree
-			if err := ctx.State.TouchWorktree(name); err != nil {
-				log.Printf("failed to touch worktree %q: %v", name, err)
-			}
+				// Switch tmux session if inside tmux (skip in agent mode)
+				if !ctx.Config.AgentMode && tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
+					sessionName := worktree.TmuxSessionName(projectName, name)
+					if err := tmux.SwitchSession(sessionName); err != nil {
+						cli.Warning(w, "Failed to switch session: %v", err)
+					} else {
+						tmuxSwitched = true
+					}
+				}
+
+				// Update last_accessed_at for target worktree
+				if err := ctx.State.TouchWorktree(name); err != nil {
+					log.Printf("failed to touch worktree %q: %v", name, err)
+				}
+				return nil
+			})
 
 			// Skip cd directive when tmux switch already moved the user
 			if !tmuxSwitched {

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -205,7 +205,7 @@ Examples:
 		// flock-merged-renamed once instead of twice.
 		if !newNoSwitch {
 			var tmuxSwitched bool
-			_ = ctx.State.Batch(func() error {
+			batchErr := ctx.State.Batch(func() error {
 				if currentWorktreeName != "" {
 					if err := ctx.State.SetLastWorktree(currentWorktreeName); err != nil {
 						log.Printf("failed to set last worktree %q: %v", currentWorktreeName, err)
@@ -238,6 +238,9 @@ Examples:
 				}
 				return nil
 			})
+			if batchErr != nil {
+				log.Printf("state save failed: %v", batchErr)
+			}
 
 			// Skip cd directive when tmux switch already moved the user
 			if !tmuxSwitched {

--- a/cmd/grove/commands/rename.go
+++ b/cmd/grove/commands/rename.go
@@ -83,8 +83,12 @@ Examples:
 			return fmt.Errorf("failed to check new name: %w", err)
 		}
 
-		// Validate rename preconditions
-		currentTree, _ := mgr.GetCurrent()
+		// Validate rename preconditions. validateRename only consults
+		// current.Path — synthesize a minimal Worktree from CurrentPath.
+		var currentTree *worktree.Worktree
+		if currentPath, err := mgr.CurrentPath(); err == nil {
+			currentTree = &worktree.Worktree{Path: currentPath}
+		}
 		if err := validateRename(wt, existing, currentTree, ctx.Config, oldName); err != nil {
 			cli.Error(stderr, "%s", err)
 			if err == errCurrentWorktree {
@@ -98,23 +102,26 @@ Examples:
 			return fmt.Errorf("failed to move worktree: %w", err)
 		}
 
-		// Step 2: Rename in state
-		if err := ctx.State.RenameWorktree(oldName, newName); err != nil {
-			cli.Warning(w, "Worktree moved but state update failed: %v", err)
-		}
-
-		// Step 3: Update the path in state to reflect the new directory
+		// Steps 2 + 3: rename in state, then update the path. Batched into a
+		// single save — without this the rename + path update would write
+		// state.json twice.
 		newFullName := mgr.FullName(newName)
-		newWt, findErr := mgr.Find(newName)
-		if findErr == nil && newWt != nil {
-			if ws, _ := ctx.State.GetWorktree(newName); ws != nil {
-				ws.Path = newWt.Path
-				// Re-add to save the updated path
-				_ = ctx.State.AddWorktree(newName, ws)
+		_ = ctx.State.Batch(func() error {
+			if err := ctx.State.RenameWorktree(oldName, newName); err != nil {
+				cli.Warning(w, "Worktree moved but state update failed: %v", err)
 			}
-		} else {
-			cli.Warning(w, "Could not update worktree path for %s", newFullName)
-		}
+
+			newWt, findErr := mgr.Find(newName)
+			if findErr == nil && newWt != nil {
+				if ws, _ := ctx.State.GetWorktree(newName); ws != nil {
+					ws.Path = newWt.Path
+					_ = ctx.State.AddWorktree(newName, ws)
+				}
+			} else {
+				cli.Warning(w, "Could not update worktree path for %s", newFullName)
+			}
+			return nil
+		})
 
 		cli.Success(w, "Renamed worktree '%s' to '%s'", oldName, newName)
 

--- a/cmd/grove/commands/rename.go
+++ b/cmd/grove/commands/rename.go
@@ -106,7 +106,7 @@ Examples:
 		// single save — without this the rename + path update would write
 		// state.json twice.
 		newFullName := mgr.FullName(newName)
-		_ = ctx.State.Batch(func() error {
+		batchErr := ctx.State.Batch(func() error {
 			if err := ctx.State.RenameWorktree(oldName, newName); err != nil {
 				cli.Warning(w, "Worktree moved but state update failed: %v", err)
 			}
@@ -122,6 +122,9 @@ Examples:
 			}
 			return nil
 		})
+		if batchErr != nil {
+			cli.Warning(w, "state save failed: %v", batchErr)
+		}
 
 		cli.Success(w, "Renamed worktree '%s' to '%s'", oldName, newName)
 

--- a/cmd/grove/commands/rm.go
+++ b/cmd/grove/commands/rm.go
@@ -128,28 +128,30 @@ Examples:
 			}
 		}
 
-		// Check if trying to remove the current worktree
-		currentTree, _ := mgr.GetCurrent()
-		if currentTree != nil && currentTree.Path == wt.Path {
+		// Check if trying to remove the current worktree. CurrentPath avoids
+		// the per-worktree dirty checks GetCurrent would perform on the rest
+		// of the repo.
+		if currentPath, err := mgr.CurrentPath(); err == nil && currentPath == wt.Path {
 			cli.Error(stderr, "cannot remove current worktree '%s'", name)
 			cli.Info(stderr, "Switch to another worktree first: grove to <name>")
 			os.Exit(exitcode.CannotRemove)
 		}
 
-		// Cannot remove dirty worktree without --force
-		if wt.IsDirty && !rmForce {
-			cli.Error(stderr, "worktree '%s' has uncommitted changes", name)
-			dirtyFiles, err := mgr.GetDirtyFiles(wt.Path)
-			if err == nil && dirtyFiles != "" {
+		// Cannot remove dirty worktree without --force. Dirty status is no
+		// longer populated by Find — check it here for just this one path.
+		if !rmForce {
+			dirtyFiles, _ := mgr.GetDirtyFiles(wt.Path)
+			if dirtyFiles != "" {
+				cli.Error(stderr, "worktree '%s' has uncommitted changes", name)
 				for _, line := range strings.Split(dirtyFiles, "\n") {
 					if line != "" {
 						cli.Faint(stderr, "  %s", line)
 					}
 				}
+				cli.Info(stderr, "To remove anyway: grove rm %s --force", name)
+				cli.Info(stderr, "To switch and commit: grove to %s", name)
+				os.Exit(exitcode.CannotRemove)
 			}
-			cli.Info(stderr, "To remove anyway: grove rm %s --force", name)
-			cli.Info(stderr, "To switch and commit: grove to %s", name)
-			os.Exit(exitcode.CannotRemove)
 		}
 
 		// Dry run - just show what would happen

--- a/cmd/grove/commands/select_worktree.go
+++ b/cmd/grove/commands/select_worktree.go
@@ -41,14 +41,16 @@ func selectWorktree(ctx *GroveContext, prompt string) (string, error) {
 // Supports selection by number or by name. Escape and Ctrl+C cancel cleanly.
 func chooseWorktree(mgr *worktree.Manager, trees []*worktree.Worktree, prompt string) (string, error) {
 	w := cli.NewStderr()
-	currentTree, _ := mgr.GetCurrent()
+	// Just need the path to mark the current row — CurrentPath skips
+	// GetCurrent's commit-info enrichment + dirty check.
+	currentPath, _ := mgr.CurrentPath()
 
 	cli.Bold(w, "%s", prompt)
 	_, _ = fmt.Fprintln(w)
 
 	for i, tree := range trees {
 		indicator := "  "
-		if currentTree != nil && tree.Path == currentTree.Path {
+		if currentPath != "" && tree.Path == currentPath {
 			indicator = cli.Accent(w, "● ") //nolint:gosmopolitan
 		}
 

--- a/cmd/grove/commands/sync.go
+++ b/cmd/grove/commands/sync.go
@@ -87,22 +87,24 @@ Examples:
 			// Sync specific worktree
 			targets = []string{args[0]}
 		} else {
-			// Sync current if it's an environment worktree
-			currentTree, err := mgr.GetCurrent()
+			// Sync current if it's an environment worktree. Use the cheap
+			// path lookup since we only need the worktree's short name.
+			currentPath, err := mgr.CurrentPath()
 			if err != nil {
 				return fmt.Errorf("failed to get current worktree: %w", err)
 			}
-			if currentTree == nil {
+			currentName := mgr.DisplayNameForPath(currentPath)
+			if currentName == "" {
 				return fmt.Errorf("could not determine current worktree")
 			}
 
-			isEnv, _ := ctx.State.IsEnvironment(currentTree.ShortName)
+			isEnv, _ := ctx.State.IsEnvironment(currentName)
 			if !isEnv {
-				fmt.Fprintf(os.Stderr, "Error: current worktree '%s' is not an environment worktree\n", currentTree.ShortName)
+				fmt.Fprintf(os.Stderr, "Error: current worktree '%s' is not an environment worktree\n", currentName)
 				fmt.Fprintf(os.Stderr, "Use 'grove sync <name>' to specify an environment worktree, or --all\n")
 				os.Exit(exitcode.ConstraintViolated)
 			}
-			targets = []string{currentTree.ShortName}
+			targets = []string{currentName}
 		}
 
 		result := SyncResult{

--- a/cmd/grove/commands/to.go
+++ b/cmd/grove/commands/to.go
@@ -70,16 +70,17 @@ When using shell integration, this will also change your current directory.`,
 			return fmt.Errorf("worktree '%s' is stale (directory missing). Run 'grove rm %s' to clean up", name, name)
 		}
 
-		// Get current worktree for hook context and state update
-		currentTree, _ := mgr.GetCurrent()
+		// Get current worktree for hook context and state update. Path +
+		// display name are all that's needed — the WIP handler does its own
+		// per-path dirty check below.
 		var prevWorktree string
 		var prevWorktreePath string
-		if currentTree != nil {
-			prevWorktree = currentTree.DisplayName()
-			prevWorktreePath = currentTree.Path
+		if currentPath, err := mgr.CurrentPath(); err == nil && currentPath != "" {
+			prevWorktree = mgr.DisplayNameForPath(currentPath)
+			prevWorktreePath = currentPath
 
 			// Check for dirty worktree before allowing switch
-			wip := worktree.NewWIPHandler(currentTree.Path)
+			wip := worktree.NewWIPHandler(currentPath)
 			hasDirty, wipErr := wip.HasWIP()
 			if wipErr != nil {
 				log.Printf("failed to check dirty state: %v", wipErr)

--- a/cmd/profile_tui/main.go
+++ b/cmd/profile_tui/main.go
@@ -1,0 +1,116 @@
+// cmd/profile_tui exercises the TUI fetch hot path against a real grove
+// project and reports timing for each phase.
+//
+// Usage: go run ./cmd/profile_tui /path/to/grove/project
+//
+// Output reports:
+//   - per-phase timing for the FetchWorktrees call path
+//   - drilldown timings for List(), GetCurrent(), tmux, and plugin status
+//
+// Use to validate performance changes against a real, populated repo
+// (e.g. one with many worktrees) since unit tests run on tiny synthetic
+// repos that hide cumulative subprocess cost.
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/lost-in-the/grove/internal/config"
+	"github.com/lost-in-the/grove/internal/grove"
+	"github.com/lost-in-the/grove/internal/plugins"
+	"github.com/lost-in-the/grove/internal/state"
+	"github.com/lost-in-the/grove/internal/tmux"
+	"github.com/lost-in-the/grove/internal/tui"
+	"github.com/lost-in-the/grove/internal/worktree"
+	docker "github.com/lost-in-the/grove/plugins/docker"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: profile_tui <project-dir>")
+		os.Exit(2)
+	}
+	dir := os.Args[1]
+	if err := os.Chdir(dir); err != nil {
+		fail("chdir: %v", err)
+	}
+
+	t0 := time.Now()
+	groveDir, err := grove.IsGroveProject()
+	if err != nil || groveDir == "" {
+		fail("not a grove project: %v", err)
+	}
+	projectRoot := grove.MustProjectRoot(groveDir)
+	step(t0, "detected grove project")
+
+	t1 := time.Now()
+	mgr, err := worktree.NewManager(projectRoot)
+	if err != nil {
+		fail("worktree.NewManager: %v", err)
+	}
+	step(t1, "worktree.NewManager")
+
+	t2 := time.Now()
+	stateMgr, err := state.NewManager(groveDir)
+	if err != nil {
+		fail("state.NewManager: %v", err)
+	}
+	step(t2, "state.NewManager")
+
+	t3 := time.Now()
+	cfg, _ := config.LoadFromGroveDir(groveDir)
+	step(t3, "config.LoadFromGroveDir")
+
+	pluginMgr := plugins.NewManager(cfg)
+	dockerPlugin := docker.New()
+	if err := dockerPlugin.Init(cfg); err == nil {
+		_ = pluginMgr.Register(dockerPlugin)
+	}
+
+	t4 := time.Now()
+	items, err := tui.FetchWorktrees(mgr, stateMgr, pluginMgr)
+	if err != nil {
+		fail("tui.FetchWorktrees: %v", err)
+	}
+	step(t4, fmt.Sprintf("tui.FetchWorktrees -> %d items", len(items)))
+
+	fmt.Printf("\nTotal: %dms\n", time.Since(t0).Milliseconds())
+
+	fmt.Println("\n--- drilldown ---")
+	mgr2, _ := worktree.NewManager(projectRoot)
+
+	t5 := time.Now()
+	trees, _ := mgr2.List()
+	step(t5, fmt.Sprintf("mgr.List() -> %d trees", len(trees)))
+
+	t6 := time.Now()
+	_, _ = mgr2.GetCurrent()
+	step(t6, "mgr.GetCurrent()")
+
+	t7 := time.Now()
+	_ = tmux.IsTmuxAvailable()
+	step(t7, "tmux.IsTmuxAvailable")
+
+	t8 := time.Now()
+	sessions, _ := tmux.ListSessions()
+	step(t8, fmt.Sprintf("tmux.ListSessions -> %d sessions", len(sessions)))
+
+	t9 := time.Now()
+	paths := make([]string, len(trees))
+	for i, t := range trees {
+		paths[i] = t.Path
+	}
+	statuses := pluginMgr.CollectStatuses(paths)
+	step(t9, fmt.Sprintf("pluginMgr.CollectStatuses -> %d statuses", len(statuses)))
+}
+
+func step(t time.Time, label string) {
+	fmt.Printf("[%6dms] %s\n", time.Since(t).Milliseconds(), label)
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/internal/hooks/executor.go
+++ b/internal/hooks/executor.go
@@ -7,6 +7,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -157,14 +158,25 @@ func disabledTypeHint(typeName string) (string, bool) {
 	return "", false
 }
 
+// currentUsername caches the result of user.Current() across hook invocations.
+// The username doesn't change during a process lifetime, so the syscall is
+// pure waste on subsequent calls.
+var (
+	currentUsernameOnce sync.Once
+	currentUsername     string
+)
+
+func cachedUsername() string {
+	currentUsernameOnce.Do(func() {
+		if u, err := user.Current(); err == nil {
+			currentUsername = u.Username
+		}
+	})
+	return currentUsername
+}
+
 // buildVariables creates the variable context for interpolation
 func (e *Executor) buildVariables(ctx *ExecutionContext) *Variables {
-	// Get current username
-	username := ""
-	if u, err := user.Current(); err == nil {
-		username = u.Username
-	}
-
 	now := time.Now()
 
 	return &Variables{
@@ -176,7 +188,7 @@ func (e *Executor) buildVariables(ctx *ExecutionContext) *Variables {
 		NewPath:      ctx.NewPath,
 		PrevPath:     ctx.PrevPath,
 		Port:         ctx.Port,
-		User:         username,
+		User:         cachedUsername(),
 		Timestamp:    now.Unix(),
 		Date:         now.Format("2006-01-02"),
 	}
@@ -197,30 +209,25 @@ type Variables struct {
 	Date         string // ISO date (YYYY-MM-DD)
 }
 
-// Interpolate replaces template variables in a string using {{.variable}} syntax
+// Interpolate replaces template variables in a string using {{.variable}} syntax.
+// Uses strings.NewReplacer for a single-pass replacement instead of N
+// sequential strings.ReplaceAll calls — meaningful when many hook fields are
+// interpolated.
 func (v *Variables) Interpolate(s string) string {
-	// Simple interpolation without full text/template for basic cases
-	// This handles the common {{.variable}} pattern
-	replacements := map[string]string{
-		"{{.worktree}}":      v.Worktree,
-		"{{.worktree_full}}": v.WorktreeFull,
-		"{{.branch}}":        v.Branch,
-		"{{.project}}":       v.Project,
-		"{{.main_path}}":     v.MainPath,
-		"{{.new_path}}":      v.NewPath,
-		"{{.prev_path}}":     v.PrevPath,
-		"{{.port}}":          fmt.Sprintf("%d", v.Port),
-		"{{.user}}":          v.User,
-		"{{.timestamp}}":     fmt.Sprintf("%d", v.Timestamp),
-		"{{.date}}":          v.Date,
-	}
-
-	result := s
-	for pattern, value := range replacements {
-		result = strings.ReplaceAll(result, pattern, value)
-	}
-
-	return result
+	r := strings.NewReplacer(
+		"{{.worktree}}", v.Worktree,
+		"{{.worktree_full}}", v.WorktreeFull,
+		"{{.branch}}", v.Branch,
+		"{{.project}}", v.Project,
+		"{{.main_path}}", v.MainPath,
+		"{{.new_path}}", v.NewPath,
+		"{{.prev_path}}", v.PrevPath,
+		"{{.port}}", fmt.Sprintf("%d", v.Port),
+		"{{.user}}", v.User,
+		"{{.timestamp}}", fmt.Sprintf("%d", v.Timestamp),
+		"{{.date}}", v.Date,
+	)
+	return r.Replace(s)
 }
 
 // builtinCopy performs a copy action

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -45,6 +45,8 @@ type Manager struct {
 	mu               sync.RWMutex
 	state            *State
 	removedWorktrees map[string]bool // tracks explicit removals for merge in save()
+	batchDepth       int             // > 0 while inside Batch — setters defer their save()
+	batchDirty       bool            // a setter ran during the current batch
 }
 
 // NewManager creates a new state manager for a grove project
@@ -98,7 +100,7 @@ func (m *Manager) SetProject(name string) error {
 	defer m.mu.Unlock()
 
 	m.state.Project = name
-	return m.save()
+	return m.saveOrDefer()
 }
 
 // GetProject returns the project name from state
@@ -125,7 +127,7 @@ func (m *Manager) SetLastWorktree(name string) error {
 	defer m.mu.Unlock()
 
 	m.state.LastWorktree = name
-	return m.save()
+	return m.saveOrDefer()
 }
 
 // AddWorktree adds a new worktree to state
@@ -141,7 +143,7 @@ func (m *Manager) AddWorktree(name string, ws *WorktreeState) error {
 	defer m.mu.Unlock()
 
 	m.state.Worktrees[name] = ws
-	return m.save()
+	return m.saveOrDefer()
 }
 
 // GetWorktree returns the worktree state for a given name
@@ -171,7 +173,7 @@ func (m *Manager) RemoveWorktree(name string) error {
 
 	delete(m.state.Worktrees, name)
 	m.removedWorktrees[name] = true
-	return m.save()
+	return m.saveOrDefer()
 }
 
 // RenameWorktree renames a worktree in state, moving all fields to the new key.
@@ -207,7 +209,7 @@ func (m *Manager) RenameWorktree(oldName, newName string) error {
 		m.state.LastWorktree = newName
 	}
 
-	return m.save()
+	return m.saveOrDefer()
 }
 
 // TouchWorktree updates the last_accessed_at timestamp for a worktree
@@ -225,7 +227,7 @@ func (m *Manager) TouchWorktree(name string) error {
 	}
 
 	ws.LastAccessedAt = time.Now()
-	return m.save()
+	return m.saveOrDefer()
 }
 
 // IsEnvironment checks if a worktree is an environment worktree
@@ -262,6 +264,48 @@ func (m *Manager) GetState() State {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return *m.state
+}
+
+// Batch suppresses individual save() calls inside fn and flushes a single
+// save when the outermost batch ends. Use when a command runs multiple state
+// mutations in sequence — collapses N flock+merge+rename cycles into one.
+//
+// The flush runs in a defer so it still happens if fn panics (the panic
+// continues to propagate after the flush). os.Exit inside fn skips deferred
+// saves — keep validation-failure exits before any state mutations.
+//
+// Contract: only the goroutine calling Batch should mutate this Manager
+// during fn. Concurrent mutations from other goroutines would also have
+// their saves suppressed and may not be flushed.
+func (m *Manager) Batch(fn func() error) (retErr error) {
+	m.mu.Lock()
+	m.batchDepth++
+	m.mu.Unlock()
+
+	defer func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.batchDepth--
+		if m.batchDepth == 0 && m.batchDirty {
+			m.batchDirty = false
+			if saveErr := m.save(); saveErr != nil && retErr == nil {
+				retErr = saveErr
+			}
+		}
+	}()
+
+	return fn()
+}
+
+// saveOrDefer saves immediately when no batch is active, or just marks the
+// in-memory state dirty when a Batch is in progress so the outermost Batch
+// can flush once. Callers must hold m.mu (matches save's contract).
+func (m *Manager) saveOrDefer() error {
+	if m.batchDepth > 0 {
+		m.batchDirty = true
+		return nil
+	}
+	return m.save()
 }
 
 // load reads the state from disk

--- a/internal/tui/animation.go
+++ b/internal/tui/animation.go
@@ -18,22 +18,27 @@ func GroveSpinner() spinner.Model {
 	return s
 }
 
+// Pre-built styles for ToastOpacity. Allocating a new lipgloss.Style on every
+// render frame (toasts can be re-rendered on every tick) is wasted work — the
+// only two states are "full" and "faint".
+var (
+	toastStyleFull  = lipgloss.NewStyle()
+	toastStyleFaint = lipgloss.NewStyle().Faint(true)
+)
+
 // ToastOpacity returns a lipgloss.Style modifier based on how close the toast
 // is to expiry. Returns full opacity for most of the lifetime, then fades in
 // the final 800ms.
 func ToastOpacity(t *Toast) lipgloss.Style {
 	if t == nil {
-		return lipgloss.NewStyle()
+		return toastStyleFull
 	}
 	elapsed := time.Since(t.CreatedAt)
 	remaining := t.Duration - elapsed
-	fadeWindow := 800 * time.Millisecond
+	const fadeWindow = 800 * time.Millisecond
 
-	if remaining <= 0 {
-		return lipgloss.NewStyle().Faint(true)
-	}
 	if remaining < fadeWindow {
-		return lipgloss.NewStyle().Faint(true)
+		return toastStyleFaint
 	}
-	return lipgloss.NewStyle()
+	return toastStyleFull
 }

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -29,9 +29,14 @@ func (m Model) fetchWorktrees() tea.Msg {
 // numbers (CommitCount, StashCount) for the given items in the background.
 // Use after the dashboard has rendered so the user doesn't wait on N extra
 // git calls before first paint.
-func fetchDetailMetricsCmd(items []WorktreeItem, defaultBranch string) tea.Cmd {
+//
+// gen is the model's detail-metrics generation at dispatch time and is
+// echoed back in the result so the handler can drop late deliveries from
+// a superseded fetch.
+func fetchDetailMetricsCmd(gen int, items []WorktreeItem, defaultBranch string) tea.Cmd {
 	return func() tea.Msg {
 		return detailMetricsLoadedMsg{
+			gen:     gen,
 			metrics: FetchDetailMetrics(items, defaultBranch),
 		}
 	}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -25,6 +25,18 @@ func (m Model) fetchWorktrees() tea.Msg {
 	return worktreesFetchedMsg{items: items, err: err}
 }
 
+// fetchDetailMetricsCmd returns a tea.Cmd that loads the detail-panel-only
+// numbers (CommitCount, StashCount) for the given items in the background.
+// Use after the dashboard has rendered so the user doesn't wait on N extra
+// git calls before first paint.
+func fetchDetailMetricsCmd(items []WorktreeItem, defaultBranch string) tea.Cmd {
+	return func() tea.Msg {
+		return detailMetricsLoadedMsg{
+			metrics: FetchDetailMetrics(items, defaultBranch),
+		}
+	}
+}
+
 func deleteWorktreeCmd(mgr *worktree.Manager, stateMgr *state.Manager, projectRoot, name string, deleteBranch bool) tea.Cmd {
 	return func() tea.Msg {
 		projectName := mgr.GetProjectName()

--- a/internal/tui/data.go
+++ b/internal/tui/data.go
@@ -106,6 +106,7 @@ type fetchContext struct {
 	cfg           *config.Config
 	stateMgr      *state.Manager
 	mgr           *worktree.Manager
+	upstreams     map[string]worktreeinfo.BranchUpstream // keyed by branch name
 }
 
 func loadFetchContext(mgr *worktree.Manager, stateMgr *state.Manager) fetchContext {
@@ -125,13 +126,14 @@ func loadFetchContext(mgr *worktree.Manager, stateMgr *state.Manager) fetchConte
 		fc.defaultBranch = cfg.DefaultBranch
 	}
 
-	currentTree, currentErr := mgr.GetCurrent()
+	// Use CurrentPath (single git rev-parse) rather than GetCurrent, which
+	// would re-run List() with N parallel git status calls — already done by
+	// the caller.
+	currentPath, currentErr := mgr.CurrentPath()
 	if currentErr != nil {
-		tuilog.Printf("warning: failed to get current worktree: %v", currentErr)
+		tuilog.Printf("warning: failed to get current worktree path: %v", currentErr)
 	}
-	if currentTree != nil {
-		fc.currentPath = currentTree.Path
-	}
+	fc.currentPath = currentPath
 
 	if tmux.IsTmuxAvailable() {
 		sessionList, err := tmux.ListSessions()
@@ -180,37 +182,76 @@ func (fc *fetchContext) setStateInfo(item *WorktreeItem, shortName string) {
 	}
 }
 
-func (fc *fetchContext) enrichGitInfo(item *WorktreeItem, treePath, branch string, isDirty bool) {
-	shortHash, message, age, err := fc.mgr.GetCommitInfo(treePath)
-	if err != nil {
-		tuilog.Printf("warning: failed to get commit info for %q: %v", treePath, err)
-	} else {
-		item.Commit = shortHash
-		item.CommitMessage = message
-		item.CommitAge = age
-	}
+func (fc *fetchContext) enrichGitInfo(item *WorktreeItem, tree *worktree.Worktree) {
+	branch := tree.Branch
 
-	if isDirty {
-		dirtyFiles, err := fc.mgr.GetDirtyFiles(treePath)
-		if err != nil {
-			tuilog.Printf("warning: failed to get dirty files for %q: %v", treePath, err)
-		} else if dirtyFiles != "" {
-			for _, f := range strings.Split(dirtyFiles, "\n") {
-				if f != "" {
-					item.DirtyFiles = append(item.DirtyFiles, f)
-				}
+	// One git log call returns both the head commit info and recent commits.
+	commitInfo, recents := worktreeinfo.HeadAndRecentCommits(tree.Path, 3)
+	item.Commit = commitInfo.ShortHash
+	item.CommitMessage = commitInfo.Message
+	item.CommitAge = commitInfo.Age
+	item.RecentCommits = recents
+
+	// Dirty file list was populated by Manager.List(); split it here.
+	if tree.DirtyFiles != "" {
+		for _, f := range strings.Split(tree.DirtyFiles, "\n") {
+			if f != "" {
+				item.DirtyFiles = append(item.DirtyFiles, f)
 			}
 		}
 	}
 
-	item.AheadCount, item.BehindCount, item.HasRemote, item.TrackingBranch = worktreeinfo.UpstreamInfo(treePath)
-
-	if branch != fc.defaultBranch {
-		item.CommitCount = worktreeinfo.CommitCountAhead(treePath, fc.defaultBranch)
+	if up, ok := fc.upstreams[branch]; ok {
+		item.AheadCount = up.Ahead
+		item.BehindCount = up.Behind
+		item.HasRemote = up.HasRemote
+		item.TrackingBranch = up.Tracking
 	}
 
-	item.RecentCommits = worktreeinfo.RecentCommits(treePath, 3)
-	item.StashCount = worktreeinfo.StashCount(treePath)
+	// CommitCount (ahead of default branch) and StashCount are detail-panel
+	// only — defer their per-worktree git calls to FetchDetailMetrics so the
+	// dashboard renders without paying for ~2N extra git invocations.
+}
+
+// DetailMetrics holds the per-worktree numbers that only appear in the detail
+// panel: commits ahead of the default branch, and stash count. Computed
+// lazily after the dashboard has rendered.
+type DetailMetrics struct {
+	CommitCount int
+	StashCount  int
+}
+
+// FetchDetailMetrics loads the per-worktree detail-panel numbers (CommitCount,
+// StashCount) for every non-prunable item in parallel. Result is keyed by
+// worktree path. Skips worktrees on the default branch for CommitCount.
+//
+// Run this AFTER the initial FetchWorktrees so the dashboard paint isn't
+// blocked on N extra git calls. Takes the existing items rather than
+// re-listing — the caller already paid for List() once.
+func FetchDetailMetrics(items []WorktreeItem, defaultBranch string) map[string]DetailMetrics {
+	result := make(map[string]DetailMetrics, len(items))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, item := range items {
+		if item.IsPrunable {
+			continue
+		}
+		wg.Add(1)
+		go func(path, branch string) {
+			defer wg.Done()
+			m := DetailMetrics{
+				StashCount: worktreeinfo.StashCount(path),
+			}
+			if branch != defaultBranch {
+				m.CommitCount = worktreeinfo.CommitCountAhead(path, defaultBranch)
+			}
+			mu.Lock()
+			result[path] = m
+			mu.Unlock()
+		}(item.Path, item.Branch)
+	}
+	wg.Wait()
+	return result
 }
 
 // FetchWorktrees gathers all enriched worktree data for display.
@@ -222,6 +263,15 @@ func FetchWorktrees(mgr *worktree.Manager, stateMgr *state.Manager, pluginMgr ..
 	}
 
 	fc := loadFetchContext(mgr, stateMgr)
+
+	// Batch upstream tracking info for every local branch in one git call,
+	// instead of 2 calls per worktree.
+	upstreams, upErr := worktreeinfo.AllBranchUpstreams(mgr.GetRepoRoot())
+	if upErr != nil {
+		tuilog.Printf("warning: failed to load upstream info: %v", upErr)
+	}
+	fc.upstreams = upstreams
+
 	items := make([]WorktreeItem, len(trees))
 
 	var wg sync.WaitGroup
@@ -246,10 +296,10 @@ func FetchWorktrees(mgr *worktree.Manager, stateMgr *state.Manager, pluginMgr ..
 
 		if !tree.IsPrunable {
 			wg.Add(1)
-			go func(item *WorktreeItem, treePath, branch string, isDirty bool) {
+			go func(item *WorktreeItem, tree *worktree.Worktree) {
 				defer wg.Done()
-				fc.enrichGitInfo(item, treePath, branch, isDirty)
-			}(item, tree.Path, tree.Branch, tree.IsDirty)
+				fc.enrichGitInfo(item, tree)
+			}(item, tree)
 		}
 	}
 

--- a/internal/tui/data.go
+++ b/internal/tui/data.go
@@ -109,12 +109,21 @@ type fetchContext struct {
 	upstreams     map[string]worktreeinfo.BranchUpstream // keyed by branch name
 }
 
+// ResolveDefaultBranch returns the default branch name to use for "ahead of
+// default" calculations: cfg.DefaultBranch when set, otherwise "main". Single
+// source of truth for both the bulk fetcher and the lazy metrics dispatcher.
+func ResolveDefaultBranch(cfg *config.Config) string {
+	if cfg != nil && cfg.DefaultBranch != "" {
+		return cfg.DefaultBranch
+	}
+	return "main"
+}
+
 func loadFetchContext(mgr *worktree.Manager, stateMgr *state.Manager) fetchContext {
 	fc := fetchContext{
-		projectName:   mgr.GetProjectName(),
-		defaultBranch: "main",
-		stateMgr:      stateMgr,
-		mgr:           mgr,
+		projectName: mgr.GetProjectName(),
+		stateMgr:    stateMgr,
+		mgr:         mgr,
 	}
 
 	cfg, cfgErr := config.Load()
@@ -122,9 +131,7 @@ func loadFetchContext(mgr *worktree.Manager, stateMgr *state.Manager) fetchConte
 		tuilog.Printf("warning: failed to load config for protection checks: %v", cfgErr)
 	}
 	fc.cfg = cfg
-	if cfg != nil && cfg.DefaultBranch != "" {
-		fc.defaultBranch = cfg.DefaultBranch
-	}
+	fc.defaultBranch = ResolveDefaultBranch(cfg)
 
 	// Use CurrentPath (single git rev-parse) rather than GetCurrent, which
 	// would re-run List() with N parallel git status calls — already done by

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -13,7 +13,12 @@ type worktreesFetchedMsg struct {
 // detailMetricsLoadedMsg is sent after the deferred detail-panel metrics
 // (CommitCount, StashCount) have been computed for the visible worktrees.
 // Keyed by worktree path.
+//
+// gen identifies the FetchWorktrees iteration this result belongs to; the
+// handler drops messages whose gen no longer matches the model's current
+// generation, so a slow fetch can't apply old numbers to a fresh item set.
 type detailMetricsLoadedMsg struct {
+	gen     int
 	metrics map[string]DetailMetrics
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -10,6 +10,13 @@ type worktreesFetchedMsg struct {
 	err   error
 }
 
+// detailMetricsLoadedMsg is sent after the deferred detail-panel metrics
+// (CommitCount, StashCount) have been computed for the visible worktrees.
+// Keyed by worktree path.
+type detailMetricsLoadedMsg struct {
+	metrics map[string]DetailMetrics
+}
+
 // worktreeDeletedMsg is sent after a worktree deletion attempt.
 type worktreeDeletedMsg struct {
 	name         string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -99,10 +99,10 @@ type Model struct {
 	// Post-create selection
 	pendingSelect string
 
-	// Lazy-loaded detail-panel metrics (CommitCount, StashCount), keyed by
-	// worktree path. Populated after the initial fetch via a deferred Cmd.
-	// Renderers overlay these onto WorktreeItem before drawing the detail.
-	detailMetrics map[string]DetailMetrics
+	// Generation counter for the deferred detail-metrics fetch. Each
+	// FetchWorktrees bumps this; results from older generations are
+	// dropped so a stale fetch can't apply old numbers to a fresh item set.
+	detailMetricsGen int
 
 	// Output
 	switchTo            string
@@ -319,24 +319,23 @@ func (m Model) handleWorktreesFetched(msg worktreesFetchedMsg) (tea.Model, tea.C
 		}
 	}
 
-	defaultBranch := "main"
-	if m.cfg != nil && m.cfg.DefaultBranch != "" {
-		defaultBranch = m.cfg.DefaultBranch
-	}
+	// Bump the generation BEFORE dispatching the lazy fetch. Any in-flight
+	// metrics from a previous fetch will arrive with an older gen and get
+	// dropped by handleDetailMetricsLoaded.
+	m.detailMetricsGen++
 	return m, tea.Batch(
 		lookupPRsCmd(branches),
-		fetchDetailMetricsCmd(msg.items, defaultBranch),
+		fetchDetailMetricsCmd(m.detailMetricsGen, msg.items, ResolveDefaultBranch(m.cfg)),
 	)
 }
 
 func (m Model) handleDetailMetricsLoaded(msg detailMetricsLoadedMsg) (tea.Model, tea.Cmd) {
-	if msg.metrics == nil {
+	// Drop results from a stale fetch (a newer FetchWorktrees was dispatched
+	// after we kicked off this metrics load).
+	if msg.gen != m.detailMetricsGen || msg.metrics == nil {
 		return m, nil
 	}
-	m.detailMetrics = msg.metrics
 
-	// Apply metrics to items in the list so detail panel renders show them
-	// even when updateDetailContent is called outside this handler path.
 	listItems := m.list.Items()
 	for i, li := range listItems {
 		item, ok := li.(WorktreeItem)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -99,6 +99,11 @@ type Model struct {
 	// Post-create selection
 	pendingSelect string
 
+	// Lazy-loaded detail-panel metrics (CommitCount, StashCount), keyed by
+	// worktree path. Populated after the initial fetch via a deferred Cmd.
+	// Renderers overlay these onto WorktreeItem before drawing the detail.
+	detailMetrics map[string]DetailMetrics
+
 	// Output
 	switchTo            string
 	switchToDisplayName string // display name for tmux session naming
@@ -214,6 +219,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleWindowSize(msg)
 	case worktreesFetchedMsg:
 		return m.handleWorktreesFetched(msg)
+	case detailMetricsLoadedMsg:
+		return m.handleDetailMetricsLoaded(msg)
 	case prLookupMsg:
 		return m.handlePRLookup(msg)
 	case worktreeDeletedMsg:
@@ -311,7 +318,40 @@ func (m Model) handleWorktreesFetched(msg worktreesFetchedMsg) (tea.Model, tea.C
 			branches = append(branches, item.Branch)
 		}
 	}
-	return m, lookupPRsCmd(branches)
+
+	defaultBranch := "main"
+	if m.cfg != nil && m.cfg.DefaultBranch != "" {
+		defaultBranch = m.cfg.DefaultBranch
+	}
+	return m, tea.Batch(
+		lookupPRsCmd(branches),
+		fetchDetailMetricsCmd(msg.items, defaultBranch),
+	)
+}
+
+func (m Model) handleDetailMetricsLoaded(msg detailMetricsLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.metrics == nil {
+		return m, nil
+	}
+	m.detailMetrics = msg.metrics
+
+	// Apply metrics to items in the list so detail panel renders show them
+	// even when updateDetailContent is called outside this handler path.
+	listItems := m.list.Items()
+	for i, li := range listItems {
+		item, ok := li.(WorktreeItem)
+		if !ok {
+			continue
+		}
+		if metrics, found := msg.metrics[item.Path]; found {
+			item.CommitCount = metrics.CommitCount
+			item.StashCount = metrics.StashCount
+			listItems[i] = item
+		}
+	}
+	m.list.SetItems(listItems)
+	m.updateDetailContent()
+	return m, nil
 }
 
 func (m Model) handlePRLookup(msg prLookupMsg) (tea.Model, tea.Cmd) {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -196,10 +196,14 @@ func (m *Manager) Move(oldName, newName string) error {
 	return nil
 }
 
-// Find searches for a worktree by short name or full name
-// Returns the worktree if found, nil if not found
+// Find searches for a worktree by short name, display name, branch, full
+// name, or path basename. Returns the worktree if found, nil if not found.
+//
+// Returned worktrees do not have IsDirty/DirtyFiles populated — callers that
+// need dirty status should call GetDirtyFiles on the returned tree's Path.
+// Skipping dirty checks here keeps Find fast in repos with many worktrees.
 func (m *Manager) Find(name string) (*Worktree, error) {
-	trees, err := m.List()
+	trees, err := m.listLight()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
@@ -217,30 +221,38 @@ func (m *Manager) Find(name string) (*Worktree, error) {
 	return nil, nil
 }
 
-// List returns all worktrees in the repository
+// List returns all worktrees in the repository.
+// Each tree's IsDirty + DirtyFiles are populated from a single git status call —
+// callers that need the dirty file list should read tree.DirtyFiles rather than
+// calling GetDirtyFiles a second time.
+//
+// In repos with many worktrees, the per-worktree dirty checks dominate cost.
+// Callers that only need the porcelain metadata (path, branch, prunable) can
+// use listLight or higher-level helpers (Find, ListNames) to skip them.
 func (m *Manager) List() ([]*Worktree, error) {
-	output, err := cmdexec.Output(context.TODO(), "git", []string{"worktree", "list", "--porcelain"}, m.repoRoot, cmdexec.GitLocal)
+	trees, err := m.listLight()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+		return nil, err
 	}
 
-	projectName := m.GetProjectName()
-	mainPath := m.getMainWorktreePath()
-	trees := parseWorktreeList(string(output), mainPath, projectName)
-
-	// Check dirty status in parallel — each goroutine writes to its own struct
+	// Check dirty status in parallel — each goroutine writes to its own struct.
+	// Cache the file list too so callers don't re-run git status to get it.
 	var wg sync.WaitGroup
 	for _, tree := range trees {
+		if tree.IsPrunable {
+			continue
+		}
 		wg.Add(1)
 		go func(t *Worktree) {
 			defer wg.Done()
-			dirty, err := m.isDirty(t.Path)
+			files, err := m.getDirtyFiles(t.Path)
 			if err != nil {
 				log.Printf("warning: dirty check failed for %q: %v", t.Path, err)
 				t.DirtyCheckFailed = true
 				return
 			}
-			t.IsDirty = dirty
+			t.DirtyFiles = files
+			t.IsDirty = files != ""
 		}(tree)
 	}
 	wg.Wait()
@@ -248,17 +260,102 @@ func (m *Manager) List() ([]*Worktree, error) {
 	return trees, nil
 }
 
-// ListNames returns display names for all worktrees without running dirty checks.
-// This is significantly faster than List() and suitable for tab completion.
-func (m *Manager) ListNames() ([]string, error) {
+// listLight returns worktrees parsed from `git worktree list --porcelain`
+// without the per-worktree dirty status check. Returned worktrees have all
+// porcelain-derived fields (Path, Name, ShortName, Branch, Commit, IsMain,
+// IsPrunable) but IsDirty/DirtyFiles/DirtyCheckFailed remain at zero values.
+//
+// Use for callers that need the worktree set but not dirty state — much
+// faster in repos with many worktrees because it skips N parallel git status
+// invocations.
+func (m *Manager) listLight() ([]*Worktree, error) {
 	output, err := cmdexec.Output(context.TODO(), "git", []string{"worktree", "list", "--porcelain"}, m.repoRoot, cmdexec.GitLocal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
 	}
 
-	projectName := m.GetProjectName()
-	mainPath := m.getMainWorktreePath()
-	trees := parseWorktreeList(string(output), mainPath, projectName)
+	// The main worktree is always the first `worktree <path>` line —
+	// extract it from the output we already have rather than running
+	// `git worktree list --porcelain` a second time via getMainWorktreePath.
+	raw := string(output)
+	mainPath := mainWorktreePathFromPorcelain(raw)
+	if mainPath == "" {
+		mainPath = m.repoRoot
+	}
+	return parseWorktreeList(raw, mainPath, m.GetProjectName()), nil
+}
+
+// mainWorktreePathFromPorcelain returns the first worktree path in the output
+// of `git worktree list --porcelain`, which is always the main worktree.
+// Returns the empty string when no worktree line is found.
+func mainWorktreePathFromPorcelain(porcelain string) string {
+	for _, line := range strings.Split(porcelain, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "worktree ") {
+			return strings.TrimPrefix(line, "worktree ")
+		}
+	}
+	return ""
+}
+
+// CurrentPath returns the absolute path of the worktree containing the current
+// working directory. Unlike GetCurrent, it does NOT call List() — use this when
+// you only need the path and the trees list either isn't needed or is already
+// in hand.
+func (m *Manager) CurrentPath() (string, error) {
+	output, err := cmdexec.Output(context.TODO(), "git", []string{"rev-parse", "--show-toplevel"}, "", cmdexec.GitLocal)
+	if err != nil {
+		return "", fmt.Errorf("failed to get current worktree path: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// PathForName returns the canonical filesystem path for a worktree of the
+// given short name, whether it exists or not. Used by callers that have
+// already created (or are about to create) a worktree at the standard
+// location and want to avoid re-running List().
+func (m *Manager) PathForName(name string) string {
+	return filepath.Join(filepath.Dir(m.repoRoot), m.FullName(name))
+}
+
+// PathExists reports whether a worktree directory already exists at the
+// canonical path for `name`. Cheap (single os.Stat) — prefer this over Find
+// for "does this name collide?" checks where the standard location is enough.
+//
+// Doesn't catch worktrees registered with git but missing from disk
+// (prunable) or worktrees living at non-standard paths; Create() will surface
+// those as a git-level error if encountered.
+func (m *Manager) PathExists(name string) bool {
+	_, err := os.Stat(m.PathForName(name))
+	return err == nil
+}
+
+// DisplayNameForPath returns the display name a worktree at `path` would have
+// (e.g. "root" for the main worktree, or the short name with project prefix
+// stripped for everything else). No git calls — pure string manipulation
+// against the configured project name and repo root.
+func (m *Manager) DisplayNameForPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	if path == m.repoRoot {
+		return "root"
+	}
+	base := filepath.Base(path)
+	prefix := m.GetProjectName() + "-"
+	if strings.HasPrefix(base, prefix) {
+		return strings.TrimPrefix(base, prefix)
+	}
+	return base
+}
+
+// ListNames returns display names for all worktrees without running dirty checks.
+// This is significantly faster than List() and suitable for tab completion.
+func (m *Manager) ListNames() ([]string, error) {
+	trees, err := m.listLight()
+	if err != nil {
+		return nil, err
+	}
 
 	names := make([]string, 0, len(trees))
 	for _, t := range trees {
@@ -273,8 +370,10 @@ func (m *Manager) Remove(name string) error {
 		return fmt.Errorf("worktree name cannot be empty")
 	}
 
-	// Find the worktree by name
-	trees, err := m.List()
+	// Find the worktree by name. listLight skips per-worktree dirty checks
+	// — Remove only needs the target's path/IsMain/IsPrunable to decide what
+	// to do.
+	trees, err := m.listLight()
 	if err != nil {
 		return fmt.Errorf("failed to list worktrees: %w", err)
 	}
@@ -334,40 +433,41 @@ func (m *Manager) Remove(name string) error {
 	return nil
 }
 
-// GetCurrent returns the current worktree
+// GetCurrent returns the current worktree, enriched with commit info and
+// the dirty file list for just that worktree.
+//
+// Performs O(1) dirty checks instead of O(N) — only the current worktree is
+// inspected, not every worktree in the repo. Significantly faster than the
+// pre-refactor implementation in repos with many worktrees.
 func (m *Manager) GetCurrent() (*Worktree, error) {
-	output, err := cmdexec.Output(context.TODO(), "git", []string{"rev-parse", "--show-toplevel"}, "", cmdexec.GitLocal)
+	currentPath, err := m.CurrentPath()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get current worktree: %w", err)
+		return nil, err
 	}
 
-	currentPath := strings.TrimSpace(string(output))
-
-	trees, err := m.List()
+	trees, err := m.listLight()
 	if err != nil {
 		return nil, err
 	}
 
 	for _, tree := range trees {
-		if tree.Path == currentPath {
-			// Enrich with commit information
-			shortHash, message, age, err := m.getCommitInfo(tree.Path)
-			if err == nil {
-				tree.ShortCommit = shortHash
-				tree.CommitMessage = message
-				tree.CommitAge = age
-			}
-
-			// Get dirty files if the worktree is dirty
-			if tree.IsDirty {
-				dirtyFiles, err := m.getDirtyFiles(tree.Path)
-				if err == nil {
-					tree.DirtyFiles = dirtyFiles
-				}
-			}
-
-			return tree, nil
+		if tree.Path != currentPath {
+			continue
 		}
+		shortHash, message, age, err := m.getCommitInfo(tree.Path)
+		if err == nil {
+			tree.ShortCommit = shortHash
+			tree.CommitMessage = message
+			tree.CommitAge = age
+		}
+		files, dirtyErr := m.getDirtyFiles(tree.Path)
+		if dirtyErr != nil {
+			tree.DirtyCheckFailed = true
+		} else {
+			tree.DirtyFiles = files
+			tree.IsDirty = files != ""
+		}
+		return tree, nil
 	}
 
 	return nil, fmt.Errorf("current worktree not found")
@@ -386,16 +486,6 @@ func (m *Manager) getDirtyFiles(path string) (string, error) {
 	}
 
 	return strings.TrimSpace(string(output)), nil
-}
-
-// isDirty checks if a worktree has uncommitted changes
-func (m *Manager) isDirty(path string) (bool, error) {
-	dirtyFiles, err := m.getDirtyFiles(path)
-	if err != nil {
-		return false, err
-	}
-
-	return len(dirtyFiles) > 0, nil
 }
 
 // GetCommitInfo retrieves detailed commit information for a worktree.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -861,7 +861,9 @@ func TestIsDirtyWithWorktree(t *testing.T) {
 	projectName := m.GetProjectName()
 	fullName := projectName + "-dirty-test"
 
-	// Linked worktree should start clean
+	// Linked worktree should start clean. Find no longer populates IsDirty
+	// (it skips the per-worktree status check) — verify by fetching dirty
+	// state explicitly through GetDirtyFiles.
 	wt, err := m.Find(fullName)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
@@ -869,8 +871,8 @@ func TestIsDirtyWithWorktree(t *testing.T) {
 	if wt == nil {
 		t.Fatal("Find() returned nil")
 	}
-	if wt.IsDirty {
-		t.Error("fresh worktree should not be dirty")
+	if files, _ := m.GetDirtyFiles(wt.Path); files != "" {
+		t.Errorf("fresh worktree should not be dirty, got %q", files)
 	}
 
 	// Make the linked worktree dirty
@@ -879,7 +881,8 @@ func TestIsDirtyWithWorktree(t *testing.T) {
 		t.Fatalf("Failed to write dirty file: %v", err)
 	}
 
-	// Re-find — should now be dirty
+	// Re-find — Find still returns the worktree, but IsDirty isn't set.
+	// Use GetDirtyFiles to confirm the new file shows up.
 	wt, err = m.Find(fullName)
 	if err != nil {
 		t.Fatalf("Find() error = %v", err)
@@ -887,14 +890,13 @@ func TestIsDirtyWithWorktree(t *testing.T) {
 	if wt == nil {
 		t.Fatal("Find() returned nil")
 	}
-	if !wt.IsDirty {
-		t.Error("worktree with uncommitted file should be dirty")
-	}
 
-	// GetDirtyFiles should list the file
 	dirtyFiles, err := m.GetDirtyFiles(wt.Path)
 	if err != nil {
 		t.Fatalf("GetDirtyFiles() error = %v", err)
+	}
+	if dirtyFiles == "" {
+		t.Error("worktree with uncommitted file should report dirty files")
 	}
 	if !strings.Contains(dirtyFiles, "dirty.txt") {
 		t.Errorf("GetDirtyFiles() = %q, want it to contain 'dirty.txt'", dirtyFiles)

--- a/internal/worktreeinfo/info.go
+++ b/internal/worktreeinfo/info.go
@@ -21,6 +21,9 @@ type RecentCommit struct {
 // worktreePath. hasRemote is false whenever no upstream is configured or
 // the rev-list output is malformed; in that case ahead, behind are 0 and
 // trackingBranch is empty.
+//
+// For bulk lookup across many worktrees, prefer AllBranchUpstreams: it
+// returns the same info for every local branch in a single git call.
 func UpstreamInfo(worktreePath string) (ahead, behind int, hasRemote bool, trackingBranch string) {
 	out, err := cmdexec.Output(context.TODO(), "git",
 		[]string{"rev-list", "--count", "--left-right", "@{upstream}...HEAD"},
@@ -45,6 +48,67 @@ func UpstreamInfo(worktreePath string) (ahead, behind int, hasRemote bool, track
 	}
 
 	return a, b, true, trackingBranch
+}
+
+// BranchUpstream describes a single branch's upstream tracking state.
+type BranchUpstream struct {
+	Ahead     int
+	Behind    int
+	Tracking  string // upstream branch name, e.g. "origin/main" (empty if no upstream)
+	HasRemote bool   // true when an upstream is configured
+}
+
+// AllBranchUpstreams returns upstream tracking info for every local branch in
+// repoRoot via a single `git for-each-ref` call. The result is keyed by short
+// branch name (e.g. "feat/foo"). Branches with no configured upstream still
+// appear in the map with HasRemote=false.
+//
+// Compared to calling UpstreamInfo per worktree, this collapses 2N git
+// invocations into one — significant when N is large.
+func AllBranchUpstreams(repoRoot string) (map[string]BranchUpstream, error) {
+	const sep = "\x1F" // unit separator — safe inside branch names
+	format := strings.Join([]string{
+		"%(refname:short)",
+		"%(upstream:short)",
+		"%(upstream:track,nobracket)",
+	}, sep)
+
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"for-each-ref", "--format=" + format, "refs/heads/"},
+		repoRoot, cmdexec.GitLocal)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]BranchUpstream)
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, sep, 3)
+		if len(parts) < 3 {
+			continue
+		}
+		branch, upstream, track := parts[0], parts[1], parts[2]
+		info := BranchUpstream{
+			Tracking:  upstream,
+			HasRemote: upstream != "",
+		}
+		// track is one of: "" (in sync), "gone", "ahead N", "behind N",
+		// "ahead N, behind M". Parse the segments we recognize.
+		if track != "" && track != "gone" {
+			for _, segment := range strings.Split(track, ", ") {
+				switch {
+				case strings.HasPrefix(segment, "ahead "):
+					info.Ahead, _ = strconv.Atoi(strings.TrimPrefix(segment, "ahead "))
+				case strings.HasPrefix(segment, "behind "):
+					info.Behind, _ = strconv.Atoi(strings.TrimPrefix(segment, "behind "))
+				}
+			}
+		}
+		result[branch] = info
+	}
+	return result, nil
 }
 
 // CommitCountAhead returns the number of commits the worktree branch is ahead
@@ -83,6 +147,51 @@ func RecentCommits(worktreePath string, n int) []RecentCommit {
 		}
 	}
 	return commits
+}
+
+// HeadCommitInfo holds enriched metadata for the HEAD commit of a worktree.
+type HeadCommitInfo struct {
+	ShortHash string
+	Message   string // commit subject
+	Age       string // relative date, e.g. "2 hours ago"
+}
+
+// HeadAndRecentCommits returns both the HEAD commit info and the n most
+// recent commits in a single git log call. Combines what would otherwise
+// require separate getCommitInfo + RecentCommits invocations.
+//
+// Returns a zero HeadCommitInfo and nil recent slice on error or empty repo.
+// When n < 1, behaves as if n=1 (always returns the head info if available).
+func HeadAndRecentCommits(worktreePath string, n int) (HeadCommitInfo, []RecentCommit) {
+	if n < 1 {
+		n = 1
+	}
+	// Format: full_hash<RS>short_hash<RS>subject<RS>relative_date
+	out, err := cmdexec.Output(context.TODO(), "git",
+		[]string{"log", fmt.Sprintf("-%d", n), "--format=%H%x1E%h%x1E%s%x1E%cr"},
+		worktreePath, cmdexec.GitLocal)
+	if err != nil {
+		return HeadCommitInfo{}, nil
+	}
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return HeadCommitInfo{}, nil
+	}
+
+	var head HeadCommitInfo
+	var recents []RecentCommit
+	for i, line := range strings.Split(raw, "\n") {
+		parts := strings.Split(line, "\x1E")
+		if len(parts) < 4 {
+			continue
+		}
+		short, subject, age := parts[1], parts[2], parts[3]
+		if i == 0 {
+			head = HeadCommitInfo{ShortHash: short, Message: subject, Age: age}
+		}
+		recents = append(recents, RecentCommit{SHA: short, Message: subject})
+	}
+	return head, recents
 }
 
 // StashCount returns the number of stashes in the worktree at worktreePath.

--- a/plugins/docker/plugin.go
+++ b/plugins/docker/plugin.go
@@ -7,10 +7,32 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/lost-in-the/grove/internal/config"
 	"github.com/lost-in-the/grove/internal/hooks"
 )
+
+// dockerAvailable caches the result of looking up docker / docker-compose in
+// PATH. Repeated Plugin.Init calls (e.g. across multiple commands sharing a
+// process or tests) would otherwise burn an exec.LookPath each time.
+var (
+	dockerAvailableOnce   sync.Once
+	dockerAvailableResult bool
+)
+
+func dockerAvailable() bool {
+	dockerAvailableOnce.Do(func() {
+		if _, err := exec.LookPath("docker-compose"); err == nil {
+			dockerAvailableResult = true
+			return
+		}
+		if _, err := exec.LookPath("docker"); err == nil {
+			dockerAvailableResult = true
+		}
+	})
+	return dockerAvailableResult
+}
 
 // ErrNoComposeFile is returned when no docker-compose file is found
 var ErrNoComposeFile = errors.New("no docker-compose file found")
@@ -58,12 +80,10 @@ func (p *Plugin) Init(cfg *config.Config) error {
 		return nil
 	}
 
-	// Check if docker is available
-	if _, err := exec.LookPath("docker-compose"); err != nil {
-		if _, err := exec.LookPath("docker"); err != nil {
-			p.enabled = false
-			return fmt.Errorf("docker or docker-compose not found in PATH")
-		}
+	// Check if docker is available (LookPath result cached across Init calls).
+	if !dockerAvailable() {
+		p.enabled = false
+		return fmt.Errorf("docker or docker-compose not found in PATH")
 	}
 
 	// Select strategy based on mode


### PR DESCRIPTION
## Summary

Profiling `tui.FetchWorktrees` in a large repo (38 worktrees) showed **6.7 s** baseline, dominated by duplicated `git status --porcelain` fan-out. This PR addresses every concrete redundancy I could find without changing user-facing behavior.

**Headline numbers (38-worktree project):**

| Operation | Before | After | Δ |
|-----------|-------:|------:|--:|
| `tui.FetchWorktrees` | 6760 ms | 2400-2600 ms | **−63%** |
| `mgr.GetCurrent()` | 2270 ms | 125-140 ms | **−94%** |
| `mgr.Find()` | ~2000 ms | ~30 ms | **−98%** |
| `grove ls` | 5.12 s | 3.05 s | −40% |
| `grove which` | ~2.5 s | 0.17 s | −93% |
| `grove here` | ~2.5 s | 0.14 s | −94% |

The TUI dashboard now paints in ~2.4 s; per-detail-panel metrics (CommitCount / StashCount) populate asynchronously ~500 ms after first paint.

## Root causes

1. **Duplicate `mgr.List()`**. `FetchWorktrees` called `List()` once, then `loadFetchContext` called `GetCurrent()` which called `List()` again — every TUI launch ran 2× N parallel `git status` checks.
2. **`isDirty()` discarded results**. Each `git status --porcelain` was run, the file list discarded, then re-run from `enrichGitInfo` to get the file list back. ~2-3× per dirty worktree.
3. **N upstream lookups**. `worktreeinfo.UpstreamInfo` ran 2 git subprocesses per worktree (`rev-list --count --left-right` + `rev-parse --abbrev-ref`) when `git for-each-ref` could return the same data for every branch in one call.
4. **Two `git log` calls per worktree**. Head info and recent commits were fetched separately when `git log -3 --format=…` returns both.
5. **`Find()` ran `List()`**. Every `Find` paid the N-status-check tax even though only `rm` actually read `IsDirty` from the result.
6. **N detail-panel-only git calls**. `CommitCountAhead` and `StashCount` ran for all 38 worktrees on every fetch, but were only displayed for the selected one.
7. **Per-mutation state saves**. `grove new` did 3 `state.json` flock+merge+write cycles in sequence; `grove to`/`last`/`fork`/`rename` did 2.

## Approach

**Commit 1** — `refactor(worktree): split List/listLight; batch upstream + commit log`
- Add private `listLight()` (porcelain parse, no dirty check) and use it from `Find`/`Remove`/`GetCurrent`.
- `List()` now caches dirty file lists on each `*Worktree`.
- New cheap helpers: `CurrentPath`, `PathForName`, `PathExists`, `DisplayNameForPath`.
- New `worktreeinfo.AllBranchUpstreams` (one `for-each-ref`) and `HeadAndRecentCommits` (one `git log`).
- Inline main-path extraction so `listLight` doesn't run `git worktree list` twice.

**Commit 2** — `refactor(tui,commands,state): use cheap helpers; batch saves; lazy detail`
- `FetchWorktrees` uses `CurrentPath` + cached dirty files + batched upstream/log; no second `List`.
- 12 commands switch to `CurrentPath`/`PathExists`/`DisplayNameForPath` where they only need a path or display name.
- New `Manager.Batch(fn)` API in `internal/state` (panic-safe via deferred flush). `grove new`/`last`/`fork`/`rename` wrap their state mutations.
- New `FetchDetailMetrics` + `detailMetricsLoadedMsg` defers `CommitCountAhead`/`StashCount` to a `tea.Cmd` that runs after the dashboard renders.

**Commit 3** — `perf: cache LookPath/user.Current; NewReplacer; profiler tool`
- Cache `exec.LookPath` for docker/docker-compose via `sync.Once` (mirrors `tmux.IsTmuxAvailable`).
- Cache `user.Current()` for hook execution.
- Replace 11 sequential `strings.ReplaceAll` in `Variables.Interpolate` with `strings.NewReplacer`.
- Cache the two possible toast opacity styles at package init.
- Add `cmd/profile_tui` for validating the hot path against a real repo.

## Behavior changes

The only user-visible change is in the `Find()` contract: returned `*Worktree` no longer has `IsDirty`/`DirtyFiles` populated (`DirtyCheckFailed` was set but never read anywhere). `rm.go` was the only caller using `wt.IsDirty` and now fetches dirty status for its specific target via `GetDirtyFiles`. The existing `TestIsDirtyWithWorktree` was updated to reflect the new contract.

`mgr.Batch` is a new public API. Documented contract: only one goroutine should mutate the manager during fn, and `os.Exit` mid-batch loses pending state (acceptable since validation exits happen before any mutation in current callers).

## Test plan

- [x] `go test ./...`
- [x] `go test -tags=integration ./...`
- [x] `make lint` — 0 issues
- [x] `cmd/profile_tui` stable at ~2.4-2.6 s across 5+ runs (was 6.7 s)
- [x] `grove ls`, `grove which`, `grove here` end-to-end on 38-worktree repo
- [ ] Spot-check the TUI: dashboard renders fast, detail panel "Ahead"/"Stash" rows populate after a moment
- [ ] `grove new`, `grove to`, `grove last`, `grove fork`, `grove rename` end-to-end (state.json updates correctly with batched saves)