### PR TITLE
fix(docker/external): layer .env under env_file for compose interpolation (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `[plugins.docker.external] env_file` set to a non-default file (e.g. `.env.local`) no longer shadows the project's `.env` for compose interpolation. Grove now passes both `--env-file .env --env-file <configured>` when `.env` is present alongside, matching developer intuition (defaults from `.env`, per-worktree overrides from the configured file). Previously, variables defined only in `.env` would silently become blank during interpolation (issue #98).
+
 ## [0.7.0] - 2026-05-11
 
 > **Upgrading:** No breaking config changes — all new fields have defaults and existing configs continue to work. Docker users should run `grove doctor` to surface host install commands that should now be `docker:compose` hooks (`grove doctor --fix` rewrites them automatically). See "Behavior changes" and "Migration / consumer-side" below.

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -309,7 +309,11 @@ path = "~/work/compose-dev"        # string (required)
 env_var = "APP_DIR"                # string (required)
 
 # File in the compose directory where grove writes the env var value.
-# Grove passes --env-file to every compose call automatically.
+# Grove passes --env-file to every compose call automatically. When this is
+# set to anything other than ".env" and a ".env" file also exists in the
+# compose directory, grove layers both (--env-file .env --env-file <configured>)
+# so committed defaults in .env stay available for interpolation alongside the
+# per-worktree overrides written here.
 # Set to ".env.local" to avoid dirtying a git-tracked .env.
 # Default: ".env"
 env_file = ".env"                  # string

--- a/plugins/docker/local.go
+++ b/plugins/docker/local.go
@@ -225,22 +225,41 @@ func hasDockerCompose(dir string) bool {
 	return false
 }
 
+// composeEnvFileArgs returns --env-file arguments for `docker compose` v2 that
+// layer the default .env (if present in composePath) underneath the configured
+// envFile. Returns nil when envFile is unset or already ".env" (compose reads
+// .env by default in that case).
+//
+// Compose v2 supports multiple --env-file flags; later ones override earlier
+// ones for interpolation. Without this layering, setting env_file=".env.local"
+// would cause `docker compose` to ignore .env entirely, silently breaking
+// interpolation of variables defined only in .env (issue #98).
+func composeEnvFileArgs(composePath, envFile string) []string {
+	if envFile == "" || envFile == ".env" {
+		return nil
+	}
+	var args []string
+	if _, err := os.Stat(filepath.Join(composePath, ".env")); err == nil {
+		args = append(args, "--env-file", ".env")
+	}
+	args = append(args, "--env-file", envFile)
+	return args
+}
+
 // composeCommand creates a docker-compose command with optional environment variables.
 // dir sets the working directory. envFile, when non-empty and not ".env", adds
-// --env-file to the compose command for YAML variable interpolation. env is a list
-// of extra KEY=VALUE strings to add to the process environment.
+// --env-file to the compose command for YAML variable interpolation; if a .env
+// file also exists alongside, it is layered underneath so compose still reads
+// defaults from .env. env is a list of extra KEY=VALUE strings to add to the
+// process environment.
 //
 // Callers set cmd.Stdout = os.Stderr intentionally: grove reserves stdout for
 // shell-integration directives (cd:, env:, tmux-attach:), so Docker output
 // must go to stderr to avoid corrupting the directive stream.
 func composeCommand(dir string, envFile string, env []string, args ...string) *exec.Cmd {
 	if _, err := exec.LookPath("docker"); err == nil {
-		var cmdArgs []string
-		if envFile != "" && envFile != ".env" {
-			cmdArgs = append(cmdArgs, "compose", "--env-file", envFile)
-		} else {
-			cmdArgs = append(cmdArgs, "compose")
-		}
+		cmdArgs := []string{"compose"}
+		cmdArgs = append(cmdArgs, composeEnvFileArgs(dir, envFile)...)
 		cmdArgs = append(cmdArgs, args...)
 		cmd := exec.Command("docker", cmdArgs...)
 		cmd.Dir = dir
@@ -250,7 +269,8 @@ func composeCommand(dir string, envFile string, env []string, args ...string) *e
 		return cmd
 	}
 
-	// docker-compose v1 fallback — --env-file goes after compose subcommand
+	// docker-compose v1 fallback — only supports a single --env-file, so we
+	// can't layer .env underneath. Pass the configured envFile as-is.
 	var cmdArgs []string
 	if envFile != "" && envFile != ".env" {
 		cmdArgs = append(cmdArgs, "--env-file", envFile)

--- a/plugins/docker/local_test.go
+++ b/plugins/docker/local_test.go
@@ -147,3 +147,62 @@ func TestLocalRun_IncludeDepsTrueOmitsNoDeps(t *testing.T) {
 		}
 	}
 }
+
+// TestComposeEnvFileArgs locks the behavior introduced for issue #98: when a
+// project configures env_file to something other than ".env", grove must still
+// layer ".env" underneath so compose v2 can interpolate variables defined only
+// in the committed defaults file.
+func TestComposeEnvFileArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		envFile   string
+		writeEnv  bool // whether a .env file exists in composePath
+		expectArg []string
+	}{
+		{
+			name:      "empty envFile returns no args",
+			envFile:   "",
+			writeEnv:  true,
+			expectArg: nil,
+		},
+		{
+			name:      "envFile equals .env returns no args (compose default)",
+			envFile:   ".env",
+			writeEnv:  true,
+			expectArg: nil,
+		},
+		{
+			name:      "envFile=.env.local with .env present layers both",
+			envFile:   ".env.local",
+			writeEnv:  true,
+			expectArg: []string{"--env-file", ".env", "--env-file", ".env.local"},
+		},
+		{
+			name:      "envFile=.env.local without .env passes only configured",
+			envFile:   ".env.local",
+			writeEnv:  false,
+			expectArg: []string{"--env-file", ".env.local"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.writeEnv {
+				if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("FOO=bar\n"), 0o644); err != nil {
+					t.Fatalf("write .env: %v", err)
+				}
+			}
+
+			got := composeEnvFileArgs(dir, tt.envFile)
+			if len(got) != len(tt.expectArg) {
+				t.Fatalf("expected %v (len %d), got %v (len %d)", tt.expectArg, len(tt.expectArg), got, len(got))
+			}
+			for i := range got {
+				if got[i] != tt.expectArg[i] {
+					t.Errorf("args[%d]: expected %q, got %q (full: %v)", i, tt.expectArg[i], got[i], got)
+				}
+			}
+		})
+	}
+}

--- a/plugins/docker/service_health.go
+++ b/plugins/docker/service_health.go
@@ -140,9 +140,7 @@ func probeServiceHealth(composePath, envFile string, env []string) ([]ServiceSta
 	defer cancel()
 
 	args := []string{"compose"}
-	if envFile != "" && envFile != ".env" {
-		args = append(args, "--env-file", envFile)
-	}
+	args = append(args, composeEnvFileArgs(composePath, envFile)...)
 	args = append(args, "ps", "--all", "--format", "json")
 
 	cmd := exec.CommandContext(ctx, "docker", args...)


### PR DESCRIPTION
Closes #98.

## Problem

Compose v2's `--env-file` flag **replaces** the default `.env` rather than layering on top of it. When `[plugins.docker.external].env_file = ".env.local"` (or any non-default value), grove passes only that file to compose. Result: any variable defined only in `.env` becomes blank during interpolation, and stacks that worked under the wrapped pattern (`.env` for committed defaults + `.env.local` for per-worktree overrides) break silently:

\`\`\`
$ grove up
WARN[0000] The \"OTEL_IMAGE\" variable is not set. Defaulting to a blank string.
service \"observability\" has neither an image nor a build context: invalid compose project
\`\`\`

## Fix

Extract \`composeEnvFileArgs(composePath, envFile)\` in \`plugins/docker/local.go\`:

| Case | Returns |
|---|---|
| \`envFile\` is \`\"\"\` or \`\".env\"\` | \`nil\` (compose reads .env by default) |
| \`envFile == \".env.local\"\`, no \`.env\` in dir | \`[--env-file .env.local]\` (unchanged from today) |
| \`envFile == \".env.local\"\`, \`.env\` exists in dir | \`[--env-file .env --env-file .env.local]\` (new — layers defaults under overrides) |

Compose v2 supports multiple \`--env-file\` flags; later overrides earlier. Used in both \`composeCommand\` (covers local/external/agent strategies, every \`compose run/up/down/exec\` call) and \`probeServiceHealth\`.

Compose v1 fallback keeps the single-file behavior since v1 doesn't support layering.

## Test plan
- [x] New \`TestComposeEnvFileArgs\` covers all four cases (empty / default / layered / single)
- [x] \`make lint\` (0 issues)
- [x] \`go test ./plugins/docker/\` — all pass, coverage 63.5% → 63.7%

## Docs
- CHANGELOG \`[Unreleased]\` entry under Fixed
- \`docs/CONFIGURATION_REFERENCE.md\` env_file note expanded to describe the layering