### PR TITLE
ci: release.yml integration parity + macOS test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ permissions:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     permissions:
       contents: read
     steps:
@@ -40,8 +44,12 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,19 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Run tests
+      - name: Run tests (Linux)
+        if: runner.os == 'Linux'
         run: go test -race -cover ./...
+
+      # macOS runners don't have Docker installed, and the plugins/docker
+      # unit tests assume `docker` is on PATH. Skip that package on macOS;
+      # everything else (including symlink and path-handling code paths
+      # this matrix exists to cover) still runs.
+      - name: Run tests (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          PKGS=$(go list ./... | grep -v '/plugins/docker$')
+          go test -race -cover $PKGS
 
   integration:
     name: Integration Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,26 @@ jobs:
       - name: Run tests
         run: make test
 
+      - name: Run integration tests
+        run: make test-integration
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.8
+          args: --timeout=5m
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run gofmt check
+        run: |
+          if [ -n "$(gofmt -s -l .)" ]; then
+            echo "Code is not formatted. Run 'go fmt ./...'"
+            gofmt -s -l .
+            exit 1
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ Downstream consumers integrating with grove via `.grove/config.toml` or `.grove/
 - Test fixtures in `internal/tui/update_overlay_test.go` now reference `version.Version` instead of a hardcoded `0.7.0-dev` literal, so they don't silently break on the next dev-cycle version bump.
 - TUI render hot path no longer reallocates lipgloss styles per frame in update overlay and footer badge — promoted to package-level vars.
 - Atomic-write helper extracted to `internal/fsutil` and used by state migration/backup paths and project-config writes. Crashes mid-write no longer corrupt `state.json` or user `.grove/config.toml`.
+- CI's release workflow now runs `make test-integration` and `make lint` before publishing, mirroring the gate fix applied to the main CI workflow in PR #83.
+- CI test matrix now includes macOS in addition to Linux, surfacing platform-specific issues (especially around symlink resolution and path handling) before release. The `plugins/docker` unit tests are excluded on the macOS runner (it has no Docker daemon and many of those tests don't gate on `exec.LookPath`); Docker-aware integration tests already self-skip when Docker isn't reachable.
 
 ### Documentation
 - `docs/AGENT_GUIDE.md` updated to cover `grove context`, `--check-update`/`--no-update-notifier` persistent flags and `GROVE_NO_UPDATE_NOTIFIER`, and `grove adopt` edge cases (detached HEAD, already-registered).


### PR DESCRIPTION
## Summary

Two release-readiness CI improvements for v0.7.0:

1. **`release.yml` integration + lint parity (P0-5)** — the release workflow ran only `make test`, so a tag could publish artifacts even if integration tests or lint would have failed. Added `make test-integration`, golangci-lint, `go vet`, and a gofmt check before the GoReleaser step. Mirrors the gate fix applied to `ci.yml` in #83.
2. **macOS test matrix (P1-9)** — `ci.yml` ran only `ubuntu-latest`, so symlink-related code paths and other platform-sensitive logic only got exercised on Linux even though release artifacts target Linux/macOS/Windows. Added `macos-latest` to the test and integration matrices.

Lint and build jobs remain Linux-only (no platform-specific behavior to verify there). Windows is deferred — a few code paths in `install.go` use forward-slash paths by design, and that's a larger change.

CHANGELOG entry added under `[0.7.0]` / `Internal`.

## Decisions

- **`plugins/docker` unit tests excluded on macOS:** `macos-latest` has no Docker installed, and most `plugins/docker` unit tests instantiate the plugin through `Init()`, which fails fast when `docker`/`docker-compose` aren't on PATH. The macOS test step runs `go test` against `go list ./... | grep -v '/plugins/docker$'`, which keeps the symlink and path-handling coverage the matrix was added to surface while skipping a Docker-only test suite. Linux still runs everything.
- **Docker-aware integration tests are unaffected:** they already gate on `exec.LookPath("docker")` + daemon-reachability checks (`tests/integration/docker_hook_test.go:81-85`), so the macOS integration job cleanly skips them.
- **No tmux dependency:** TUI integration tests use data fixtures rather than spawning tmux, so they run on macOS without extra setup.
- **`fail-fast: false`** on both matrices so a Linux failure doesn't mask macOS regressions and vice versa.

## Test plan

- [x] CI passes on `ubuntu-latest` (Test, Integration Tests, Lint, Build)
- [x] CI passes on `macos-latest` (Test, Integration Tests)
- [x] No new lint findings
- [x] CHANGELOG `[0.7.0]` / `Internal` shows entries