### PR TITLE
Fix issues #104–#107: naming pattern, --peek/--no-tmux, drop compose v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ machine-parseable.
 
 - Export the env block below before any grove invocation
 - Always use `--json` for status queries; never scrape human-readable output
-- Worktrees are named `{project}-{name}` (e.g., `myapp-pr-42`) — this is enforced
+- Worktree directories default to `{project}-{name}` (e.g., `myapp-pr-42`); projects can override via `[naming] pattern` — check `.grove/config.toml`
 - `grove ls` and `grove here` show **short** names; tmux sessions use **full** names
 - Read the **Trust model** section before `grove new`/`grove fetch` in an unfamiliar repo
 - `skills/grove-worktree-management/` has deterministic Python helpers for common tasks
@@ -145,10 +145,12 @@ for the full multi-agent workflow.
 
 ## Worktree Naming
 
-Grove enforces `{project}-{name}` — e.g., `myapp-auth`, `myapp-pr-42`. The project
-name is derived from the git remote URL, then the parent directory name, then an explicit
-config setting. `grove ls` shows the **short** name (`auth`); tmux session names use
-the **full** name (`myapp-auth`).
+Worktree directories follow the project's `[naming] pattern` (in `.grove/config.toml`),
+default `{project}-{name}` — e.g., `myapp-auth`, `myapp-pr-42`. The pattern must contain
+`{project}` and `{name}` exactly once each. The project name comes from project config,
+then the git remote URL, then the directory name. `grove ls` shows the **short** name
+(`auth`); tmux session names always use the canonical `{project}-{name}` form
+(`myapp-auth`) regardless of the directory pattern.
 
 ## Drift + Adopt
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,10 @@ export GROVE_TUI=0               # disable dashboard; bare `grove` prints usage
 ```
 
 > `GROVE_AGENT_MODE=1` suppresses tmux attachment in `grove to` but **not** session
-> creation in `grove new`. To fully disable tmux, set `[tmux] mode = "off"` in
-> `.grove/config.toml`.
+> creation in `grove new` — and it also forces the isolated Docker strategy. For
+> per-invocation tmux suppression without the Docker coupling, pass `--no-tmux` to
+> `grove to` / `grove new` (on `new` it also skips session creation). To fully
+> disable tmux, set `[tmux] mode = "off"` in `.grove/config.toml`.
 
 ---
 
@@ -40,7 +42,7 @@ export GROVE_TUI=0               # disable dashboard; bare `grove` prints usage
 | Command | Purpose | `--json` | Mutates |
 |---------|---------|:--------:|:-------:|
 | `grove new [name]` | Create worktree + branch + Docker + tmux (aliases: `spawn`, `n`) | — | ✓ |
-| `grove to [name]` | Switch context atomically; `--peek` skips hooks/tmux (aliases: `switch`, `t`) | — | ✓ |
+| `grove to [name]` | Switch context atomically; `--peek` skips hooks/tmux, `--no-tmux` skips tmux only (aliases: `switch`, `t`) | — | ✓ |
 | `grove fetch <pr\|issue>/<n>` | Create worktree from GitHub PR/issue; needs `gh` (aliases: `f`) | — | ✓ |
 | `grove ls` | List all worktrees in this project (aliases: `list`, `l`) | ✓ | — |
 | `grove here` | Current worktree status (aliases: `h`) | ✓ | — |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `grove to --no-tmux` and `grove new --no-tmux` — per-invocation tmux suppression (no session creation, switch, or attach) without the isolated-Docker coupling of `GROVE_AGENT_MODE`. Hooks and Docker still run (closes #106).
+
+### Fixed
+- `grove to --peek` no longer relocates the caller's tmux client. Peek now skips tmux entirely (session creation, `switch-client`, and attach) in addition to hooks, matching its documented "observational" intent (closes #105).
+
 ## [0.7.1] - 2026-05-11
 
 > **Upgrading:** No breaking changes. New surface added for adopting existing branches into worktrees, auditing per-worktree provisioning, and detecting Docker bind-mount drift. One latent bug fix for projects using `env_file` set to anything other than `.env`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- Standalone `docker-compose` (Compose v1) support. The docker plugin now requires the `docker` CLI with Compose v2. The v1 fallback only accepted a single `--env-file`, silently bypassing the `.env` layering fix from #98 (v1 has been EOL since mid-2023) (closes #107).
+
 ### Added
 - `grove to --no-tmux` and `grove new --no-tmux` — per-invocation tmux suppression (no session creation, switch, or attach) without the isolated-Docker coupling of `GROVE_AGENT_MODE`. Hooks and Docker still run (closes #106).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `grove to --no-tmux` and `grove new --no-tmux` — per-invocation tmux suppression (no session creation, switch, or attach) without the isolated-Docker coupling of `GROVE_AGENT_MODE`. Hooks and Docker still run (closes #106).
-- `[naming] pattern` now actually controls worktree directory names. Placeholders `{project}` and `{name}` (each required exactly once, literals limited to `[A-Za-z0-9._-]`), default `{project}-{name}`. Read from the project's `.grove/config.toml`; short-name display, lookup, rename, and adopt all honor the pattern. Invalid patterns warn on stderr and fall back to the default. Tmux session names intentionally keep the canonical `{project}-{name}` form. Previously the key was parsed and displayed but never applied (closes #104).
+- `[naming] pattern` now actually controls worktree directory names. Placeholders `{project}` and `{name}` (each required exactly once, literals limited to `[A-Za-z0-9._-]`), default `{project}-{name}`. Loaded via standard config layering (global → project → `config.local.toml`); short-name display, lookup, rename, adopt, and TUI create previews all honor the pattern. Invalid patterns warn on stderr and fall back to the default. Tmux session names intentionally keep the canonical `{project}-{name}` form. Previously the key was parsed and displayed but never applied (closes #104).
 
 ### Fixed
 - `grove to --peek` no longer relocates the caller's tmux client. Peek now skips tmux entirely (session creation, `switch-client`, and attach) in addition to hooks, matching its documented "observational" intent (closes #105).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `grove to --no-tmux` and `grove new --no-tmux` — per-invocation tmux suppression (no session creation, switch, or attach) without the isolated-Docker coupling of `GROVE_AGENT_MODE`. Hooks and Docker still run (closes #106).
+- `[naming] pattern` now actually controls worktree directory names. Placeholders `{project}` and `{name}` (each required exactly once, literals limited to `[A-Za-z0-9._-]`), default `{project}-{name}`. Read from the project's `.grove/config.toml`; short-name display, lookup, rename, and adopt all honor the pattern. Invalid patterns warn on stderr and fall back to the default. Tmux session names intentionally keep the canonical `{project}-{name}` form. Previously the key was parsed and displayed but never applied (closes #104).
 
 ### Fixed
 - `grove to --peek` no longer relocates the caller's tmux client. Peek now skips tmux entirely (session creation, `switch-client`, and attach) in addition to hooks, matching its documented "observational" intent (closes #105).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ If you're an agent helping a user *use* grove (install, configure, run commands)
 ## Critical Rules
 
 ### Worktree Naming
-Worktrees MUST follow `{project}-{name}`: `grove-testing` not `testing`.
-Project name derived from: git remote > directory name > config.
+Worktree directories follow the project's `[naming] pattern` (default `{project}-{name}`: `grove-testing` not `testing`). Patterns must contain `{project}` and `{name}` exactly once each; literals limited to `[A-Za-z0-9._-]`.
+Tmux session names ALWAYS use canonical `{project}-{name}`, regardless of the directory pattern.
+Project name derived from: config > git remote > directory name.
 
 ### Shell Integration Protocol
 Commands that change directories output `cd:/path/to/dir` — shell wrapper intercepts when `GROVE_SHELL=1`.

--- a/cmd/grove/commands/adopt.go
+++ b/cmd/grove/commands/adopt.go
@@ -69,13 +69,9 @@ Examples:
 			return fmt.Errorf("worktree manager: %w", err)
 		}
 
-		projectName := mgr.GetProjectName()
-		name := filepath.Base(target)
-		// Strip the project prefix so the state key matches grove's convention
+		// Strip the naming pattern so the state key matches grove's convention
 		// (state stores short names, not full directory names).
-		if prefix := projectName + "-"; strings.HasPrefix(name, prefix) {
-			name = strings.TrimPrefix(name, prefix)
-		}
+		name := mgr.ShortName(filepath.Base(target))
 
 		if existing, err := ctx.State.GetWorktree(name); err == nil && existing != nil {
 			existingResolved, _ := filepath.EvalSymlinks(existing.Path)
@@ -95,7 +91,7 @@ Examples:
 			Branch:       branch,
 			WorktreePath: target,
 			MainPath:     ctx.ProjectRoot,
-			ProjectName:  projectName,
+			ProjectName:  mgr.GetProjectName(),
 		}
 		if err := worktree.BootstrapWorktree(ctx.State, ctx.Config, bootstrapOpts, w); err != nil {
 			return fmt.Errorf("bootstrap: %w", err)

--- a/cmd/grove/commands/agent_help.go
+++ b/cmd/grove/commands/agent_help.go
@@ -53,7 +53,8 @@ func writeAgentHelp(cmd *cobra.Command) {
   grove ls                  List worktrees (table)
   grove ls --json           List worktrees (JSON, machine-readable)
   grove to <name>           Switch to worktree
-  grove to <name> --peek    Switch without hooks (lightweight)
+  grove to <name> --peek    Switch without hooks or tmux (lightweight)
+  grove to <name> --no-tmux Switch with hooks but without tmux
   grove fetch pr/<N>        Create worktree from GitHub PR
   grove fetch issue/<N>     Create worktree from GitHub issue
   grove rm <name>           Remove worktree

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -26,6 +26,7 @@ var (
 	newFromBranch string // Check out an existing branch in the new worktree
 	newDirty      bool   // Carry over `git diff HEAD` from the current worktree
 	newNoSwitch   bool   // Skip auto-switching to the new worktree
+	newNoTmux     bool   // Skip tmux session creation/switch
 )
 
 var newCmd = &cobra.Command{
@@ -41,6 +42,9 @@ Use --from to specify the base ref for the new branch (default: HEAD).
 
 When Docker agent stacks are configured, containers start automatically.
 Use --no-docker to skip Docker auto-start.
+
+Use --no-tmux to skip tmux entirely for this invocation: no session is
+created and your tmux client is not switched. Docker and hooks still run.
 
 Use --mirror to create an environment worktree that tracks a remote branch.
 Environment worktrees are read-only and can be synced with 'grove sync'.
@@ -225,8 +229,9 @@ Examples:
 
 		projectName := mgr.GetProjectName()
 
-		// Create tmux session if tmux is available
-		if tmux.IsTmuxAvailable() {
+		// Create tmux session if tmux is available (skip with --no-tmux; agent
+		// mode intentionally still creates the detached session — see AGENTS.md)
+		if !newNoTmux && tmux.IsTmuxAvailable() {
 			sessionName := worktree.TmuxSessionName(projectName, name)
 			if err := tmux.CreateSession(sessionName, wt.Path); err != nil {
 				if !newJSON {
@@ -284,8 +289,8 @@ Examples:
 					}
 				}
 
-				// Switch tmux session if inside tmux (skip in agent mode)
-				if !ctx.Config.AgentMode && tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
+				// Switch tmux session if inside tmux (skip in agent mode or --no-tmux)
+				if !ctx.Config.AgentMode && !newNoTmux && tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
 					sessionName := worktree.TmuxSessionName(projectName, name)
 					if err := tmux.SwitchSession(sessionName); err != nil {
 						cli.Warning(w, "Failed to switch session: %v", err)
@@ -356,6 +361,7 @@ func init() {
 	newCmd.Flags().BoolVar(&newDirty, "dirty", false, "Carry over `git diff HEAD` from the current worktree (requires --from-branch)")
 	newCmd.Flags().StringVar(&newMirror, "mirror", "", "Create environment worktree tracking a remote branch (e.g., origin/main)")
 	newCmd.Flags().BoolVar(&newNoDocker, "no-docker", false, "Skip Docker auto-start")
+	newCmd.Flags().BoolVar(&newNoTmux, "no-tmux", false, "Skip tmux session creation/switch for this invocation")
 	newCmd.Flags().BoolVarP(&newNoSwitch, "no-switch", "n", false, "Stay in current worktree after creation")
 	newCmd.MarkFlagsMutuallyExclusive("mirror", "from")
 	newCmd.MarkFlagsMutuallyExclusive("mirror", "branch")

--- a/cmd/grove/commands/rm.go
+++ b/cmd/grove/commands/rm.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -196,7 +197,7 @@ Examples:
 				Project:      projectName,
 				MainPath:     ctx.ProjectRoot,
 				NewPath:      wt.Path,
-				WorktreeFull: projectName + "-" + name,
+				WorktreeFull: filepath.Base(wt.Path),
 			}
 			cli.Step(w, "Running pre-remove hooks...")
 			if err := hookExecutor.Execute(hooks.EventPreRemove, hookCtx); err != nil {

--- a/cmd/grove/commands/to.go
+++ b/cmd/grove/commands/to.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	toJSON bool
-	toPeek bool
+	toJSON   bool
+	toPeek   bool
+	toNoTmux bool
 )
 
 var toCmd = &cobra.Command{
@@ -27,8 +28,13 @@ var toCmd = &cobra.Command{
 	Long: `Switch to a worktree by name. If a tmux session exists for the worktree, switch to it.
 If no tmux session exists, create one.
 
-Use --peek for a lightweight switch that skips hooks (no Docker side effects).
-Useful for code review or quick file checks.
+Use --peek for a lightweight switch that skips hooks and tmux entirely
+(no Docker side effects, no tmux client relocation). Useful for code review
+or quick file checks.
+
+Use --no-tmux to switch without creating, switching, or attaching tmux
+sessions — hooks still fire. Useful for automation running inside an
+existing tmux session.
 
 When using shell integration, this will also change your current directory.`,
 	Args:              cobra.MaximumNArgs(1),
@@ -165,10 +171,7 @@ When using shell integration, this will also change your current directory.`,
 			tmuxMode = tmuxModeAuto
 		}
 		useCC := tmux.ShouldUseControlMode(cfg.Tmux.ControlMode)
-		// Agent mode: suppress tmux to prevent terminal takeover
-		if cfg.AgentMode {
-			tmuxMode = tmuxModeOff
-		}
+		tmuxMode = effectiveTmuxMode(tmuxMode, cfg.AgentMode, toNoTmux, toPeek)
 
 		// Handle tmux session (unless mode is "off")
 		var sessionName string
@@ -280,6 +283,17 @@ When using shell integration, this will also change your current directory.`,
 	}),
 }
 
+// effectiveTmuxMode returns the tmux mode after per-invocation overrides.
+// Agent mode suppresses tmux to prevent terminal takeover; --no-tmux does the
+// same for a single invocation without implying agent Docker isolation; --peek
+// is observational and must never relocate the caller's tmux client (#105).
+func effectiveTmuxMode(mode string, agentMode, noTmux, peek bool) string {
+	if agentMode || noTmux || peek {
+		return tmuxModeOff
+	}
+	return mode
+}
+
 // handleDirectoryDrift detects if a tmux session's active pane has drifted
 // from the worktree root and corrects it based on the configured on_switch mode.
 func handleDirectoryDrift(sessionName, worktreePath, onSwitch string, stderr *cli.Writer) {
@@ -313,6 +327,7 @@ func handleDirectoryDrift(sessionName, worktreePath, onSwitch string, stderr *cl
 
 func init() {
 	toCmd.Flags().BoolVarP(&toJSON, "json", "j", false, "Output as JSON with switch_to field")
-	toCmd.Flags().BoolVar(&toPeek, "peek", false, "Lightweight switch: skip hooks (no Docker side effects)")
+	toCmd.Flags().BoolVar(&toPeek, "peek", false, "Lightweight switch: skip hooks and tmux (no Docker or session side effects)")
+	toCmd.Flags().BoolVar(&toNoTmux, "no-tmux", false, "Skip tmux session creation/switch/attach for this invocation")
 	rootCmd.AddCommand(toCmd)
 }

--- a/cmd/grove/commands/to_test.go
+++ b/cmd/grove/commands/to_test.go
@@ -1,0 +1,33 @@
+package commands
+
+import "testing"
+
+func TestEffectiveTmuxMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      string
+		agentMode bool
+		noTmux    bool
+		peek      bool
+		want      string
+	}{
+		{name: "auto mode unchanged", mode: tmuxModeAuto, want: tmuxModeAuto},
+		{name: "manual mode unchanged", mode: "manual", want: "manual"},
+		{name: "off mode unchanged", mode: tmuxModeOff, want: tmuxModeOff},
+		{name: "agent mode forces off", mode: tmuxModeAuto, agentMode: true, want: tmuxModeOff},
+		{name: "no-tmux forces off", mode: tmuxModeAuto, noTmux: true, want: tmuxModeOff},
+		{name: "peek forces off", mode: tmuxModeAuto, peek: true, want: tmuxModeOff},
+		{name: "peek forces off in manual mode", mode: "manual", peek: true, want: tmuxModeOff},
+		{name: "all overrides together", mode: tmuxModeAuto, agentMode: true, noTmux: true, peek: true, want: tmuxModeOff},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveTmuxMode(tt.mode, tt.agentMode, tt.noTmux, tt.peek)
+			if got != tt.want {
+				t.Errorf("effectiveTmuxMode(%q, %v, %v, %v) = %q, want %q",
+					tt.mode, tt.agentMode, tt.noTmux, tt.peek, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -99,8 +99,9 @@ naming pattern. The default (and recommended) pattern is:
 {project}-{name}
 ```
 
-The pattern is configurable via `[naming] pattern` in the project's
-`.grove/config.toml`. It must contain `{project}` and `{name}` exactly once
+The pattern is configurable via `[naming] pattern` (standard config layering;
+set it in the project's `.grove/config.toml` for shared repos). It must
+contain `{project}` and `{name}` exactly once
 each, and literal characters are limited to `[A-Za-z0-9._-]` — this keeps
 directory names safe for git, tmux, GitHub, and shell use, keeps the project
 identifiable in every directory name, and keeps the short name recoverable.

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -480,8 +480,9 @@ Arguments:
   name    Name of worktree to switch to (required)
 
 Flags:
-  -j, --json   Output as JSON with switch_to field
-      --peek   Lightweight switch: skip hooks (no Docker side effects)
+  -j, --json      Output as JSON with switch_to field
+      --peek      Lightweight switch: skip hooks and tmux (no Docker or session side effects)
+      --no-tmux   Skip tmux session creation/switch/attach for this invocation
 ```
 
 **Behavior:**
@@ -500,7 +501,7 @@ Flags:
    - If the dirty check itself fails (e.g., git error), treat the worktree as clean and proceed — never block the user on a failed status check
    - `--peek` always bypasses dirty checks (peek is a lightweight switch with no side effects)
 
-3. **Handle tmux session:**
+3. **Handle tmux session** (skipped entirely with `--peek`, `--no-tmux`, or `GROVE_AGENT_MODE`):
    - If session exists and inside tmux: `tmux switch-client -t {session}`
    - If session exists and outside tmux: `tmux attach -t {session}` (or `tmux -CC attach` in iTerm2 when `control_mode` is enabled)
    - If session doesn't exist: Create it, then attach/switch
@@ -511,7 +512,7 @@ Flags:
      - `"prompt"`: Ask user before starting/stopping containers. Falls back to `auto` in non-interactive sessions.
      - `"off"`: Skip container start/stop entirely. In external mode, env var persistence and env directives still run — only `stopServices()` and `startServices()` are skipped.
 
-5. **Switch tmux session** (if inside tmux): `tmux switch-client -t {session}`
+5. **Switch tmux session** (if inside tmux, and neither `--peek` nor `--no-tmux` nor `GROVE_AGENT_MODE` is set): `tmux switch-client -t {session}`
 
 6. **Fire post-switch hooks** (Docker start, etc.) before tmux switch so progress is visible in current session (unless `--peek`). Container lifecycle gating from step 4 applies here too.
 
@@ -620,6 +621,7 @@ Please be more specific.
 | Dirty worktree, prompt mode (TTY) | Show dirty files, ask user to confirm, abort or proceed |
 | Dirty worktree, prompt mode (non-TTY) | Fall back to refuse behavior (exit 1) |
 | Dirty worktree with `--peek` | Bypass dirty check entirely, proceed with switch |
+| `--peek` or `--no-tmux` | No tmux session is created, switched, or attached; cd directive still emitted |
 | Dirty check fails (git error) | Treat as clean, proceed with switch |
 | container_switch = "off" | Skip Docker start/stop; env var persistence still runs in external mode |
 | container_switch = "prompt" (TTY) | Ask before start/stop; user can decline |

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -92,18 +92,35 @@ Priority 3: Root directory name
 
 ### Worktree Naming Convention
 
-**CRITICAL:** All worktrees created by grove follow this pattern:
+**CRITICAL:** All worktree directories created by grove follow the project's
+naming pattern. The default (and recommended) pattern is:
 
 ```
-{project}-{worktree-name}
+{project}-{name}
 ```
 
-**Examples:**
+The pattern is configurable via `[naming] pattern` in the project's
+`.grove/config.toml`. It must contain `{project}` and `{name}` exactly once
+each, and literal characters are limited to `[A-Za-z0-9._-]` — this keeps
+directory names safe for git, tmux, GitHub, and shell use, keeps the project
+identifiable in every directory name, and keeps the short name recoverable.
+Invalid patterns are ignored with a stderr warning and the default is used.
+
+**Tmux sessions always use the canonical `{project}-{name}` form**, regardless
+of the directory pattern — session names are grove-internal keys and stay
+stable across pattern changes.
+
+**Examples (default pattern):**
 | Project | User Input | Worktree Directory | Tmux Session |
 |---------|------------|-------------------|--------------|
 | grove | testing | grove-testing | grove-testing |
 | grove | feature-auth | grove-feature-auth | grove-feature-auth |
 | my-app | hotfix-123 | my-app-hotfix-123 | my-app-hotfix-123 |
+
+**Example (custom pattern `{name}.{project}`):**
+| Project | User Input | Worktree Directory | Tmux Session |
+|---------|------------|-------------------|--------------|
+| grove | testing | testing.grove | grove-testing |
 
 **Rationale:** 
 - Prevents naming collisions across projects
@@ -153,8 +170,7 @@ my-app-main: 1 windows
 When creating a worktree, grove creates a branch if needed:
 
 ```
-Default pattern: {worktree-name}
-Configurable: {type}/{description}
+Default: branch name = worktree name (override with --branch)
 
 Examples:
   w new testing          →  branch: testing
@@ -1929,8 +1945,7 @@ Switch:
   dirty_handling:   prompt
 
 Naming:
-  pattern:          {type}/{description}
-  max_length:       50
+  pattern:          {project}-{name}
 
 Tmux:
   prefix:           (none, uses naming pattern)

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -100,15 +100,26 @@ container_switch = "auto"          # string: auto | prompt | off
 
 ### [naming]
 
-Controls how new worktree names are suggested when branching.
+Controls how worktree **directories** are named.
 
 ```toml
 [naming]
-# Pattern template for suggested worktree names.
-# Tokens: {type} (branch type, e.g. "feat"), {description} (branch slug)
-# Default: "{type}/{description}"
-pattern = "{type}/{description}"   # string
+# Template for worktree directory names.
+# Placeholders: {project} (project name), {name} (short worktree name).
+# Rules: each placeholder exactly once; literal characters limited to
+# [A-Za-z0-9._-]. Invalid patterns warn on stderr and fall back to default.
+# Default: "{project}-{name}"
+pattern = "{project}-{name}"       # string
 ```
+
+**Read from the project's `.grove/config.toml` only** — worktree naming is a
+repo-level convention that every grove invocation must agree on, so global
+(`~/.config/grove/config.toml`) values are not applied here.
+
+Tmux session names always use the canonical `{project}-{name}` form regardless
+of this pattern; they are internal keys and stay stable across pattern changes.
+Worktrees created under a previous pattern keep working: directory names that
+don't match the current pattern are displayed as-is (full directory name).
 
 ---
 

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -758,8 +758,8 @@ on_failure  = "ignore"
 2. **Wrong file location** — hooks must be in `.grove/hooks.toml` (project) or
    `~/.config/grove/hooks.toml` (global). A file named `hooks.toml` in the repo root is ignored.
 
-3. **Using `--peek`** — `grove to <name> --peek` skips all hooks by design. Remove `--peek` for
-   a full switch with hooks.
+3. **Using `--peek`** — `grove to <name> --peek` skips all hooks (and tmux) by design. Remove
+   `--peek` for a full switch with hooks.
 
 4. **Branch matches a skip pattern** — check `[[overrides]]` entries in your hooks file.
    An override with `skip_hooks = true` silences all hooks for matching branches:
@@ -792,7 +792,7 @@ These are read at runtime and never written to config files.
 | `GROVE_SHELL` | `1` | Set by shell integration. Enables the directive protocol (cd:, env:, tmux-attach:, tmux-attach-cc:). |
 | `GROVE_SHELL_VERSION` | integer | Set by shell integration. Binary warns if shell is outdated. |
 | `GROVE_TUI` | `0` to disable | Set to `0` to disable TUI mode. Bare `grove` shows help instead. Default: enabled. |
-| `GROVE_AGENT_MODE` | any non-empty | Forces isolated Docker strategy and suppresses tmux for AI agent workloads. |
+| `GROVE_AGENT_MODE` | any non-empty | Forces isolated Docker strategy and suppresses tmux for AI agent workloads. To suppress tmux alone for one invocation, use `--no-tmux` on `grove to` / `grove new` instead. |
 | `GROVE_LOG` | `1` or path | Enable command-level logging. `1` writes to `~/.grove/grove.log`. |
 | `GROVE_DEBUG` | `1` or path | Enable TUI debug logging. `1` writes to `~/.grove-debug.log`. |
 | `GROVE_NO_COLOR` | any non-empty | Disable all colored output. Also respected: `NO_COLOR`. |

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -112,9 +112,10 @@ Controls how worktree **directories** are named.
 pattern = "{project}-{name}"       # string
 ```
 
-**Read from the project's `.grove/config.toml` only** — worktree naming is a
-repo-level convention that every grove invocation must agree on, so global
-(`~/.config/grove/config.toml`) values are not applied here.
+Follows standard config layering (global → project → `config.local.toml`), the
+same value `grove config` displays. Set it in the project's `.grove/config.toml`
+in shared repos — worktree naming is a repo-level convention, and a personal
+override changes how existing directory names are parsed for display.
 
 Tmux session names always use the canonical `{project}-{name}` form regardless
 of this pattern; they are internal keys and stay stable across pattern changes.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,9 +79,9 @@ type SwitchConfig struct {
 type NamingConfig struct {
 	// Pattern is the worktree directory naming template. Placeholders
 	// {project} and {name} must each appear exactly once; literal characters
-	// are limited to [A-Za-z0-9._-]. Grove reads the effective value from the
-	// project-level .grove/config.toml (see worktree.Manager); tmux session
-	// names always use the canonical {project}-{name} form regardless.
+	// are limited to [A-Za-z0-9._-] (validated in worktree.ValidateNamePattern;
+	// invalid values fall back to the default). Tmux session names always use
+	// the canonical {project}-{name} form regardless.
 	Pattern string `toml:"pattern"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,7 +77,12 @@ type SwitchConfig struct {
 
 // NamingConfig controls worktree naming conventions
 type NamingConfig struct {
-	Pattern string `toml:"pattern"` // Pattern for naming worktrees
+	// Pattern is the worktree directory naming template. Placeholders
+	// {project} and {name} must each appear exactly once; literal characters
+	// are limited to [A-Za-z0-9._-]. Grove reads the effective value from the
+	// project-level .grove/config.toml (see worktree.Manager); tmux session
+	// names always use the canonical {project}-{name} form regardless.
+	Pattern string `toml:"pattern"`
 }
 
 // TmuxConfig controls tmux session behavior

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -25,7 +25,7 @@ func LoadDefaults() *Config {
 			ContainerSwitch: "auto",
 		},
 		Naming: NamingConfig{
-			Pattern: "{type}/{description}",
+			Pattern: "{project}-{name}",
 		},
 		Tmux: TmuxConfig{
 			Mode:        "auto",

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -100,7 +101,7 @@ func runPreRemoveHooks(projectName, name string, wt *worktree.Worktree) {
 	if wt != nil {
 		hookCtx.Branch = wt.Branch
 		hookCtx.NewPath = wt.Path
-		hookCtx.WorktreeFull = projectName + "-" + name
+		hookCtx.WorktreeFull = filepath.Base(wt.Path)
 	}
 	if err := hookExecutor.Execute(hooks.EventPreRemove, hookCtx); err != nil {
 		tuilog.Printf("warning: pre-remove hook failed for %q: %v", name, err)
@@ -166,7 +167,7 @@ func runPostCreateStreaming(ch chan<- creationEvent, mgr *worktree.Manager, stat
 		hookCtx := &hooks.ExecutionContext{
 			Event:        hooks.EventPostCreate,
 			Worktree:     name,
-			WorktreeFull: projectName + "-" + name,
+			WorktreeFull: filepath.Base(wt.Path),
 			Branch:       wt.Branch,
 			Project:      projectName,
 			MainPath:     projectRoot,

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -273,13 +273,14 @@ func (m Model) findWorktreeByName(name string) *WorktreeItem {
 
 // prefillCreateStateForPR creates a CreateState pre-filled from a PR,
 // skipping directly to the name step.
-func prefillCreateStateForPR(pr *tracker.PullRequest, projectName string, branches []string) *CreateState {
+func prefillCreateStateForPR(pr *tracker.PullRequest, projectName, namePattern string, branches []string) *CreateState {
 	suggestion := worktree.DeriveWorktreeName(pr.Branch, "")
 	ni := newNameInput("")
 	return &CreateState{
 		Step:              CreateStepName,
 		Source:            "pr",
 		ProjectName:       projectName,
+		NamePattern:       namePattern,
 		BaseBranch:        pr.Branch,
 		NameSuggestion:    suggestion,
 		NameInput:         ni,
@@ -292,12 +293,13 @@ func prefillCreateStateForPR(pr *tracker.PullRequest, projectName string, branch
 // prefillCreateStateForIssue creates a CreateState pre-filled from an issue,
 // starting at the branch choice step so the user can pick a base branch.
 // The issue-derived name is carried as NameSuggestion for the Name step.
-func prefillCreateStateForIssue(issue *tracker.Issue, projectName string, branches []string) *CreateState {
+func prefillCreateStateForIssue(issue *tracker.Issue, projectName, namePattern string, branches []string) *CreateState {
 	name := fmt.Sprintf("issue-%d", issue.Number)
 	return &CreateState{
 		Step:              CreateStepBranchChoice,
 		Source:            "issue",
 		ProjectName:       projectName,
+		NamePattern:       namePattern,
 		NameSuggestion:    name,
 		Branches:          branches,
 		BranchFilterInput: newBranchFilterInput(),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1070,12 +1070,23 @@ func (m Model) handleDashboardNewKey() (tea.Model, tea.Cmd) {
 		Step:              CreateStepBranchChoice,
 		ReturnView:        ViewDashboard,
 		ProjectName:       m.projectName,
+		NamePattern:       m.worktreeNamePattern(),
 		Branches:          branches,
 		BranchFilterInput: newBranchFilterInput(),
 		BranchNameInput:   newBranchNameInput(),
 		WorktreeBranches:  m.worktreeBranchMap(),
 	}
 	return m, nil
+}
+
+// worktreeNamePattern returns the configured worktree naming pattern for
+// directory-name previews. Empty when config is unavailable — interpolation
+// falls back to the default pattern.
+func (m Model) worktreeNamePattern() string {
+	if m.cfg == nil {
+		return ""
+	}
+	return m.cfg.Naming.Pattern
 }
 
 func (m Model) handleDashboardDeleteKey() (tea.Model, tea.Cmd) {

--- a/internal/tui/overlay_config.go
+++ b/internal/tui/overlay_config.go
@@ -193,7 +193,7 @@ func populateConfigFields(cfg *config.Config) [][]ConfigField {
 			Value:       cfg.Naming.Pattern,
 			Default:     cfg.Naming.Pattern,
 			Type:        ConfigString,
-			Description: "Pattern for naming worktrees",
+			Description: "Worktree directory template; {project} and {name} each exactly once",
 		},
 		{
 			Key:         "tui.skip_branch_notice",

--- a/internal/tui/overlay_create.go
+++ b/internal/tui/overlay_create.go
@@ -32,6 +32,7 @@ type CreateState struct {
 	Name           string
 	NameSuggestion string // derived from branch, shown as placeholder
 	ProjectName    string
+	NamePattern    string // worktree naming pattern for directory-name previews
 	BaseBranch     string // set when using existing branch (split)
 	NewBranchName  string // set when creating new branch via selector
 	Error          string

--- a/internal/tui/overlay_create_v2.go
+++ b/internal/tui/overlay_create_v2.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/lost-in-the/grove/internal/worktree"
 )
 
 // renderCreateV2 is the V2 dispatcher for the create wizard overlay.
@@ -255,7 +257,8 @@ func renderCreateNameV2(s *CreateState, width int) string {
 		effectiveName = s.NameSuggestion
 	}
 	if s.ProjectName != "" && effectiveName != "" {
-		b.WriteString(d.indent + Styles.DetailDim.Render(fmt.Sprintf("→ %s-%s", s.ProjectName, effectiveName)) + "\n")
+		full := worktree.InterpolateNamePattern(s.NamePattern, s.ProjectName, effectiveName)
+		b.WriteString(d.indent + Styles.DetailDim.Render("→ "+full) + "\n")
 	}
 
 	if s.Error != "" {
@@ -337,7 +340,7 @@ func renderContextSummary(s *CreateState, width int) string {
 	if s.Name != "" {
 		lines = append(lines, fmt.Sprintf("Name:     %s", s.Name))
 		if s.ProjectName != "" {
-			lines = append(lines, fmt.Sprintf("Full:     %s-%s", s.ProjectName, s.Name))
+			lines = append(lines, fmt.Sprintf("Full:     %s", worktree.InterpolateNamePattern(s.NamePattern, s.ProjectName, s.Name)))
 		}
 	}
 

--- a/internal/tui/view_issues.go
+++ b/internal/tui/view_issues.go
@@ -158,7 +158,7 @@ func (m Model) handleIssueKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) openCreateWizardForIssue(issue *tracker.Issue) (tea.Model, tea.Cmd) {
 	branches, _ := git.ListAllBranches(m.projectRoot)
-	m.createState = prefillCreateStateForIssue(issue, m.projectName, branches)
+	m.createState = prefillCreateStateForIssue(issue, m.projectName, m.worktreeNamePattern(), branches)
 	m.createState.ReturnView = ViewIssues
 	m.createState.WorktreeBranches = m.worktreeBranchMap()
 	m.activeView = ViewCreate

--- a/internal/tui/view_prs.go
+++ b/internal/tui/view_prs.go
@@ -175,7 +175,7 @@ func (m Model) handlePREnter(s *PRViewState, filtered []*tracker.PullRequest) (t
 
 func (m Model) openCreateWizardForPR(pr *tracker.PullRequest) (tea.Model, tea.Cmd) {
 	branches, _ := git.ListAllBranches(m.projectRoot)
-	m.createState = prefillCreateStateForPR(pr, m.projectName, branches)
+	m.createState = prefillCreateStateForPR(pr, m.projectName, m.worktreeNamePattern(), branches)
 	m.createState.ReturnView = ViewPRs
 	m.createState.WorktreeBranches = m.worktreeBranchMap()
 	m.createState.ExistingWorktree = checkDuplicateWorktree(

--- a/internal/worktree/naming.go
+++ b/internal/worktree/naming.go
@@ -14,6 +14,7 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/lost-in-the/grove/internal/cmdexec"
+	"github.com/lost-in-the/grove/internal/config"
 )
 
 // TestEnvNumber derives a stable TEST_ENV_NUMBER in range [50, 99] from a worktree name.
@@ -27,9 +28,6 @@ func TestEnvNumber(name string) int {
 // projectConfig represents the project-level configuration
 type projectConfig struct {
 	ProjectName string `toml:"project_name"`
-	Naming      struct {
-		Pattern string `toml:"pattern"`
-	} `toml:"naming"`
 }
 
 // DefaultNamePattern is the worktree directory naming pattern used when
@@ -63,6 +61,23 @@ func ValidateNamePattern(pattern string) error {
 // invalidPatternWarning ensures the invalid-pattern warning prints at most
 // once per process even when several Managers are created.
 var invalidPatternWarning sync.Once
+
+// EffectiveNamePattern returns pattern when it is a valid naming pattern and
+// DefaultNamePattern otherwise (including empty input).
+func EffectiveNamePattern(pattern string) string {
+	if ValidateNamePattern(pattern) == nil {
+		return pattern
+	}
+	return DefaultNamePattern
+}
+
+// InterpolateNamePattern builds a full worktree directory name from a naming
+// pattern. Invalid or empty patterns fall back to DefaultNamePattern, so
+// callers (e.g. UI previews) always produce the name grove would create.
+func InterpolateNamePattern(pattern, project, name string) string {
+	full := strings.ReplaceAll(EffectiveNamePattern(pattern), "{project}", project)
+	return strings.ReplaceAll(full, "{name}", name)
+}
 
 // detectProjectName determines the project name using priority:
 // 1. .grove/config.toml -> project_name (from main worktree)
@@ -158,24 +173,20 @@ func DeriveWorktreeName(branch, strategy string) string {
 	return branch
 }
 
-// getNamePattern returns the worktree naming pattern for the project, read
-// from [naming] pattern in the main worktree's .grove/config.toml (the same
-// project-level file detectProjectName reads). Unset or invalid patterns fall
-// back to DefaultNamePattern; invalid ones additionally warn on stderr so the
-// fallback is visible.
+// getNamePattern returns the worktree naming pattern, loaded through the
+// standard layered config (defaults → global → project → config.local.toml)
+// anchored at the main worktree's .grove directory — the same value `grove
+// config` displays. Invalid patterns fall back to DefaultNamePattern with a
+// stderr warning so the fallback is visible.
 func (m *Manager) getNamePattern() string {
 	if m.namePattern != "" {
 		return m.namePattern
 	}
 	m.namePattern = DefaultNamePattern
 
-	configPath := filepath.Join(m.getMainWorktreePath(), ".grove", "config.toml")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return m.namePattern
-	}
-	var cfg projectConfig
-	if err := toml.Unmarshal(data, &cfg); err != nil || cfg.Naming.Pattern == "" {
+	groveDir := filepath.Join(m.getMainWorktreePath(), ".grove")
+	cfg, err := config.LoadFromGroveDir(groveDir)
+	if err != nil || cfg == nil {
 		return m.namePattern
 	}
 	if err := ValidateNamePattern(cfg.Naming.Pattern); err != nil {
@@ -198,8 +209,7 @@ func (m *Manager) FullName(name string) string {
 		m.projectName = m.detectProjectName()
 	}
 
-	full := strings.ReplaceAll(m.getNamePattern(), "{project}", m.projectName)
-	return strings.ReplaceAll(full, "{name}", name)
+	return InterpolateNamePattern(m.getNamePattern(), m.projectName, name)
 }
 
 // ShortName inverts the naming pattern: given a full worktree directory name,

--- a/internal/worktree/naming.go
+++ b/internal/worktree/naming.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 
@@ -24,7 +27,42 @@ func TestEnvNumber(name string) int {
 // projectConfig represents the project-level configuration
 type projectConfig struct {
 	ProjectName string `toml:"project_name"`
+	Naming      struct {
+		Pattern string `toml:"pattern"`
+	} `toml:"naming"`
 }
+
+// DefaultNamePattern is the worktree directory naming pattern used when
+// [naming] pattern is unset or invalid.
+const DefaultNamePattern = "{project}-{name}"
+
+// namePatternLiterals restricts literal (non-placeholder) characters to ones
+// that are safe in directory names, git branch names, tmux targets, and
+// GitHub URLs.
+var namePatternLiterals = regexp.MustCompile(`^[A-Za-z0-9._-]*$`)
+
+// ValidateNamePattern checks that a worktree naming pattern is usable:
+// exactly one {project} and one {name} placeholder (so full names stay
+// project-identifiable and short names are recoverable), with literal
+// characters limited to [A-Za-z0-9._-].
+func ValidateNamePattern(pattern string) error {
+	if strings.Count(pattern, "{project}") != 1 {
+		return fmt.Errorf("pattern must contain {project} exactly once")
+	}
+	if strings.Count(pattern, "{name}") != 1 {
+		return fmt.Errorf("pattern must contain {name} exactly once")
+	}
+	literals := strings.ReplaceAll(pattern, "{project}", "")
+	literals = strings.ReplaceAll(literals, "{name}", "")
+	if !namePatternLiterals.MatchString(literals) {
+		return fmt.Errorf("literal characters must match [A-Za-z0-9._-] (got %q)", literals)
+	}
+	return nil
+}
+
+// invalidPatternWarning ensures the invalid-pattern warning prints at most
+// once per process even when several Managers are created.
+var invalidPatternWarning sync.Once
 
 // detectProjectName determines the project name using priority:
 // 1. .grove/config.toml -> project_name (from main worktree)
@@ -120,14 +158,76 @@ func DeriveWorktreeName(branch, strategy string) string {
 	return branch
 }
 
-// FullName returns the full worktree name with project prefix.
-// Format: {project}-{name}
-// Example: grove-cli-testing
+// getNamePattern returns the worktree naming pattern for the project, read
+// from [naming] pattern in the main worktree's .grove/config.toml (the same
+// project-level file detectProjectName reads). Unset or invalid patterns fall
+// back to DefaultNamePattern; invalid ones additionally warn on stderr so the
+// fallback is visible.
+func (m *Manager) getNamePattern() string {
+	if m.namePattern != "" {
+		return m.namePattern
+	}
+	m.namePattern = DefaultNamePattern
+
+	configPath := filepath.Join(m.getMainWorktreePath(), ".grove", "config.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return m.namePattern
+	}
+	var cfg projectConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil || cfg.Naming.Pattern == "" {
+		return m.namePattern
+	}
+	if err := ValidateNamePattern(cfg.Naming.Pattern); err != nil {
+		invalidPatternWarning.Do(func() {
+			fmt.Fprintf(os.Stderr, "grove: warning: ignoring invalid [naming] pattern %q: %v (using %q)\n",
+				cfg.Naming.Pattern, err, DefaultNamePattern)
+		})
+		return m.namePattern
+	}
+	m.namePattern = cfg.Naming.Pattern
+	return m.namePattern
+}
+
+// FullName returns the full worktree directory name, built from the project
+// naming pattern (default "{project}-{name}", e.g. grove-cli-testing).
+// Tmux session names intentionally do NOT follow the pattern — they always
+// use the canonical {project}-{name} form (see TmuxSessionName).
 func (m *Manager) FullName(name string) string {
 	if m.projectName == "" {
 		m.projectName = m.detectProjectName()
 	}
 
-	// Return project-name format
-	return m.projectName + "-" + name
+	full := strings.ReplaceAll(m.getNamePattern(), "{project}", m.projectName)
+	return strings.ReplaceAll(full, "{name}", name)
+}
+
+// ShortName inverts the naming pattern: given a full worktree directory name,
+// it extracts the short {name} part. Names that don't match the pattern are
+// returned unchanged (e.g. worktrees created before a pattern change or by
+// raw `git worktree add`).
+func (m *Manager) ShortName(fullName string) string {
+	if m.projectName == "" {
+		m.projectName = m.detectProjectName()
+	}
+	short, _ := shortNameFromFull(fullName, m.projectName, m.getNamePattern())
+	return short
+}
+
+// shortNameFromFull extracts the {name} segment from a full directory name by
+// matching the pattern's literal prefix and suffix around {name}. Returns the
+// input unchanged (and false) when it doesn't match the pattern.
+func shortNameFromFull(fullName, projectName, pattern string) (string, bool) {
+	before, after, found := strings.Cut(pattern, "{name}")
+	if !found {
+		return fullName, false
+	}
+	prefix := strings.ReplaceAll(before, "{project}", projectName)
+	suffix := strings.ReplaceAll(after, "{project}", projectName)
+	if len(fullName) > len(prefix)+len(suffix) &&
+		strings.HasPrefix(fullName, prefix) &&
+		strings.HasSuffix(fullName, suffix) {
+		return fullName[len(prefix) : len(fullName)-len(suffix)], true
+	}
+	return fullName, false
 }

--- a/internal/worktree/naming_test.go
+++ b/internal/worktree/naming_test.go
@@ -269,3 +269,138 @@ func TestDetectProjectNameFromConfig(t *testing.T) {
 		t.Errorf("detectProjectName() with config = %q, want %q", got, want)
 	}
 }
+
+func TestValidateNamePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{name: "default pattern", pattern: "{project}-{name}", wantErr: false},
+		{name: "reversed order", pattern: "{name}-{project}", wantErr: false},
+		{name: "underscore separator", pattern: "{project}_{name}", wantErr: false},
+		{name: "dot separator", pattern: "{name}.{project}", wantErr: false},
+		{name: "no separator", pattern: "{project}{name}", wantErr: false},
+		{name: "literal affixes", pattern: "wt-{project}-{name}", wantErr: false},
+		{name: "missing project", pattern: "{name}", wantErr: true},
+		{name: "missing name", pattern: "{project}", wantErr: true},
+		{name: "empty", pattern: "", wantErr: true},
+		{name: "duplicate name", pattern: "{project}-{name}-{name}", wantErr: true},
+		{name: "duplicate project", pattern: "{project}{project}-{name}", wantErr: true},
+		{name: "path separator", pattern: "{project}/{name}", wantErr: true},
+		{name: "whitespace literal", pattern: "{project} {name}", wantErr: true},
+		{name: "shell metachar", pattern: "{project}${name}", wantErr: true},
+		{name: "legacy branch tokens", pattern: "{type}/{description}", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNamePattern(tt.pattern)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateNamePattern(%q) error = %v, wantErr %v", tt.pattern, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFullNameWithPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		project string
+		short   string
+		want    string
+	}{
+		{name: "default", pattern: "{project}-{name}", project: "grove", short: "testing", want: "grove-testing"},
+		{name: "reversed", pattern: "{name}.{project}", project: "grove", short: "testing", want: "testing.grove"},
+		{name: "underscore", pattern: "{project}_{name}", project: "myapp", short: "pr-42", want: "myapp_pr-42"},
+		{name: "literal prefix", pattern: "wt-{project}-{name}", project: "myapp", short: "auth", want: "wt-myapp-auth"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{repoRoot: "/fake/path", projectName: tt.project, namePattern: tt.pattern}
+			if got := m.FullName(tt.short); got != tt.want {
+				t.Errorf("FullName(%q) = %q, want %q", tt.short, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShortNameFromFull(t *testing.T) {
+	tests := []struct {
+		name    string
+		full    string
+		project string
+		pattern string
+		want    string
+		wantOK  bool
+	}{
+		{name: "default pattern", full: "grove-testing", project: "grove", pattern: "{project}-{name}", want: "testing", wantOK: true},
+		{name: "reversed pattern", full: "testing.grove", project: "grove", pattern: "{name}.{project}", want: "testing", wantOK: true},
+		{name: "hyphenated short name", full: "grove-feature-auth", project: "grove", pattern: "{project}-{name}", want: "feature-auth", wantOK: true},
+		{name: "no match returns input", full: "unrelated-dir", project: "grove", pattern: "{project}-{name}", want: "unrelated-dir", wantOK: false},
+		{name: "prefix only no name", full: "grove-", project: "grove", pattern: "{project}-{name}", want: "grove-", wantOK: false},
+		{name: "literal affix pattern", full: "wt-grove-auth", project: "grove", pattern: "wt-{project}-{name}", want: "auth", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := shortNameFromFull(tt.full, tt.project, tt.pattern)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("shortNameFromFull(%q, %q, %q) = (%q, %v), want (%q, %v)",
+					tt.full, tt.project, tt.pattern, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestGetNamePatternFromConfig(t *testing.T) {
+	setup := func(t *testing.T, configContent string) *Manager {
+		t.Helper()
+		tmpDir := t.TempDir()
+		initCmd := exec.Command("git", "init")
+		initCmd.Dir = tmpDir
+		if err := initCmd.Run(); err != nil {
+			t.Fatalf("Failed to init git repo: %v", err)
+		}
+		if configContent != "" {
+			groveDir := filepath.Join(tmpDir, ".grove")
+			if err := os.MkdirAll(groveDir, 0755); err != nil {
+				t.Fatalf("Failed to create .grove dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(configContent), 0644); err != nil {
+				t.Fatalf("Failed to write config: %v", err)
+			}
+		}
+		return &Manager{repoRoot: tmpDir}
+	}
+
+	t.Run("no config falls back to default", func(t *testing.T) {
+		m := setup(t, "")
+		if got := m.getNamePattern(); got != DefaultNamePattern {
+			t.Errorf("getNamePattern() = %q, want %q", got, DefaultNamePattern)
+		}
+	})
+
+	t.Run("valid pattern is used", func(t *testing.T) {
+		m := setup(t, "[naming]\npattern = \"{name}.{project}\"\n")
+		if got := m.getNamePattern(); got != "{name}.{project}" {
+			t.Errorf("getNamePattern() = %q, want %q", got, "{name}.{project}")
+		}
+	})
+
+	t.Run("invalid pattern falls back to default", func(t *testing.T) {
+		m := setup(t, "[naming]\npattern = \"{name}\"\n")
+		if got := m.getNamePattern(); got != DefaultNamePattern {
+			t.Errorf("getNamePattern() = %q, want %q", got, DefaultNamePattern)
+		}
+	})
+
+	t.Run("pattern applies end to end via FullName", func(t *testing.T) {
+		m := setup(t, "project_name = \"proj\"\n\n[naming]\npattern = \"{name}_{project}\"\n")
+		if got := m.FullName("foo"); got != "foo_proj" {
+			t.Errorf("FullName(\"foo\") = %q, want %q", got, "foo_proj")
+		}
+	})
+}

--- a/internal/worktree/naming_test.go
+++ b/internal/worktree/naming_test.go
@@ -356,22 +356,28 @@ func TestShortNameFromFull(t *testing.T) {
 }
 
 func TestGetNamePatternFromConfig(t *testing.T) {
+	writeConfig := func(t *testing.T, tmpDir, fileName, content string) {
+		t.Helper()
+		groveDir := filepath.Join(tmpDir, ".grove")
+		if err := os.MkdirAll(groveDir, 0755); err != nil {
+			t.Fatalf("Failed to create .grove dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(groveDir, fileName), []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to write %s: %v", fileName, err)
+		}
+	}
 	setup := func(t *testing.T, configContent string) *Manager {
 		t.Helper()
 		tmpDir := t.TempDir()
+		// Isolate from the developer's real global config (~/.config/grove).
+		t.Setenv("GROVE_CONFIG", filepath.Join(tmpDir, "no-global.toml"))
 		initCmd := exec.Command("git", "init")
 		initCmd.Dir = tmpDir
 		if err := initCmd.Run(); err != nil {
 			t.Fatalf("Failed to init git repo: %v", err)
 		}
 		if configContent != "" {
-			groveDir := filepath.Join(tmpDir, ".grove")
-			if err := os.MkdirAll(groveDir, 0755); err != nil {
-				t.Fatalf("Failed to create .grove dir: %v", err)
-			}
-			if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte(configContent), 0644); err != nil {
-				t.Fatalf("Failed to write config: %v", err)
-			}
+			writeConfig(t, tmpDir, "config.toml", configContent)
 		}
 		return &Manager{repoRoot: tmpDir}
 	}
@@ -401,6 +407,14 @@ func TestGetNamePatternFromConfig(t *testing.T) {
 		m := setup(t, "project_name = \"proj\"\n\n[naming]\npattern = \"{name}_{project}\"\n")
 		if got := m.FullName("foo"); got != "foo_proj" {
 			t.Errorf("FullName(\"foo\") = %q, want %q", got, "foo_proj")
+		}
+	})
+
+	t.Run("config.local.toml overlay overrides project config", func(t *testing.T) {
+		m := setup(t, "[naming]\npattern = \"{project}-{name}\"\n")
+		writeConfig(t, m.repoRoot, "config.local.toml", "[naming]\npattern = \"{name}.{project}\"\n")
+		if got := m.getNamePattern(); got != "{name}.{project}" {
+			t.Errorf("getNamePattern() = %q, want %q (local overlay should win)", got, "{name}.{project}")
 		}
 	})
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -38,6 +38,7 @@ type Worktree struct {
 type Manager struct {
 	repoRoot    string // Root of the git repository
 	projectName string // Cached project name
+	namePattern string // Cached worktree naming pattern (see getNamePattern)
 }
 
 // NewManager creates a new worktree manager
@@ -176,13 +177,14 @@ func (m *Manager) Move(oldName, newName string) error {
 	}
 	oldPath := wt.Path
 
-	// Place the renamed worktree as a sibling of the original,
-	// preserving the naming convention (with or without project prefix).
+	// Place the renamed worktree as a sibling of the original, preserving
+	// the naming convention: directories that match the naming pattern get
+	// the new name interpolated into the same pattern, others are renamed
+	// bare (e.g. worktrees created by raw `git worktree add`).
 	oldBase := filepath.Base(oldPath)
-	prefix := m.GetProjectName() + "-"
 	var newBase string
-	if strings.HasPrefix(oldBase, prefix) {
-		newBase = prefix + newName
+	if _, matched := shortNameFromFull(oldBase, m.GetProjectName(), m.getNamePattern()); matched {
+		newBase = m.FullName(newName)
 	} else {
 		newBase = newName
 	}
@@ -282,7 +284,7 @@ func (m *Manager) listLight() ([]*Worktree, error) {
 	if mainPath == "" {
 		mainPath = m.repoRoot
 	}
-	return parseWorktreeList(raw, mainPath, m.GetProjectName()), nil
+	return parseWorktreeList(raw, mainPath, m.GetProjectName(), m.getNamePattern()), nil
 }
 
 // mainWorktreePathFromPorcelain returns the first worktree path in the output
@@ -341,12 +343,7 @@ func (m *Manager) DisplayNameForPath(path string) string {
 	if path == m.repoRoot {
 		return "root"
 	}
-	base := filepath.Base(path)
-	prefix := m.GetProjectName() + "-"
-	if strings.HasPrefix(base, prefix) {
-		return strings.TrimPrefix(base, prefix)
-	}
-	return base
+	return m.ShortName(filepath.Base(path))
 }
 
 // ListNames returns display names for all worktrees without running dirty checks.
@@ -512,16 +509,13 @@ func (m *Manager) getCommitInfo(path string) (shortHash, message, age string, er
 }
 
 // newWorktreeEntry creates a Worktree from a "worktree <path>" porcelain line.
-func newWorktreeEntry(path, mainPath, projectName string) *Worktree {
+func newWorktreeEntry(path, mainPath, projectName, namePattern string) *Worktree {
 	name := filepath.Base(path)
 	isMain := (path == mainPath)
 
 	shortName := name
 	if !isMain {
-		prefix := projectName + "-"
-		if strings.HasPrefix(name, prefix) {
-			shortName = strings.TrimPrefix(name, prefix)
-		}
+		shortName, _ = shortNameFromFull(name, projectName, namePattern)
 	}
 
 	return &Worktree{
@@ -548,7 +542,7 @@ func applyWorktreeAttribute(wt *Worktree, line string) {
 }
 
 // parseWorktreeList parses the output of 'git worktree list --porcelain'
-func parseWorktreeList(output, mainPath, projectName string) []*Worktree {
+func parseWorktreeList(output, mainPath, projectName, namePattern string) []*Worktree {
 	var trees []*Worktree
 	var current *Worktree
 
@@ -564,7 +558,7 @@ func parseWorktreeList(output, mainPath, projectName string) []*Worktree {
 		}
 
 		if strings.HasPrefix(line, "worktree ") {
-			current = newWorktreeEntry(strings.TrimPrefix(line, "worktree "), mainPath, projectName)
+			current = newWorktreeEntry(strings.TrimPrefix(line, "worktree "), mainPath, projectName, namePattern)
 		} else if current != nil {
 			applyWorktreeAttribute(current, line)
 		}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -116,7 +116,7 @@ detached
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			trees := parseWorktreeList(tt.input, "/home/user/project", "project")
+			trees := parseWorktreeList(tt.input, "/home/user/project", "project", DefaultNamePattern)
 			if len(trees) != tt.wantCount {
 				t.Errorf("parseWorktreeList() got %d worktrees, want %d", len(trees), tt.wantCount)
 			}

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -8,7 +8,7 @@ The Docker plugin provides automatic container lifecycle management for Grove wo
 - **Multi-compose file support**: Supports docker-compose.yml, docker-compose.yaml, compose.yml, compose.yaml
 - **Service-level control**: Manage individual services or all at once
 - **Log streaming**: Tail logs from running containers
-- **Modern Docker Compose**: Works with both `docker compose` and `docker-compose`
+- **Modern Docker Compose**: Uses `docker compose` (Compose v2)
 - **External compose mode**: Manage projects whose Docker services live in a shared orchestrator directory
 
 ## Commands
@@ -338,12 +338,13 @@ Run `grove doctor` to check that your loader is detected and configured correctl
 
 ## Requirements
 
-The Docker plugin requires one of the following:
+The Docker plugin requires:
 
 - **Docker with Compose V2**: `docker compose` command available
-- **Docker Compose V1**: `docker-compose` command available
 
-The plugin automatically detects which version is available and uses the appropriate command.
+The standalone `docker-compose` (Compose v1) binary is not supported — v1 is
+EOL and only accepts a single `--env-file`, which breaks grove's `.env`
+layering for non-default `env_file` settings.
 
 ## How It Works
 
@@ -448,11 +449,12 @@ w to feature-auth
 
 ## Troubleshooting
 
-### "docker or docker-compose not found"
+### "docker not found"
 
-The plugin is automatically disabled if neither `docker` nor `docker-compose` is found in your PATH.
+The plugin is automatically disabled if `docker` is not found in your PATH.
+The standalone `docker-compose` (v1) binary does not count — Compose v2 is required.
 
-**Solution**: Install Docker and ensure it's in your PATH.
+**Solution**: Install Docker (with Compose v2) and ensure it's in your PATH.
 
 ### "no docker-compose file found"
 

--- a/plugins/docker/local.go
+++ b/plugins/docker/local.go
@@ -246,37 +246,25 @@ func composeEnvFileArgs(composePath, envFile string) []string {
 	return args
 }
 
-// composeCommand creates a docker-compose command with optional environment variables.
-// dir sets the working directory. envFile, when non-empty and not ".env", adds
-// --env-file to the compose command for YAML variable interpolation; if a .env
-// file also exists alongside, it is layered underneath so compose still reads
-// defaults from .env. env is a list of extra KEY=VALUE strings to add to the
-// process environment.
+// composeCommand creates a `docker compose` (v2) command with optional
+// environment variables. dir sets the working directory. envFile, when
+// non-empty and not ".env", adds --env-file to the compose command for YAML
+// variable interpolation; if a .env file also exists alongside, it is layered
+// underneath so compose still reads defaults from .env. env is a list of
+// extra KEY=VALUE strings to add to the process environment.
+//
+// The standalone docker-compose v1 binary is not supported: v1 is EOL and
+// only accepts a single --env-file, which would silently break the .env
+// layering above (issue #107).
 //
 // Callers set cmd.Stdout = os.Stderr intentionally: grove reserves stdout for
 // shell-integration directives (cd:, env:, tmux-attach:), so Docker output
 // must go to stderr to avoid corrupting the directive stream.
 func composeCommand(dir string, envFile string, env []string, args ...string) *exec.Cmd {
-	if _, err := exec.LookPath("docker"); err == nil {
-		cmdArgs := []string{"compose"}
-		cmdArgs = append(cmdArgs, composeEnvFileArgs(dir, envFile)...)
-		cmdArgs = append(cmdArgs, args...)
-		cmd := exec.Command("docker", cmdArgs...)
-		cmd.Dir = dir
-		if len(env) > 0 {
-			cmd.Env = append(os.Environ(), env...)
-		}
-		return cmd
-	}
-
-	// docker-compose v1 fallback — only supports a single --env-file, so we
-	// can't layer .env underneath. Pass the configured envFile as-is.
-	var cmdArgs []string
-	if envFile != "" && envFile != ".env" {
-		cmdArgs = append(cmdArgs, "--env-file", envFile)
-	}
+	cmdArgs := []string{"compose"}
+	cmdArgs = append(cmdArgs, composeEnvFileArgs(dir, envFile)...)
 	cmdArgs = append(cmdArgs, args...)
-	cmd := exec.Command("docker-compose", cmdArgs...)
+	cmd := exec.Command("docker", cmdArgs...)
 	cmd.Dir = dir
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)

--- a/plugins/docker/plugin.go
+++ b/plugins/docker/plugin.go
@@ -13,9 +13,11 @@ import (
 	"github.com/lost-in-the/grove/internal/hooks"
 )
 
-// dockerAvailable caches the result of looking up docker / docker-compose in
-// PATH. Repeated Plugin.Init calls (e.g. across multiple commands sharing a
-// process or tests) would otherwise burn an exec.LookPath each time.
+// dockerAvailable caches the result of looking up docker in PATH. Repeated
+// Plugin.Init calls (e.g. across multiple commands sharing a process or
+// tests) would otherwise burn an exec.LookPath each time. Only the docker
+// CLI (compose v2) counts — the standalone docker-compose v1 binary is EOL
+// and no longer supported (issue #107).
 var (
 	dockerAvailableOnce   sync.Once
 	dockerAvailableResult bool
@@ -23,10 +25,6 @@ var (
 
 func dockerAvailable() bool {
 	dockerAvailableOnce.Do(func() {
-		if _, err := exec.LookPath("docker-compose"); err == nil {
-			dockerAvailableResult = true
-			return
-		}
 		if _, err := exec.LookPath("docker"); err == nil {
 			dockerAvailableResult = true
 		}

--- a/skills/grove-worktree-management/SKILL.md
+++ b/skills/grove-worktree-management/SKILL.md
@@ -55,10 +55,10 @@ export GROVE_TUI=0               # disable dashboard
 
 ## Critical Rules
 
-- **Worktree naming:** `{project}-{name}` — enforced. `grove ls` shows short names; tmux uses full names.
+- **Worktree naming:** directories default to `{project}-{name}`; projects can override via `[naming] pattern` in `.grove/config.toml`. `grove ls` shows short names; tmux sessions always use canonical `{project}-{name}`.
 - **Read-only switching:** `grove to <name> --peek` — skips hooks and tmux. Safe for PR review.
 - **Shell directives:** Without `GROVE_SHELL=1`, grove emits `cd:`, `tmux-attach:`, `env:` lines raw. Filter them: `grove to x 2>&1 | grep -vE '^(cd:|tmux-attach(-cc)?:|env:)'`
-- **`grove new` and tmux:** `GROVE_AGENT_MODE=1` does NOT suppress tmux session creation in `grove new`. Set `[tmux] mode = "off"` in config to prevent this.
+- **`grove new` and tmux:** `GROVE_AGENT_MODE=1` does NOT suppress tmux session creation in `grove new` — pass `--no-tmux` for that, or set `[tmux] mode = "off"` in config.
 - **Trust:** `.grove/hooks.toml` runs as `sh -c` with full env. Run `grove doctor` and check hooks before `grove new`/`grove fetch` in an unfamiliar repo.
 
 ## Deterministic Helpers


### PR DESCRIPTION
## Summary

Addresses all four issues filed 2026-07-05:

- **#105** — `grove to --peek` no longer relocates the caller's tmux client. Peek now skips tmux entirely (session creation, switch-client, attach) in addition to hooks, matching its documented observational intent.
- **#106** — New `--no-tmux` flag on `grove to` and `grove new`: per-invocation tmux suppression (on `new`, including session creation) without the isolated-Docker coupling of `GROVE_AGENT_MODE`. Hooks and Docker still run.
- **#104** — `[naming] pattern` now actually controls worktree directory names. Placeholders `{project}` and `{name}` (each required exactly once, literals limited to `[A-Za-z0-9._-]`), default `{project}-{name}`. Display, lookup, rename, and adopt all invert the pattern; invalid patterns warn on stderr and fall back to the default. Tmux session names intentionally keep the canonical `{project}-{name}` form so sessions stay stable across pattern changes.
- **#107** — Dropped the docker-compose v1 fallback (**breaking**): the docker plugin now requires the `docker` CLI with Compose v2. The v1 path only accepted a single `--env-file`, silently bypassing the #98 layering fix; v1 has been EOL since mid-2023.

## Design notes

- The naming pattern is read from the project-level `.grove/config.toml` (same mechanism as `project_name`) because worktree naming is a repo-level convention every invocation must interpret identically.
- `GROVE_AGENT_MODE` behavior in `grove new` is unchanged (still creates the detached session, per AGENTS.md); `--no-tmux` is the new opt-out.

## Testing

- `make lint test` green
- New unit tests: `TestEffectiveTmuxMode`, `TestValidateNamePattern`, `TestFullNameWithPattern`, `TestShortNameFromFull`, `TestGetNamePatternFromConfig`
- Manual smoke tests: `{name}.{project}` and `{name}_{project}` patterns create/display/invert correctly; invalid pattern warns and falls back; `grove new --no-tmux` creates no session

Closes #104, closes #105, closes #106, closes #107