### PR TITLE
feat(new): --from-branch and --dirty for adopting existing branches (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `grove new --from-branch <branch>` — adopts an existing local or remote branch into a new worktree without creating a new branch (calls `git worktree add <path> <branch>`). Mutually exclusive with `--from`, `--branch`, and `--mirror`. Git's "branch already checked out" guardrail still fires when the branch is in use elsewhere (closes #95).
+- `grove new --dirty` — when paired with `--from-branch`, transfers `git diff HEAD` (working tree + staged tracked changes) from the current worktree into the new one via `git apply`. Untracked files are intentionally excluded. Transferred changes land as unstaged in the destination; re-stage manually if needed. A patch that fails to apply (conflict, etc.) emits a warning rather than aborting — the new worktree is intact and the source is unmodified.
+
 ### Fixed
 - `[plugins.docker.external] env_file` set to a non-default file (e.g. `.env.local`) no longer shadows the project's `.env` for compose interpolation. Grove now passes both `--env-file .env --env-file <configured>` when `.env` is present alongside, matching developer intuition (defaults from `.env`, per-worktree overrides from the configured file). Previously, variables defined only in `.env` would silently become blank during interpolation (issue #98).
 

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -18,12 +18,14 @@ import (
 )
 
 var (
-	newJSON     bool
-	newMirror   string // Remote branch to mirror (e.g., "origin/main")
-	newNoDocker bool   // Skip auto-starting Docker
-	newBranch   string // Override branch name
-	newFrom     string // Create branch from this ref
-	newNoSwitch bool   // Skip auto-switching to the new worktree
+	newJSON       bool
+	newMirror     string // Remote branch to mirror (e.g., "origin/main")
+	newNoDocker   bool   // Skip auto-starting Docker
+	newBranch     string // Override branch name
+	newFrom       string // Create branch from this ref
+	newFromBranch string // Check out an existing branch in the new worktree
+	newDirty      bool   // Carry over `git diff HEAD` from the current worktree
+	newNoSwitch   bool   // Skip auto-switching to the new worktree
 )
 
 var newCmd = &cobra.Command{
@@ -43,13 +45,21 @@ Use --no-docker to skip Docker auto-start.
 Use --mirror to create an environment worktree that tracks a remote branch.
 Environment worktrees are read-only and can be synced with 'grove sync'.
 
+Use --from-branch to check out an existing local or remote branch in the new
+worktree (no new branch is created). Pair with --dirty to also carry over
+uncommitted changes ('git diff HEAD' — working tree + staged) from the current
+worktree. Useful when promoting an in-progress branch from your main checkout
+into its own worktree.
+
 Examples:
   grove new feature-auth                          # Create worktree + tmux + Docker
   grove new feature-auth --branch custom-branch   # Use custom branch name
   grove new feature-auth --from develop            # Branch from develop
   grove new feature-auth --no-docker               # Skip Docker auto-start
   grove spawn feature-x                            # Alias (implies --json output)
-  grove new staging --mirror origin/main           # Environment worktree tracking origin/main`,
+  grove new staging --mirror origin/main           # Environment worktree tracking origin/main
+  grove new payments --from-branch feature/payments         # Adopt existing branch as worktree
+  grove new payments --from-branch feature/payments --dirty # Also carry over uncommitted edits`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		// spawn alias implies JSON output
@@ -76,6 +86,27 @@ Examples:
 
 		if name == "" {
 			return fmt.Errorf("worktree name cannot be empty")
+		}
+
+		// --dirty only makes sense paired with --from-branch (adopting an
+		// existing branch). For the default flow (new branch from HEAD) the
+		// branch is empty and a working-tree carry-over has no obvious
+		// destination semantics.
+		if newDirty && newFromBranch == "" {
+			return fmt.Errorf("--dirty requires --from-branch")
+		}
+
+		// Capture the diff BEFORE creating the worktree. If creation fails we
+		// just discard the patch; if it succeeds we apply it in the new
+		// worktree after setup. `git diff HEAD` combines staged + unstaged
+		// tracked changes; untracked files are intentionally excluded.
+		var dirtyPatch []byte
+		if newDirty {
+			out, diffErr := cmdexec.Output(context.TODO(), "git", []string{"-C", ctx.ProjectRoot, "diff", "HEAD"}, "", cmdexec.GitLocal)
+			if diffErr != nil {
+				return fmt.Errorf("failed to capture working-tree diff: %w", diffErr)
+			}
+			dirtyPatch = out
 		}
 
 		mgr, err := worktree.NewManager(ctx.ProjectRoot)
@@ -126,6 +157,19 @@ Examples:
 			if !newJSON {
 				cli.Success(w, "Created environment worktree '%s' tracking %s", name, mirror)
 			}
+		} else if newFromBranch != "" {
+			// Adopt an existing branch into a new worktree. No new branch is
+			// created; the worktree checks out newFromBranch directly. Git
+			// refuses if the branch is already checked out elsewhere — that
+			// guardrail is intentional and surfaces to the user as-is.
+			branchName = newFromBranch
+			if err := mgr.CreateFromBranch(name, newFromBranch); err != nil {
+				return fmt.Errorf("failed to create worktree from branch %q: %w", newFromBranch, err)
+			}
+
+			if !newJSON {
+				cli.Success(w, "Created worktree '%s' from branch '%s'", name, newFromBranch)
+			}
 		} else {
 			// Regular worktree - use --branch if provided, otherwise name
 			if newBranch != "" {
@@ -159,6 +203,24 @@ Examples:
 		}, w)
 		if err != nil {
 			return err
+		}
+
+		// Apply the diff captured before worktree creation. Empty diff is a
+		// no-op (issued as informational text only); a non-empty diff that
+		// fails to apply is surfaced as a warning rather than a hard error
+		// because the worktree itself is intact and useful — the user can
+		// inspect and re-apply manually.
+		if newDirty {
+			if len(dirtyPatch) == 0 {
+				if !newJSON {
+					cli.Info(w, "--dirty: no uncommitted changes to transfer")
+				}
+			} else if err := applyDirtyPatch(wt.Path, dirtyPatch); err != nil {
+				cli.Warning(stderr, "--dirty: failed to apply patch to new worktree: %v", err)
+				cli.Faint(stderr, "The patch is intact in your current worktree; resolve manually and re-apply.")
+			} else if !newJSON {
+				cli.Success(w, "Transferred uncommitted changes (--dirty)")
+			}
 		}
 
 		projectName := mgr.GetProjectName()
@@ -261,14 +323,44 @@ Examples:
 	}),
 }
 
+// applyDirtyPatch writes the captured diff to a temp file alongside the new
+// worktree and applies it via `git apply`. The temp file is removed regardless
+// of apply outcome so a stray patch file doesn't litter the worktree root.
+func applyDirtyPatch(worktreePath string, patch []byte) error {
+	f, err := os.CreateTemp("", "grove-dirty-*.patch")
+	if err != nil {
+		return fmt.Errorf("create temp patch file: %w", err)
+	}
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	if _, err := f.Write(patch); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write temp patch file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temp patch file: %w", err)
+	}
+
+	out, err := cmdexec.CombinedOutput(context.TODO(), "git", []string{"-C", worktreePath, "apply", f.Name()}, "", cmdexec.GitLocal)
+	if err != nil {
+		return fmt.Errorf("git apply: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 func init() {
 	newCmd.Flags().BoolVarP(&newJSON, "json", "j", false, "Output as JSON with switch_to field")
 	newCmd.Flags().StringVarP(&newBranch, "branch", "b", "", "Branch name to create (default: worktree name)")
 	newCmd.Flags().StringVarP(&newFrom, "from", "f", "", "Create branch from this ref (default: HEAD)")
+	newCmd.Flags().StringVar(&newFromBranch, "from-branch", "", "Check out an existing branch in the new worktree (no new branch created)")
+	newCmd.Flags().BoolVar(&newDirty, "dirty", false, "Carry over `git diff HEAD` from the current worktree (requires --from-branch)")
 	newCmd.Flags().StringVar(&newMirror, "mirror", "", "Create environment worktree tracking a remote branch (e.g., origin/main)")
 	newCmd.Flags().BoolVar(&newNoDocker, "no-docker", false, "Skip Docker auto-start")
 	newCmd.Flags().BoolVarP(&newNoSwitch, "no-switch", "n", false, "Stay in current worktree after creation")
 	newCmd.MarkFlagsMutuallyExclusive("mirror", "from")
 	newCmd.MarkFlagsMutuallyExclusive("mirror", "branch")
+	newCmd.MarkFlagsMutuallyExclusive("mirror", "from-branch")
+	newCmd.MarkFlagsMutuallyExclusive("from", "from-branch")
+	newCmd.MarkFlagsMutuallyExclusive("branch", "from-branch")
 	rootCmd.AddCommand(newCmd)
 }

--- a/cmd/grove/commands/new_test.go
+++ b/cmd/grove/commands/new_test.go
@@ -1,8 +1,14 @@
 package commands
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/lost-in-the/grove/internal/cmdexec"
 )
 
 func TestNewCmd(t *testing.T) {
@@ -194,5 +200,130 @@ func TestNewCmd_HasSpawnAlias(t *testing.T) {
 	}
 	if !found {
 		t.Error("newCmd should have 'spawn' alias")
+	}
+}
+
+func TestNewCmd_FromBranchFlag(t *testing.T) {
+	flag := newCmd.Flags().Lookup("from-branch")
+	if flag == nil {
+		t.Fatal("newCmd missing --from-branch flag")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("--from-branch should default to empty, got %q", flag.DefValue)
+	}
+	if !strings.Contains(strings.ToLower(flag.Usage), "existing") {
+		t.Errorf("--from-branch usage should mention 'existing' branch, got: %q", flag.Usage)
+	}
+}
+
+func TestNewCmd_DirtyFlag(t *testing.T) {
+	flag := newCmd.Flags().Lookup("dirty")
+	if flag == nil {
+		t.Fatal("newCmd missing --dirty flag")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--dirty should default to false, got %q", flag.DefValue)
+	}
+	if !strings.Contains(flag.Usage, "from-branch") {
+		t.Errorf("--dirty usage should mention --from-branch requirement, got: %q", flag.Usage)
+	}
+}
+
+// TestNewCmd_FromBranchMutuallyExclusive verifies --from-branch is mutually
+// exclusive with --from, --branch, and --mirror (all attempt to create a new
+// branch in different ways, so combining them is nonsense).
+func TestNewCmd_FromBranchMutuallyExclusive(t *testing.T) {
+	flag := newCmd.Flags().Lookup("from-branch")
+	if flag == nil {
+		t.Fatal("--from-branch flag not found")
+	}
+	annotations := flag.Annotations
+	if annotations == nil {
+		t.Fatal("--from-branch has no annotations; MarkFlagsMutuallyExclusive not configured")
+	}
+	group, ok := annotations["cobra_annotation_mutually_exclusive"]
+	if !ok {
+		t.Fatal("--from-branch missing cobra_annotation_mutually_exclusive annotation")
+	}
+
+	for _, peer := range []string{"from", "branch", "mirror"} {
+		found := false
+		for _, g := range group {
+			if strings.Contains(g, peer) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("--from-branch should be mutually exclusive with --%s (annotations: %v)", peer, group)
+		}
+	}
+}
+
+// TestApplyDirtyPatch_RoundTrip exercises the diff-capture + diff-apply pair
+// against a real git repo. It writes a baseline file, commits it, modifies it,
+// captures `git diff HEAD`, then applies the patch in a freshly-built worktree
+// directory and asserts the modification is reproduced. This is the core
+// invariant of --dirty: whatever the user sees as uncommitted in their current
+// worktree must appear identically in the new one.
+func TestApplyDirtyPatch_RoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+
+	source := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = source
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-b", "main", ".")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "test")
+
+	baseline := filepath.Join(source, "file.txt")
+	if err := os.WriteFile(baseline, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "file.txt")
+	runGit("commit", "-m", "baseline")
+
+	// Modify the file but don't commit — this is what --dirty should carry.
+	if err := os.WriteFile(baseline, []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	patch, err := cmdexec.Output(context.Background(), "git", []string{"-C", source, "diff", "HEAD"}, "", cmdexec.GitLocal)
+	if err != nil {
+		t.Fatalf("capture diff: %v", err)
+	}
+	if len(patch) == 0 {
+		t.Fatal("expected non-empty diff after modification")
+	}
+
+	// Build a separate "worktree" by adding via git worktree on a new branch.
+	// applyDirtyPatch only needs a git working tree at the target path.
+	target := filepath.Join(t.TempDir(), "wt")
+	if out, err := exec.Command("git", "-C", source, "worktree", "add", "-b", "feature", target).CombinedOutput(); err != nil {
+		t.Fatalf("create target worktree: %v\n%s", err, out)
+	}
+
+	if err := applyDirtyPatch(target, patch); err != nil {
+		t.Fatalf("applyDirtyPatch: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(target, "file.txt"))
+	if err != nil {
+		t.Fatalf("read target file: %v", err)
+	}
+	if string(got) != "hello\nworld\n" {
+		t.Errorf("target file contents = %q, want %q", string(got), "hello\nworld\n")
 	}
 }

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -287,21 +287,30 @@ Arguments:
   name    Name for the new worktree (required)
 
 Flags:
-  -b, --branch <branch>  Branch name to create (default: worktree name)
-  -f, --from <ref>       Create branch from this ref (default: HEAD)
-  -j, --json             Output as JSON with switch_to field
-      --mirror <ref>     Create environment worktree tracking a remote branch (e.g., origin/main)
-      --no-docker        Skip Docker auto-start
+  -b, --branch <branch>      Branch name to create (default: worktree name)
+  -f, --from <ref>           Create branch from this ref (default: HEAD)
+      --from-branch <branch> Check out an existing local or remote branch (no new branch created)
+      --dirty                Carry over `git diff HEAD` from the current worktree (requires --from-branch)
+  -j, --json                 Output as JSON with switch_to field
+      --mirror <ref>         Create environment worktree tracking a remote branch (e.g., origin/main)
+      --no-docker            Skip Docker auto-start
+  -n, --no-switch            Stay in current worktree after creation
 ```
+
+`--mirror`, `--from`, `--branch`, and `--from-branch` are mutually exclusive — pick the one that matches your intent.
 
 **Behavior:**
 
 1. **Validate name:**
    - Apply naming transformations
    - Check for existing worktree with same name
-   
-2. **Create worktree:**
+   - If `--dirty` is set without `--from-branch`, return an error before any creation
+
+2. **(If `--dirty`) Capture diff** from the current worktree via `git -C <project-root> diff HEAD` (working tree + staged tracked changes; untracked files excluded by design). Held in memory until step 5; failures here abort the command before any worktree is created.
+
+3. **Create worktree:**
    - If `--mirror` specified: verify remote branch exists, create environment worktree tracking it
+   - If `--from-branch <branch>` specified: check out the existing branch in the new worktree (`git worktree add <path> <branch>`). No new branch is created. Git refuses if the branch is already checked out elsewhere — that guardrail is intentional.
    - Otherwise: create new worktree with branch matching the name
    ```bash
    git worktree add <path> <branch>
@@ -322,6 +331,12 @@ Flags:
 8. **Auto-start Docker** (unless `--no-docker`):
    - Only runs when `shouldAutoDocker()` returns true: agent stacks configured (`plugins.docker.external.agent.enabled = true`) or `plugins.docker.auto_up = true`
    - Calls `docker.Up()` for the new worktree path
+
+9. **(If `--dirty`) Apply the captured patch** via `git -C <new-worktree> apply <tempfile>`:
+   - Empty patch (no uncommitted changes in source): informational message, no-op
+   - Non-empty patch that applies cleanly: success message
+   - Non-empty patch that fails to apply: warning to stderr — the original worktree is untouched, the new worktree is intact, and the user is told to re-apply manually. Not a hard failure because the worktree creation already succeeded
+   - All transferred edits land in the new worktree as **unstaged** changes regardless of staging state in the source; re-stage manually if needed
 
 **Output (Success):**
 ```
@@ -358,6 +373,11 @@ To remove it:    grove rm testing
 | Branch exists, worktree doesn't | Create worktree with existing branch |
 | Invalid name characters | Auto-transform and proceed with warning |
 | Disk full | Error: "Failed to create worktree: {git error}" |
+| `--from-branch <branch>` and branch is checked out elsewhere | Git refuses with "branch already checked out at <path>"; grove surfaces the error and exits non-zero. The user must switch the other worktree off the branch first. |
+| `--from-branch <branch>` with branch that only exists on origin | Grove fetches `origin/<branch>:<branch>` into a local ref (best-effort; logged but non-fatal), then `git worktree add` checks it out. |
+| `--dirty` with no uncommitted changes in source | Informational message ("no uncommitted changes to transfer"), worktree still created. |
+| `--dirty` patch fails to apply (conflicts) | Warning to stderr, worktree intact, source unmodified, user told to re-apply manually. Non-zero in this case is *not* returned. |
+| `--dirty` without `--from-branch` | Validation error before any state changes. |
 | No write permission | Error: "Cannot create worktree: permission denied at {path}" |
 | Inside a worktree (not main) | Still works, creates sibling |
 | Parent directory doesn't exist | Create parent directories |


### PR DESCRIPTION
Closes #95.

## Problem

\`grove new\` always creates a new branch. It can't adopt an existing local branch into a new worktree, and there's no way to carry over working-tree edits from the current worktree when doing so. The workaround was \`git diff HEAD > /tmp/wip.patch && git worktree add ... && git apply\` outside grove — undermining the one-command-does-everything model.

## Solution

Two new flags on \`grove new\`:

\`\`\`
--from-branch <branch>   # check out existing branch (no new branch created)
--dirty                  # also carry over `git diff HEAD` (requires --from-branch)
\`\`\`

\`--from-branch\` routes through \`mgr.CreateFromBranch\` (same path as \`--mirror\` but without the \`env/\` rename). Mutually exclusive with \`--mirror\`, \`--from\`, and \`--branch\` — they all create a new branch in different ways and combining is incoherent.

\`--dirty\` captures \`git diff HEAD\` **before** worktree creation (so a capture failure aborts before any state changes), then applies it in the new worktree via temp file + \`git apply\` **after** \`setupCreatedWorktree\`. Untracked files are intentionally excluded (per the issue). Apply failures are warnings, not hard errors — the worktree is intact and the source is unmodified.

## Behavior matrix

| Scenario | Behavior |
|---|---|
| \`--from-branch\` with branch checked out elsewhere | Git refuses → grove surfaces error → exit non-zero |
| \`--from-branch\` with branch that exists only on origin | Grove fetches \`origin/<branch>:<branch>\` best-effort, then checks out |
| \`--dirty\` with no uncommitted changes | Info message, worktree still created |
| \`--dirty\` patch fails to apply (conflicts) | Warning to stderr, worktree intact, no abort |
| \`--dirty\` without \`--from-branch\` | Validation error before any state changes |

## Test plan
- [x] \`TestNewCmd_FromBranchFlag\` — flag exists with correct usage text
- [x] \`TestNewCmd_DirtyFlag\` — flag exists, defaults false, usage references --from-branch
- [x] \`TestNewCmd_FromBranchMutuallyExclusive\` — annotation check vs all three peers
- [x] \`TestApplyDirtyPatch_RoundTrip\` — real temp git repo: commit baseline → modify → capture → apply in fresh worktree → assert file matches
- [x] \`make lint\` (0 issues)
- [x] \`make test\` (all packages pass)

## Docs
- CHANGELOG \`[Unreleased]\` → Added
- \`docs/COMMAND_SPECIFICATIONS.md\` — flags table, behavior steps, edge cases
- Inline help text + Examples in \`grove new --help\`