### PR TITLE
chore(release): set v0.7.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - YYYY-MM-DD
+## [0.7.0] - 2026-05-11
 
 > **Upgrading:** No breaking config changes — all new fields have defaults and existing configs continue to work. Docker users should run `grove doctor` to surface host install commands that should now be `docker:compose` hooks (`grove doctor --fix` rewrites them automatically). See "Behavior changes" and "Migration / consumer-side" below.
 


### PR DESCRIPTION
Sets the `## [0.7.0]` CHANGELOG entry from `YYYY-MM-DD` to `2026-05-11` in preparation for tagging `v0.7.0`.

Last release-prep edit before the tag push. The CHANGELOG body, README upgrading section, agent-facing docs (`AGENT_GUIDE.md`, `PLUGIN_DEVELOPMENT.md`, `CONFIGURATION_REFERENCE.md`), `release.yml` workflow, and `.goreleaser.yml` are already in shape.

## Post-merge plan
1. Tag `v0.7.0` on `main` and push — release workflow handles GoReleaser + Homebrew formula update.
2. Bump `internal/version/version.go` from `0.7.0-dev` → `0.8.0-dev` in a follow-up PR.

## Test plan
- [x] `make lint` (0 issues)
- [x] `make test` (all packages pass)
- [x] `make test-integration` (tui + docker)
- [x] `go vet ./...` / `gofmt -s -l .` clean