### PR TITLE
chore(release): cut v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-11
+
+> **Upgrading:** No breaking changes. New surface added for adopting existing branches into worktrees, auditing per-worktree provisioning, and detecting Docker bind-mount drift. One latent bug fix for projects using `env_file` set to anything other than `.env`.
+
 ### Added
 - `grove new --from-branch <branch>` — adopts an existing local or remote branch into a new worktree without creating a new branch (calls `git worktree add <path> <branch>`). Mutually exclusive with `--from`, `--branch`, and `--mirror`. Git's "branch already checked out" guardrail still fires when the branch is in use elsewhere (closes #95).
 - `grove new --dirty` — when paired with `--from-branch`, transfers `git diff HEAD` (working tree + staged tracked changes) from the current worktree into the new one via `git apply`. Untracked files are intentionally excluded. Transferred changes land as unstaged in the destination; re-stage manually if needed. A patch that fails to apply (conflict, etc.) emits a warning rather than aborting — the new worktree is intact and the source is unmodified.


### PR DESCRIPTION
Promotes the four feature/bug PRs landed today into a tagged release.

Renames \`## [Unreleased]\` → \`## [0.7.1] - 2026-05-11\` and re-introduces an empty \`[Unreleased]\` above for the next cycle.

## What ships in v0.7.1

### Features
- \`grove new --from-branch <branch>\` + \`--dirty\` for adopting existing branches (#95, #100)
- \`grove doctor <worktree>\` / \`--all\` per-worktree audit with type-aware \`--fix\` (#96, #101)
- \`grove here --check-mount\` for bind-mount drift detection + new \`mount_dest\` config (#97, #102)

### Fixes
- \`env_file\` no longer shadows \`.env\` in compose interpolation (#98, #99)

## Post-merge

1. Tag \`v0.7.1\` on \`main\`, push — release workflow handles GoReleaser + Homebrew formula update
2. Open a small follow-up PR if \`internal/version/version.go\` needs to flip from \`0.8.0-dev\` to \`0.8.0-dev\` (no change — bump already landed in #94 post-v0.7.0; \`0.7.1\` is a patch on \`0.7\`, not a new minor cycle)

## Test plan
- [x] \`make lint\` (0 issues)
- [x] \`make test\` (all packages pass on main HEAD)