### PR TITLE
feat(cli): JSON casing consistency + grove context exit-code spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Behavior changes (read before upgrading)
 
+- **`grove here --json`, `grove ls --json`, and `grove ps --json` field names changed to snake_case for consistency with `grove context --json`.** Scripts parsing these outputs need to update field-name lookups: `fullName → full_name` (here, ls), `agentSlot → agent_slot`, `agentURL → agent_url`, `shortHash → short_hash` (here), `composeProject → compose_project` (ps).
 - **Post-create hook ordering inverted.** Plugin Go hooks now fire BEFORE config-driven hooks in `.grove/hooks.toml` (so containers are up by the time user setup commands run). Pre-existing hook setups that rely on the old ordering may need verification.
 - **`grove test` defaults to `--no-deps`.** Tests that rely on `depends_on` services starting must opt in via `[test] include_deps = true` in `.grove/config.toml` or pass `--with-deps`.
 - **External compose path resolution changed.** Relative paths in `[plugins.docker.external] path` resolve against the directory containing `.grove/`, not grove's CWD.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Service-health probe timeout raised from 1s to 3s to tolerate slow systems.
 - Compose `--env-file` is now honored when reading the active-worktree env var (previously hardcoded to `.env`).
 - Worktree ages now reflect real timestamps (no more "9999 days").
+- `docs/COMMAND_SPECIFICATIONS.md` clarifies `grove context` exit codes: exit 10 only when the command runs outside any grove project; exit 1 when in a grove project but the current directory is not a registered worktree.
 
 ### Fixed
 - TUI update-available opt-outs now also gate the Skip flow for full parity with the CLI box (issue #84, PR #83). Previously the Skip-cache gate didn't honor every documented opt-out env var.

--- a/cmd/grove/commands/here.go
+++ b/cmd/grove/commands/here.go
@@ -37,7 +37,7 @@ var (
 // hereOutput represents the JSON output structure for grove here
 type hereOutput struct {
 	Name        string     `json:"name"`
-	FullName    string     `json:"fullName"`
+	FullName    string     `json:"full_name"`
 	Project     string     `json:"project"`
 	Branch      string     `json:"branch"`
 	Path        string     `json:"path"`
@@ -47,13 +47,13 @@ type hereOutput struct {
 	Tmux        tmuxInfo   `json:"tmux"`
 	Environment bool       `json:"environment,omitempty"`
 	Mirror      string     `json:"mirror,omitempty"`
-	AgentSlot   int        `json:"agentSlot,omitempty"`
-	AgentURL    string     `json:"agentURL,omitempty"`
+	AgentSlot   int        `json:"agent_slot,omitempty"`
+	AgentURL    string     `json:"agent_url,omitempty"`
 }
 
 type commitInfo struct {
 	Hash      string `json:"hash"`
-	ShortHash string `json:"shortHash"`
+	ShortHash string `json:"short_hash"`
 	Message   string `json:"message"`
 	Age       string `json:"age"`
 }

--- a/cmd/grove/commands/ls.go
+++ b/cmd/grove/commands/ls.go
@@ -22,7 +22,7 @@ var (
 // lsWorktreeOutput represents a worktree in JSON output
 type lsWorktreeOutput struct {
 	Name        string            `json:"name"`
-	FullName    string            `json:"fullName"`
+	FullName    string            `json:"full_name"`
 	Branch      string            `json:"branch"`
 	Path        string            `json:"path"`
 	Status      string            `json:"status"`

--- a/cmd/grove/commands/ps.go
+++ b/cmd/grove/commands/ps.go
@@ -16,7 +16,7 @@ var psJSON bool
 type psSlotOutput struct {
 	Slot    int    `json:"slot"`
 	Name    string `json:"worktree"`
-	Project string `json:"composeProject"`
+	Project string `json:"compose_project"`
 	URL     string `json:"url,omitempty"`
 }
 

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -1005,11 +1005,13 @@ Recent:
 | Dirty worktree | Shows modified files (up to 5 shown; remainder counted) |
 | No stashes | `Stash:` line omitted in human output; `stash_count: 0` in JSON |
 | No commits yet | Recent commits section omitted |
-| Not in grove project | Exit non-zero with "not a grove project" error |
+| Not in grove project | Exit 10 with "not a grove project" error |
+| In a grove project but cwd is not a registered worktree | Exit 1 with "not in a grove worktree" error |
 
 **Exit Codes:**
 - 0: Success
-- 10: Not in a grove project
+- 1: In a grove project but the current directory is not a registered worktree
+- 10: Not in any grove project (no `.grove/` directory found)
 
 ---
 

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -246,7 +246,7 @@ NAME            BRANCH          STATUS     TMUX        PATH
   "worktrees": [
     {
       "name": "main",
-      "fullName": "grove",
+      "full_name": "grove",
       "branch": "main",
       "path": "~/projects/grove",
       "status": "clean",
@@ -853,13 +853,13 @@ testing
 ```json
 {
   "name": "testing",
-  "fullName": "grove-testing",
+  "full_name": "grove-testing",
   "project": "grove",
   "branch": "testing",
   "path": "~/projects/grove-testing",
   "commit": {
     "hash": "abc1234def5678",
-    "shortHash": "abc1234",
+    "short_hash": "abc1234",
     "message": "Fix authentication bug",
     "age": "2 hours ago"
   },
@@ -1353,7 +1353,7 @@ To enable, add to .grove/config.toml:
   {
     "slot": 1,
     "worktree": "feature-x",
-    "composeProject": "myapp-agent-1",
+    "compose_project": "myapp-agent-1",
     "url": "http://localhost:3101"
   }
 ]


### PR DESCRIPTION
## Summary

Two pre-v0.7.0-release CLI consistency fixes:

### 1. Standardize `--json` output to snake_case (P1-1)

`grove here`, `grove ls`, and `grove ps` previously emitted camelCase JSON keys (`fullName`, `agentSlot`, `agentURL`, `shortHash`, `composeProject`). The newer `grove context --json` (added in v0.7.0) emits snake_case (`tracking_branch`, `has_remote`, `stash_count`, `recent_commits`).

Standardize on **snake_case** before v0.7.0 ships so we don't lock in two conventions:

- `grove here`: `fullName → full_name`, `agentSlot → agent_slot`, `agentURL → agent_url`, `shortHash → short_hash`
- `grove ls`: `fullName → full_name`
- `grove ps`: `composeProject → compose_project`

Rationale: snake_case is what `grove context` already uses, what most modern CLI tools (kubectl, aws-cli, gh) use, and one breaking change now is cheaper than two later. Only struct tags change; Go field names are unchanged.

**This is a breaking change for any scripts parsing these outputs by field name.** Documented in CHANGELOG under "Behavior changes (read before upgrading)".

### 2. Clarify `grove context` exit-code spec (P1-4)

Spec listed only exit 10 for `grove context`, but the implementation distinguishes:

- exit 10 when no `.grove/` directory is found anywhere (no grove project at all)
- exit 1 when in a grove project but the current directory is not a registered worktree (returned from `RequireGroveContext`'s callback as `not in a grove worktree`)

Spec-only update — no code change.

## Test plan

- [x] `make lint` clean
- [x] `make test` passes (all packages)
- [x] `make test-integration` passes
- [ ] Reviewer: spot-check `grove here --json` / `grove ls --json` / `grove ps --json` field names match CHANGELOG note
- [ ] Reviewer: verify CHANGELOG "Behavior changes" entry surfaces the breaking change clearly