### PR TITLE
refactor(tui): render-alloc hygiene + keybind doc gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `grove adopt` errors out on detached HEAD instead of storing the literal `"HEAD"` as a branch name.
 - Post-create hook execution failures are now logged to grove's debug log (previously discarded silently).
 - `docs/COMMAND_SPECIFICATIONS.md` `grove init` section now documents the actual command (it had been showing `grove install <shell>` content). New init flags (`--auto`, `--walkthrough`, `--yes`) and Docker-aware install routing are now discoverable from the spec, the Docker plugin README, and the agent guide.
+- `docs/TUI.md` keybind reference now includes `v` (view-mode toggle) and `u` (update modal).
 
 ### Migration / consumer-side
 
@@ -93,6 +94,7 @@ Downstream consumers integrating with grove via `.grove/config.toml` or `.grove/
 - `state.Manager.Batch()` and the new `worktreeinfo` package extracted to consolidate git fan-out (#74, #85).
 - Removed unused `matchesActive` parameter from external-status classifier; removed `_ = name` dead wiring in env-loader doctor checks; removed dead `BootstrapOpts.Now` injection field.
 - Test fixtures in `internal/tui/update_overlay_test.go` now reference `version.Version` instead of a hardcoded `0.7.0-dev` literal, so they don't silently break on the next dev-cycle version bump.
+- TUI render hot path no longer reallocates lipgloss styles per frame in update overlay and footer badge — promoted to package-level vars.
 
 ### Documentation
 - `docs/AGENT_GUIDE.md` updated to cover `grove context`, `--check-update`/`--no-update-notifier` persistent flags and `GROVE_NO_UPDATE_NOTIFIER`, and `grove adopt` edge cases (detached HEAD, already-registered).

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -116,6 +116,8 @@ Toast levels:
 | `a` | Bulk delete |
 | `o` | Cycle sort mode |
 | `r` | Refresh worktree list |
+| `v` | Toggle view mode (compact / detailed) |
+| `u` | Open update modal (only when a newer release is cached — the footer badge indicates availability) |
 | `/` | Filter list |
 | `?` | Toggle expanded help |
 | `q` / `esc` | Quit |

--- a/internal/tui/help_v2.go
+++ b/internal/tui/help_v2.go
@@ -196,6 +196,14 @@ func (h *HelpFooter) CompactHeight(view ActiveView, width int) int {
 	return strings.Count(rendered, "\n") + 1
 }
 
+// Pre-built styles for RenderUpdateBadge. The badge re-renders on every
+// dashboard frame whenever an update is cached, so allocating these per
+// call is wasted work.
+var (
+	updateBadgeMutedStyle = lipgloss.NewStyle().Foreground(Colors.TextMuted)
+	updateBadgeKeyStyle   = lipgloss.NewStyle().Foreground(Colors.Primary).Bold(true)
+)
+
 // RenderUpdateBadge returns a muted "↑ current → latest  press u" badge string
 // suitable for appending to a footer. Returns "" when no update is available
 // (zero strings) — caller should handle the empty case.
@@ -203,10 +211,8 @@ func RenderUpdateBadge(currentVersion, latestVersion string) string {
 	if currentVersion == "" || latestVersion == "" {
 		return ""
 	}
-	mutedStyle := lipgloss.NewStyle().Foreground(Colors.TextMuted)
-	keyStyle := lipgloss.NewStyle().Foreground(Colors.Primary).Bold(true)
-	return mutedStyle.Render("↑ "+currentVersion+" → "+latestVersion+"  press ") +
-		keyStyle.Render("u")
+	return updateBadgeMutedStyle.Render("↑ "+currentVersion+" → "+latestVersion+"  press ") +
+		updateBadgeKeyStyle.Render("u")
 }
 
 // RenderCompactWithHints renders a one- or two-line footer with the given hints

--- a/internal/tui/update_overlay.go
+++ b/internal/tui/update_overlay.go
@@ -20,6 +20,19 @@ type UpdateOverlay struct {
 	latestURL      string
 }
 
+// Pre-built styles for UpdateOverlay.View(). Allocating these on every render
+// is wasted work — they don't depend on per-call state. Package-level init
+// runs after Colors is assigned (theme_v2.go declares Colors first), so
+// these references resolve correctly.
+var (
+	updateOverlayLabelStyle = lipgloss.NewStyle().Foreground(Colors.TextMuted)
+	updateOverlayValueStyle = lipgloss.NewStyle().Foreground(Colors.TextNormal)
+	updateOverlayEmphStyle  = lipgloss.NewStyle().Bold(true).Foreground(Colors.TextBright)
+	updateOverlayCmdStyle   = lipgloss.NewStyle().Foreground(Colors.Primary)
+	updateOverlayURLStyle   = lipgloss.NewStyle().Foreground(Colors.Info).Underline(true)
+	updateOverlayRuleStyle  = lipgloss.NewStyle().Foreground(Colors.SurfaceBorder)
+)
+
 // NewUpdateOverlay creates an inactive UpdateOverlay.
 func NewUpdateOverlay() *UpdateOverlay {
 	return &UpdateOverlay{}
@@ -53,12 +66,6 @@ func (u *UpdateOverlay) View(width, height int) string {
 
 	title := Styles.OverlayTitle.Render("↑ Update available")
 
-	labelStyle := lipgloss.NewStyle().Foreground(Colors.TextMuted)
-	valueStyle := lipgloss.NewStyle().Foreground(Colors.TextNormal)
-	emphStyle := lipgloss.NewStyle().Bold(true).Foreground(Colors.TextBright)
-	cmdStyle := lipgloss.NewStyle().Foreground(Colors.Primary)
-	urlStyle := lipgloss.NewStyle().Foreground(Colors.Info).Underline(true)
-
 	// Align all values at the same column. "Changelog:" is 10 chars; pad
 	// labels so values start at column 12 (matches the previous layout).
 	const valueColumn = 12
@@ -68,26 +75,25 @@ func (u *UpdateOverlay) View(width, height int) string {
 		if n < 1 {
 			n = 1
 		}
-		return labelStyle.Render(text + strings.Repeat(" ", n))
+		return updateOverlayLabelStyle.Render(text + strings.Repeat(" ", n))
 	}
 
-	current := pad("Current") + valueStyle.Render(u.currentVersion)
-	latest := pad("Latest") + emphStyle.Render(u.latestVersion)
+	current := pad("Current") + updateOverlayValueStyle.Render(u.currentVersion)
+	latest := pad("Latest") + updateOverlayEmphStyle.Render(u.latestVersion)
 
 	// Always show all three install methods. The user picks whichever applies
 	// to their setup. The CLI box (render.go) still uses DetectInstall to pick
 	// a single method for its space-constrained one-liner.
-	brewLine := pad("Brew") + cmdStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallBrew))
-	goLine := pad("Go") + cmdStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallGoInstall))
-	binaryLine := pad("Binary") + urlStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallBinary))
+	brewLine := pad("Brew") + updateOverlayCmdStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallBrew))
+	goLine := pad("Go") + updateOverlayCmdStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallGoInstall))
+	binaryLine := pad("Binary") + updateOverlayURLStyle.Render(updatecheck.UpdateCommand(updatecheck.InstallBinary))
 
 	var changelogLine string
 	if u.latestURL != "" {
-		changelogLine = pad("Changelog") + urlStyle.Render(u.latestURL)
+		changelogLine = pad("Changelog") + updateOverlayURLStyle.Render(u.latestURL)
 	}
 
-	footerRule := lipgloss.NewStyle().Foreground(Colors.SurfaceBorder).
-		Render(strings.Repeat("─", textWidth))
+	footerRule := updateOverlayRuleStyle.Render(strings.Repeat("─", textWidth))
 	// Group both keys with a single action label.
 	footerKeys := "  " +
 		Styles.HelpKey.Render("esc/u") + "   " + Styles.HelpDesc.Render("close")


### PR DESCRIPTION
## Summary

Two small v0.7.0 release-audit cleanups:

- **P1-10 (render allocations):** `UpdateOverlay.View()` and `RenderUpdateBadge` each constructed `lipgloss.NewStyle()` values on every render. The badge re-renders on every dashboard frame whenever an update is cached; the overlay re-renders while it's open. None of those styles depend on per-call state. Promoted to package-level vars, mirroring the existing pattern in `animation.go` (`toastStyleFull` / `toastStyleFaint`).
- **P1-7 (keybind doc gap):** `docs/TUI.md`'s dashboard keybinding table was missing `v` (view-mode toggle) and `u` (open update modal). Added both.

## Notes

- Package-level init runs after `Colors` is assigned in `theme_v2.go`, so the new vars resolve correctly at init time. The existing `Styles = NewStyleSet(Colors)` package var already exercises the same dependency, so this is well-trodden ground.
- Visual output is unchanged — purely allocation-side cleanup.
- The `u` keybind is gated on the cache having a newer release available (the badge in the footer indicates availability); the doc note reflects that.

## Test plan

- [x] `make test` (full suite passes)
- [x] `make test-integration-tui` (golden snapshots for update overlay and footer badge unchanged)
- [x] `make lint` (0 issues)
- [x] `go build ./...`