### PR TITLE
docs: AGENT_GUIDE + PLUGIN_DEVELOPMENT gaps for v0.7.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ Downstream consumers integrating with grove via `.grove/config.toml` or `.grove/
 - `state.Manager.Batch()` and the new `worktreeinfo` package extracted to consolidate git fan-out (#74, #85).
 - Removed unused `matchesActive` parameter from external-status classifier; removed `_ = name` dead wiring in env-loader doctor checks; removed dead `BootstrapOpts.Now` injection field.
 
+### Documentation
+- `docs/AGENT_GUIDE.md` updated to cover `grove context`, `--check-update`/`--no-update-notifier` persistent flags and `GROVE_NO_UPDATE_NOTIFIER`, and `grove adopt` edge cases (detached HEAD, already-registered).
+- `docs/PLUGIN_DEVELOPMENT.md` now documents `docker:compose` and `docker:exec` action-type handler signatures and the post-create hook ordering invariant (plugin Go hooks fire before config-driven hooks).
+
 ## [0.6.1] - 2026-03-19
 
 ### Fixed

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -295,6 +295,25 @@ grove last
 
 Switches back to the previous worktree (tracked in `.grove/state.json`). Same hook/directive behavior as `grove to`.
 
+### Inspect the Current Worktree
+
+```bash
+grove here              # short summary
+grove here --json       # machine-readable
+grove context           # full context (sidebar-style)
+grove context --json    # richer JSON
+```
+
+`grove here` is the cheap option — name, branch, short SHA, status, tmux/Docker state. Useful for "where am I?" probes between commands.
+
+`grove context` returns a richer payload tailored for agents that need to make decisions without re-running git themselves: tracking branch, ahead/behind counts, stash count, and the last 5 commits. **Prefer `grove context --json` over `grove here --json`** when you need any of:
+
+- Sync state vs remote (`ahead`, `behind`, `has_remote`)
+- Stash awareness (`stash_count`)
+- Recent history (`recent_commits`) without shelling out to `git log`
+
+Both commands exit non-zero when not inside a grove-managed worktree.
+
 ### Work from a GitHub PR or Issue
 
 ```bash
@@ -419,6 +438,14 @@ grove adopt /path/to/other-worktree
 ```
 
 The short name is derived from the directory by stripping the project prefix (`project-feature` → `feature`), matching the convention `grove new` produces.
+
+**Edge cases:**
+
+| Scenario | Behavior |
+|----------|----------|
+| Already adopted | Prints `worktree "<name>" is already registered (path: ...)` and exits 0. Safe to call repeatedly. |
+| Detached HEAD | Errors out with `worktree is in detached HEAD state; check out a branch first` rather than registering with the literal branch `HEAD`. Run `git checkout -b <branch>` (or `git switch -c <branch>`) inside the worktree first, then re-run `grove adopt`. |
+| Path outside the project | Returns an error — adopt only registers worktrees that belong to the current grove project. |
 
 ---
 
@@ -644,6 +671,14 @@ Run `grove config` to see the merged effective config for the current project.
 | `GROVE_DEBUG` | unset | Set to `1` for verbose debug output. |
 | `GROVE_NONINTERACTIVE` | unset | Set to `1` to skip all interactive prompts (auto-accept defaults). |
 | `GROVE_CONFIG` | unset | Override path to global config file. Replaces `~/.config/grove/config.toml`. |
+| `GROVE_NO_UPDATE_NOTIFIER` | unset | Set to `1` to suppress the "update available" annotation across all grove commands. Also honors the standard `NO_UPDATE_NOTIFIER`. Implied by `GROVE_AGENT_MODE=1` and common CI vars. |
+
+### Persistent flags (apply to every command)
+
+| Flag | Purpose |
+|------|---------|
+| `--no-update-notifier` | Suppress the update annotation for this invocation only. Useful for one-off scripted runs without exporting the env var. |
+| `--check-update` | Force a synchronous update check, bypassing the cache and the standard opt-outs. Prints either an update box or `grove is up to date (X.Y.Z)` and exits. Use when an agent explicitly wants to know the latest version. |
 
 ---
 

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -113,6 +113,85 @@ type" error. The docker plugin extends `disabledTypeHint` in
 `docker:compose` and `docker:exec` — consider adding to that switch if your
 plugin is similarly load-conditional.
 
+### Hook ordering invariant
+
+When implementing custom action handlers, know which fires first:
+
+1. **Plugin Go hooks** (registered via `Plugin.RegisterHooks` against
+   `hooks.EventPostCreate`, etc.) fire **before** any `hooks.toml` actions.
+2. **Config-driven hooks** (`[[hooks.post_create]]` entries in `hooks.toml`,
+   including `docker:compose` and `docker:exec` action types) run after.
+
+This ordering is what makes `type = "docker:compose"` with `mode = "exec"`
+viable on `post_create` — the docker plugin's Go hook brings the local stack
+up first, so by the time the config hook fires there's a running container
+to exec into. A handler you add can rely on the same guarantee for resources
+its plugin provisions.
+
+The invariant is enforced in `internal/worktree/bootstrap.go` (`hooks.Fire`
+runs before `hookExecutor.Execute`). Don't try to reorder by re-firing
+`EventPostCreate` from a config-driven handler.
+
+### Built-in action types: `docker:compose` and `docker:exec`
+
+The docker plugin registers two action types that plugin authors can
+reference for parity. Both are implemented in `plugins/docker/`.
+
+**`docker:compose`** — runs a command via `docker compose run --rm` (default)
+or `docker compose exec` against a service in the worktree's compose file.
+Implementation: `plugins/docker/hook_compose.go`.
+
+```toml
+[[hooks.post_create]]
+type       = "docker:compose"
+service    = "app"                    # required: compose service name
+command    = "bundle install --quiet" # required: shell command run inside the container
+mode       = "run"                    # optional: "run" (default, ephemeral) | "exec" (existing container)
+timeout    = 300                      # optional: seconds (default 60); applied by executor, not the handler
+on_failure = "warn"                   # optional: "fail" (default) | "warn" | "ignore"
+```
+
+Field reference (matches `HookAction` in `internal/hooks/config.go`):
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `service` | yes | Compose service name; supports `${VAR}` interpolation |
+| `command` | yes | Shell command run inside the container |
+| `mode` | no | `"run"` brings up service deps on demand; `"exec"` requires a running container and fails with a hint if the stack is down |
+| `timeout` | no | Per-action timeout (seconds), enforced by the hook executor |
+| `on_failure` | no | Standard error-handling field shared with all action types |
+
+The handler returns a targeted error when no compose file is present at the
+worktree path, suggesting `type = "docker:exec"` as the alternative.
+
+**`docker:exec`** — runs a command directly via `docker exec` in an
+externally-managed container that grove doesn't lifecycle (e.g., a long-
+running dev shell started outside grove). Bypasses compose entirely.
+Implementation: `plugins/docker/hook_docker_exec.go`.
+
+```toml
+[[hooks.post_create]]
+type       = "docker:exec"
+container  = "app-dev"                # required: docker container name (not service name)
+command    = "bin/setup"              # required: command to run
+shell      = "bash -lc"               # optional: shell wrapper (default "bash -lc"); plain command + flags only, no quotes
+timeout    = 60                       # optional: seconds (default 60)
+on_failure = "fail"
+```
+
+Differences from `docker:compose mode = "exec"`:
+
+| | `docker:compose` (`mode = "exec"`) | `docker:exec` |
+|---|---|---|
+| Targets | A compose **service** in the worktree's compose file | A raw docker **container** by name |
+| Requires compose file | Yes | No |
+| Brings up dependencies | No (errors if stack is down) | No (errors if container isn't running) |
+| Use when | The container is part of grove's managed compose stack | The container is started/managed outside grove |
+
+The handler pre-checks that the container is running (3s-bounded
+`docker inspect`) and returns an actionable error rather than the noisy
+`docker exec` "no such container" output.
+
 ## Creating a Plugin
 
 ### 1. Create Plugin Package


### PR DESCRIPTION
Closes documentation gaps surfaced in the v0.7.0 release audit (P2-2 and P2-3).

## P2-2: AGENT_GUIDE.md gaps

- **`grove context`** is fully specced in `COMMAND_SPECIFICATIONS.md` but never cross-referenced in the agent guide. Added a section in §3 Core Workflows alongside `grove here`, with a clear "prefer `grove context --json` when you need ahead/behind, stash, or recent commits" recommendation.
- **`--check-update` and `--no-update-notifier`** persistent flags and the `GROVE_NO_UPDATE_NOTIFIER` env var were undocumented. Added to §6 Environment Variables (new env-var row) and a new "Persistent flags" sub-table beneath it.
- **`grove adopt` edge cases**: existing prose covered idempotent already-registered behavior. Added an explicit edge-case table covering detached-HEAD (errors out rather than registering literal `HEAD` as a branch — verified in `cmd/grove/commands/adopt.go:142`) and the path-outside-project case.

## P2-3: PLUGIN_DEVELOPMENT.md gaps

The plugin guide previously mentioned `docker:compose` and `docker:exec` only as named examples, with no field-level reference. A plugin author writing a comparable handler had to read source.

Added:

- **Hook ordering invariant** subsection — plugin Go hooks fire before config-driven hooks (verified in `internal/worktree/bootstrap.go:34` and the `hooks.Fire` / `hookExecutor.Execute` call sequence). This is the guarantee that makes `docker:compose mode = "exec"` on `post_create` viable.
- **`docker:compose` field reference** (`service`, `command`, `mode`, `timeout`, `on_failure`) sourced from `plugins/docker/hook_compose.go` and the `HookAction` struct in `internal/hooks/config.go`.
- **`docker:exec` field reference** (`container`, `command`, `shell`, `timeout`) sourced from `plugins/docker/hook_docker_exec.go`, with a comparison table against `docker:compose mode = "exec"` to clarify the difference (raw container vs compose service).

`hooks.RegisterActionHandler` was already documented — no change needed there.

## CHANGELOG

Added a new `### Documentation` subsection under `[0.7.0]` describing both doc fixes.

## Test plan

- [x] `make lint` clean
- [x] All cited file paths and line numbers verified against current source (`cmd/grove/commands/adopt.go`, `cmd/grove/commands/root.go`, `internal/updatecheck/skip.go`, `internal/hooks/config.go`, `internal/worktree/bootstrap.go`, `plugins/docker/hook_compose.go`, `plugins/docker/hook_docker_exec.go`)
- [x] Examples use generic placeholders (`app`, `app-dev`, `myplugin`) — no consumer-project specifics