### PR TITLE
test(tui): use version.Version instead of literal in update overlay tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Downstream consumers integrating with grove via `.grove/config.toml` or `.grove/
 - `internal/grove.IsWorktreeInState` — shared helper for state.json drift detection.
 - `state.Manager.Batch()` and the new `worktreeinfo` package extracted to consolidate git fan-out (#74, #85).
 - Removed unused `matchesActive` parameter from external-status classifier; removed `_ = name` dead wiring in env-loader doctor checks; removed dead `BootstrapOpts.Now` injection field.
+- Test fixtures in `internal/tui/update_overlay_test.go` now reference `version.Version` instead of a hardcoded `0.7.0-dev` literal, so they don't silently break on the next dev-cycle version bump.
 
 ## [0.6.1] - 2026-03-19
 

--- a/internal/tui/update_overlay_test.go
+++ b/internal/tui/update_overlay_test.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/lost-in-the/grove/internal/version"
 )
 
 // stripANSIUpdate removes ANSI escape codes for substring assertions.
@@ -22,13 +24,16 @@ func TestNewUpdateOverlay(t *testing.T) {
 
 func TestUpdateOverlayOpen(t *testing.T) {
 	u := NewUpdateOverlay()
-	u.Open("0.7.0-dev", "99.0.0", "https://github.com/lost-in-the/grove/releases/tag/v99.0.0")
+	// Use the live version.Version so this test doesn't silently break on the
+	// next dev-cycle version bump. Whatever the current build's version is,
+	// Open should round-trip it through currentVersion unchanged.
+	u.Open(version.Version, "99.0.0", "https://github.com/lost-in-the/grove/releases/tag/v99.0.0")
 
 	if !u.Active {
 		t.Error("expected Active to be true after Open")
 	}
-	if u.currentVersion != "0.7.0-dev" {
-		t.Errorf("currentVersion = %q, want %q", u.currentVersion, "0.7.0-dev")
+	if u.currentVersion != version.Version {
+		t.Errorf("currentVersion = %q, want %q", u.currentVersion, version.Version)
 	}
 	if u.latestVersion != "99.0.0" {
 		t.Errorf("latestVersion = %q, want %q", u.latestVersion, "99.0.0")


### PR DESCRIPTION
## Summary

`internal/tui/update_overlay_test.go` hardcoded `"0.7.0-dev"` as a literal current-version string in test fixtures. When `internal/version/version.go` shifts to `"0.8.0-dev"` (or any subsequent dev-cycle bump), these assertions would silently break — the test would still pass `Open(...)` a stale literal that no longer matches what the live build reports as current.

This swaps the literal for `version.Version` so the round-trip assertion (whatever the build reports as current, `Open` should preserve it) survives version bumps without manual updates.

## Scope (P1-5)

- Touches only `internal/tui/update_overlay_test.go` and `CHANGELOG.md`
- Two literal occurrences in the `TestUpdateOverlayOpen` fixture replaced with `version.Version`
- Adds `github.com/lost-in-the/grove/internal/version` import
- CHANGELOG entry filed under `[0.7.0]` `### Internal`

Other tests in the file (`TestUpdateOverlayClose`, `TestUpdateOverlayViewContent`, `TestUpdateOverlayViewOmitsChangelogWhenURLEmpty`, `TestUpdateOverlayViewMultipleWidths`) intentionally use specific literal versions like `"0.6.0"`/`"0.7.0"` to assert exact rendering of those strings in the overlay view, not to track the live version. Those stay as-is.

## Test plan

- [x] `go test ./internal/tui/ -count=1 -v` — passes
- [x] `go test ./internal/tui/ -tags=integration -run '^TestProgram_UpdateOverlay' -count=1 -v` — passes
- [x] `make lint` — 0 issues
