### PR TITLE
fix(core): state hygiene — RemoveWorktree.LastWorktree, atomic writes, symmetric path resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Post-create hook execution failures are now logged to grove's debug log (previously discarded silently).
 - `docs/COMMAND_SPECIFICATIONS.md` `grove init` section now documents the actual command (it had been showing `grove install <shell>` content). New init flags (`--auto`, `--walkthrough`, `--yes`) and Docker-aware install routing are now discoverable from the spec, the Docker plugin README, and the agent guide.
 - `docs/TUI.md` keybind reference now includes `v` (view-mode toggle) and `u` (update modal).
+- `grove rm` now clears `LastWorktree` in state.json when removing the worktree it points at, so `grove last` no longer returns a removed name.
+- `IsWorktreeInState` resolves symlinks on both the stored path and the caller's path, so drift detection remains correct when state.json was written before symlink-aware path normalization.
 
 ### Migration / consumer-side
 
@@ -95,6 +97,7 @@ Downstream consumers integrating with grove via `.grove/config.toml` or `.grove/
 - Removed unused `matchesActive` parameter from external-status classifier; removed `_ = name` dead wiring in env-loader doctor checks; removed dead `BootstrapOpts.Now` injection field.
 - Test fixtures in `internal/tui/update_overlay_test.go` now reference `version.Version` instead of a hardcoded `0.7.0-dev` literal, so they don't silently break on the next dev-cycle version bump.
 - TUI render hot path no longer reallocates lipgloss styles per frame in update overlay and footer badge — promoted to package-level vars.
+- Atomic-write helper extracted to `internal/fsutil` and used by state migration/backup paths and project-config writes. Crashes mid-write no longer corrupt `state.json` or user `.grove/config.toml`.
 
 ### Documentation
 - `docs/AGENT_GUIDE.md` updated to cover `grove context`, `--check-update`/`--no-update-notifier` persistent flags and `GROVE_NO_UPDATE_NOTIFIER`, and `grove adopt` edge cases (detached HEAD, already-registered).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/lost-in-the/grove/internal/fsutil"
 )
 
 // TestConfig controls test command behavior
@@ -481,7 +483,7 @@ func SetProjectConfigValues(updates map[string]string) error {
 	if !strings.HasSuffix(content, "\n") {
 		content += "\n"
 	}
-	return os.WriteFile(projectPath, []byte(content), 0o644)
+	return fsutil.AtomicWriteFile(projectPath, []byte(content), 0o644)
 }
 
 // splitKey splits "section.field" into ("section", "field").

--- a/internal/fsutil/atomic.go
+++ b/internal/fsutil/atomic.go
@@ -1,0 +1,51 @@
+package fsutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteFile writes data to path atomically. It creates a uniquely-named
+// temp file in the destination directory, writes the data, fsync-equivalent
+// close, then renames over the destination. The unique suffix avoids clobbers
+// when multiple processes write concurrently — each writer renames its own
+// temp file, with last-rename winning.
+//
+// Creates the parent directory if it doesn't exist (mode 0o755). Cleans up
+// the temp file on every error path so partial writes don't leak.
+func AtomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("atomic write: mkdir parent: %w", err)
+	}
+
+	base := filepath.Base(path)
+	f, err := os.CreateTemp(dir, base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("atomic write: create temp: %w", err)
+	}
+	tmp := f.Name()
+	cleanup := func() { _ = os.Remove(tmp) }
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("atomic write: write: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("atomic write: close: %w", err)
+	}
+	// CreateTemp uses 0o600; align to caller-requested perm before rename so
+	// the destination ends up with the expected mode.
+	if err := os.Chmod(tmp, perm); err != nil {
+		cleanup()
+		return fmt.Errorf("atomic write: chmod: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		cleanup()
+		return fmt.Errorf("atomic write: rename: %w", err)
+	}
+	return nil
+}

--- a/internal/fsutil/atomic_test.go
+++ b/internal/fsutil/atomic_test.go
@@ -1,0 +1,133 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestAtomicWriteFile_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.txt")
+	want := []byte("hello world\n")
+
+	if err := AtomicWriteFile(path, want, 0o644); err != nil {
+		t.Fatalf("AtomicWriteFile() error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("contents = %q, want %q", got, want)
+	}
+}
+
+func TestAtomicWriteFile_NoLeftoverTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.txt")
+
+	if err := AtomicWriteFile(path, []byte("payload"), 0o644); err != nil {
+		t.Fatalf("AtomicWriteFile() error = %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() == "data.txt" {
+			continue
+		}
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file %q after successful write", e.Name())
+		}
+	}
+}
+
+func TestAtomicWriteFile_ConcurrentWritersBothSucceed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.txt")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs <- AtomicWriteFile(path, []byte("writer-a-content"), 0o644)
+	}()
+	go func() {
+		defer wg.Done()
+		errs <- AtomicWriteFile(path, []byte("writer-b-content"), 0o644)
+	}()
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent AtomicWriteFile() error = %v", err)
+		}
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	// One writer must have won cleanly — the contents must be one of the two
+	// payloads, never an interleaved blend.
+	s := string(got)
+	if s != "writer-a-content" && s != "writer-b-content" {
+		t.Errorf("contents = %q, expected one full payload", s)
+	}
+
+	// And no temp files should be left around.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() == "shared.txt" {
+			continue
+		}
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file %q after concurrent writes", e.Name())
+		}
+	}
+}
+
+func TestAtomicWriteFile_CreatesMissingParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deeper", "data.txt")
+
+	if err := AtomicWriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("AtomicWriteFile() error = %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s, got stat error: %v", path, err)
+	}
+}
+
+func TestAtomicWriteFile_HonorsRequestedMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.txt")
+
+	if err := AtomicWriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("AtomicWriteFile() error = %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	// Mask out non-permission bits before comparing (umask doesn't apply to
+	// chmod, but be explicit about what we're checking).
+	gotPerm := info.Mode().Perm()
+	if gotPerm != 0o600 {
+		t.Errorf("perm = %o, want %o", gotPerm, 0o600)
+	}
+}

--- a/internal/grove/diagnose.go
+++ b/internal/grove/diagnose.go
@@ -88,15 +88,28 @@ func IsWorktreeInState(stateData []byte, worktreePath string) bool {
 		return false
 	}
 
-	// Resolve symlinks once so we can compare against either stored form
-	// (handles macOS /var → /private/var and similar).
-	resolved, resolveErr := filepath.EvalSymlinks(worktreePath)
+	// Resolve symlinks on the caller's path once so we can compare against
+	// either stored form (handles macOS /var → /private/var and similar).
+	resolvedCaller, resolveCallerErr := filepath.EvalSymlinks(worktreePath)
 
 	for _, wt := range snap.Worktrees {
 		if wt.Path == worktreePath {
 			return true
 		}
-		if resolveErr == nil && resolved != worktreePath && wt.Path == resolved {
+		if resolveCallerErr == nil && resolvedCaller != worktreePath && wt.Path == resolvedCaller {
+			return true
+		}
+		// Also resolve the stored path so a state.json written before
+		// path normalization (unresolved /var/...) still matches a caller
+		// that already passes a resolved /private/var/... path.
+		resolvedStored, err := filepath.EvalSymlinks(wt.Path)
+		if err != nil {
+			continue
+		}
+		if resolvedStored == worktreePath {
+			return true
+		}
+		if resolveCallerErr == nil && resolvedStored == resolvedCaller {
 			return true
 		}
 	}

--- a/internal/grove/diagnose_test.go
+++ b/internal/grove/diagnose_test.go
@@ -182,6 +182,39 @@ func TestIsWorktreeInState(t *testing.T) {
 	}
 }
 
+func TestIsWorktreeInState_SymmetricSymlinkResolution(t *testing.T) {
+	// state.json may have been written with the unresolved form of a path
+	// (e.g. /var/folders/... on macOS) while the caller passes the resolved
+	// form (/private/var/folders/...). The helper must match either way.
+	tmpDir := t.TempDir()
+
+	// Create a real directory (the resolved path) and a symlink that points
+	// at it (the unresolved path).
+	realDir := filepath.Join(tmpDir, "real")
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	linkDir := filepath.Join(tmpDir, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// state.json stores the symlinked (unresolved) path.
+	stateData := []byte(`{"worktrees":{"wt":{"path":"` + linkDir + `","branch":"main"}}}`)
+
+	// Caller passes the resolved real path — should still match.
+	if !IsWorktreeInState(stateData, realDir) {
+		t.Errorf("IsWorktreeInState(stored=symlink, caller=real) = false, want true")
+	}
+
+	// Inverse: state.json stores the real path, caller passes the symlinked
+	// form. EvalSymlinks(linkDir) returns realDir, so this must also match.
+	stateData2 := []byte(`{"worktrees":{"wt":{"path":"` + realDir + `","branch":"main"}}}`)
+	if !IsWorktreeInState(stateData2, linkDir) {
+		t.Errorf("IsWorktreeInState(stored=real, caller=symlink) = false, want true")
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/state/migrate.go
+++ b/internal/state/migrate.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/lost-in-the/grove/internal/fsutil"
 )
 
 // LegacyState represents the V0/V1 state schema (frozen.json)
@@ -48,7 +50,7 @@ func MigrateFromLegacy(groveDir string, legacyPath string) (bool, error) {
 		return false, fmt.Errorf("failed to marshal new state: %w", err)
 	}
 
-	if err := os.WriteFile(stateFile, stateData, 0644); err != nil {
+	if err := fsutil.AtomicWriteFile(stateFile, stateData, 0644); err != nil {
 		return false, fmt.Errorf("failed to write new state: %w", err)
 	}
 
@@ -122,7 +124,7 @@ func BackupState(groveDir string) error {
 	}
 
 	// Write backup
-	if err := os.WriteFile(backupFile, data, 0644); err != nil {
+	if err := fsutil.AtomicWriteFile(backupFile, data, 0644); err != nil {
 		return fmt.Errorf("failed to write state backup: %w", err)
 	}
 
@@ -146,7 +148,7 @@ func RestoreStateBackup(groveDir string) error {
 	}
 
 	// Write to state file
-	if err := os.WriteFile(stateFile, data, 0644); err != nil {
+	if err := fsutil.AtomicWriteFile(stateFile, data, 0644); err != nil {
 		return fmt.Errorf("failed to restore state: %w", err)
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -173,6 +173,13 @@ func (m *Manager) RemoveWorktree(name string) error {
 
 	delete(m.state.Worktrees, name)
 	m.removedWorktrees[name] = true
+
+	// Clear LastWorktree if it pointed at the removed entry, so callers
+	// like `grove last` don't return a name that no longer exists.
+	if m.state.LastWorktree == name {
+		m.state.LastWorktree = ""
+	}
+
 	return m.saveOrDefer()
 }
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -333,6 +333,50 @@ func TestManagerWorktreeOperations(t *testing.T) {
 		}
 	})
 
+	t.Run("remove clears last_worktree when it points at the removed entry", func(t *testing.T) {
+		mgr := setupTestManager(t)
+
+		_ = mgr.AddWorktree("first", &WorktreeState{Path: "/p1", Branch: "b1"})
+		_ = mgr.AddWorktree("second", &WorktreeState{Path: "/p2", Branch: "b2"})
+		if err := mgr.SetLastWorktree("first"); err != nil {
+			t.Fatalf("SetLastWorktree() error = %v", err)
+		}
+
+		if err := mgr.RemoveWorktree("first"); err != nil {
+			t.Fatalf("RemoveWorktree() error = %v", err)
+		}
+
+		last, err := mgr.GetLastWorktree()
+		if err != nil {
+			t.Fatalf("GetLastWorktree() error = %v", err)
+		}
+		if last != "" {
+			t.Errorf("GetLastWorktree() = %q, want empty after removing pointed-at worktree", last)
+		}
+	})
+
+	t.Run("remove leaves last_worktree alone when it points elsewhere", func(t *testing.T) {
+		mgr := setupTestManager(t)
+
+		_ = mgr.AddWorktree("first", &WorktreeState{Path: "/p1", Branch: "b1"})
+		_ = mgr.AddWorktree("second", &WorktreeState{Path: "/p2", Branch: "b2"})
+		if err := mgr.SetLastWorktree("second"); err != nil {
+			t.Fatalf("SetLastWorktree() error = %v", err)
+		}
+
+		if err := mgr.RemoveWorktree("first"); err != nil {
+			t.Fatalf("RemoveWorktree() error = %v", err)
+		}
+
+		last, err := mgr.GetLastWorktree()
+		if err != nil {
+			t.Fatalf("GetLastWorktree() error = %v", err)
+		}
+		if last != "second" {
+			t.Errorf("GetLastWorktree() = %q, want %q (unchanged)", last, "second")
+		}
+	})
+
 	t.Run("list worktrees returns sorted names", func(t *testing.T) {
 		mgr := setupTestManager(t)
 


### PR DESCRIPTION
Three independent code-quality fixes for the v0.7.0 release.

## Summary

### 1. `RemoveWorktree` clears `LastWorktree` when it points at the removed entry (P1-2)

`internal/state/state.go::RemoveWorktree` previously left `state.LastWorktree` pointing at the removed entry, so `grove last` could resolve to a name that no longer existed. Mirrors `RenameWorktree`'s existing pattern: when `LastWorktree` matches the removed name, clear it.

Tests cover both directions: clearing when `LastWorktree` points at the removed worktree, and leaving it untouched when it points elsewhere.

### 2. Atomic-write helper extracted to `internal/fsutil` (P1-3)

New `fsutil.AtomicWriteFile` writes to a uniquely-named temp file in the destination directory, then renames. The unique suffix avoids clobbers when multiple processes write concurrently, and the temp file is cleaned up on every error path.

Migrated four call sites that were previously calling `os.WriteFile` directly:
- `state.MigrateFromLegacy` — writes new `state.json`
- `state.BackupState` — writes `state.json.bak`
- `state.RestoreStateBackup` — restores `state.json` from backup
- `config.SetProjectConfigValues` — writes user `.grove/config.toml`

A crash mid-write at any of these no longer corrupts `state.json` or the user's project config. `state.Manager.save()` already used a tmp+rename flow and is left untouched.

Tests cover roundtrip, no leftover `.tmp` files after success, concurrent writes (one full payload wins, no interleaving), parent-dir creation, and mode preservation.

### 3. Symmetric symlink resolution in `IsWorktreeInState` (P1-6)

The helper previously called `filepath.EvalSymlinks` only on the caller's `worktreePath`. The contract was asymmetric: a `state.json` written before path normalization (storing `/var/folders/...`) could fail to match a caller passing the resolved `/private/var/folders/...` form, even though both refer to the same directory.

Now resolves each stored path too, with fallback to the original on `EvalSymlinks` error. Adds a test using a real `os.Symlink` to verify matching in both directions.

## Audit items addressed

P1-2, P1-3, P1-6.

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make lint` — 0 issues
- [x] `make test-integration` — TUI + Docker integration suites pass
- [x] New tests:
  - `TestManagerWorktreeOperations/remove_clears_last_worktree_when_it_points_at_the_removed_entry`
  - `TestManagerWorktreeOperations/remove_leaves_last_worktree_alone_when_it_points_elsewhere`
  - `TestAtomicWriteFile_*` (5 cases)
  - `TestIsWorktreeInState_SymmetricSymlinkResolution`