### PR TITLE
chore(version): bump dev cycle to 0.8.0-dev

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,7 +5,7 @@ import "runtime"
 // Version information set by build flags or defaults
 var (
 	// Version is the semantic version of the application
-	Version = "0.7.0-dev"
+	Version = "0.8.0-dev"
 	// Commit is the git commit hash
 	Commit = "unknown"
 	// BuildDate is the date the binary was built


### PR DESCRIPTION
Post-release bump now that **v0.7.0 is tagged and published** (release: https://github.com/lost-in-the/grove/releases/tag/v0.7.0).

Bumps the fallback Version constant in `internal/version/version.go` from `0.7.0-dev` → `0.8.0-dev`. GoReleaser overrides this with the real tag on release builds via ldflags; this constant only affects local `make build` / `go install ...@main` (edge) builds, which should advertise themselves as ahead-of-released.

The `[Unreleased]` section in `CHANGELOG.md` is already empty and ready to accept entries for the next cycle — no edit needed there.

The `0.7.0-dev` references that remain in `internal/updatecheck/check_test.go` and `internal/updatecheck/skip_test.go` are deliberate fixture strings testing that any `-dev` suffix suppresses the update badge — not version-tracking, leaving them alone.

## Test plan
- [x] `make build` → binary reports `grove 0.8.0-dev darwin/arm64`
- [x] `go test ./internal/version/... ./internal/updatecheck/... ./internal/tui/...` all pass