### PR TITLE
fix(plugins): tracker gh PR lookup, docker status budget, env layering, plugin DRY

### DIFF
--- a/plugins/docker/container_switch.go
+++ b/plugins/docker/container_switch.go
@@ -1,6 +1,10 @@
 package docker
 
-import "github.com/lost-in-the/grove/internal/cli"
+import (
+	"github.com/lost-in-the/grove/internal/cli"
+	"github.com/lost-in-the/grove/internal/config"
+	"github.com/lost-in-the/grove/internal/hooks"
+)
 
 // ContainerSwitchAction represents the resolved action for container lifecycle during switch.
 type ContainerSwitchAction int
@@ -30,4 +34,61 @@ func ResolveContainerSwitch(configValue string, isInteractive bool) ContainerSwi
 // resolveFromConfig is a convenience that reads the config and checks interactivity.
 func resolveFromConfig(containerSwitch string) ContainerSwitchAction {
 	return ResolveContainerSwitch(containerSwitch, cli.IsInteractive())
+}
+
+// Prompt strings shared by the local and external switch hooks.
+const (
+	promptStopContainers  = "Stop containers in previous worktree?"
+	promptStartContainers = "Start containers for this worktree?"
+)
+
+// containerSwitchSetting reads the container_switch config value from the hook context.
+func containerSwitchSetting(ctx *hooks.Context) string {
+	if ctx.Config != nil {
+		return ctx.Config.Switch.ContainerSwitch
+	}
+	return ""
+}
+
+// confirmSwitchAction gates a container lifecycle action during switch hooks,
+// combining the auto_start/auto_stop config gate, the container_switch
+// resolution, and the interactive prompt. Shared by the local and external
+// strategies; per-mode defaults live in the strategies' getters. Returns true
+// when the caller should proceed with the container action. A declined or
+// failed prompt counts as "don't proceed" — the switch itself must not fail
+// because of a container prompt.
+func confirmSwitchAction(autoEnabled bool, ctx *hooks.Context, prompt string, promptDefault bool) bool {
+	if !autoEnabled {
+		return false
+	}
+
+	action := resolveFromConfig(containerSwitchSetting(ctx))
+	if action == ContainerSwitchOff {
+		return false
+	}
+
+	if action == ContainerSwitchPrompt {
+		yes, err := cli.Confirm(prompt, promptDefault)
+		if err != nil || !yes {
+			return false
+		}
+	}
+
+	return true
+}
+
+// dockerAutoStart returns the configured auto_start value or the strategy's default.
+func dockerAutoStart(cfg *config.Config, defaultValue bool) bool {
+	if cfg != nil && cfg.Plugins.Docker.AutoStart != nil {
+		return *cfg.Plugins.Docker.AutoStart
+	}
+	return defaultValue
+}
+
+// dockerAutoStop returns the configured auto_stop value or the strategy's default.
+func dockerAutoStop(cfg *config.Config, defaultValue bool) bool {
+	if cfg != nil && cfg.Plugins.Docker.AutoStop != nil {
+		return *cfg.Plugins.Docker.AutoStop
+	}
+	return defaultValue
 }

--- a/plugins/docker/container_switch_test.go
+++ b/plugins/docker/container_switch_test.go
@@ -1,6 +1,11 @@
 package docker
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/config"
+	"github.com/lost-in-the/grove/internal/hooks"
+)
 
 func TestResolveContainerSwitch(t *testing.T) {
 	tests := []struct {
@@ -54,5 +59,84 @@ func TestResolveContainerSwitch(t *testing.T) {
 				t.Errorf("ResolveContainerSwitch(%q, %v) = %d, want %d", tt.configValue, tt.isInteractive, got, tt.want)
 			}
 		})
+	}
+}
+
+// confirmSwitchAction combines the auto gate, container_switch resolution, and
+// the interactive prompt. Tests run non-interactively, so "prompt" resolves to
+// Auto and the cli.Confirm path is never reached here.
+func TestConfirmSwitchAction(t *testing.T) {
+	ctxWithSwitch := func(value string) *hooks.Context {
+		return &hooks.Context{Config: &config.Config{
+			Switch: config.SwitchConfig{ContainerSwitch: value},
+		}}
+	}
+
+	tests := []struct {
+		name        string
+		autoEnabled bool
+		ctx         *hooks.Context
+		want        bool
+	}{
+		{
+			name:        "auto gate disabled returns false",
+			autoEnabled: false,
+			ctx:         ctxWithSwitch("auto"),
+			want:        false,
+		},
+		{
+			name:        "container_switch off returns false",
+			autoEnabled: true,
+			ctx:         ctxWithSwitch("off"),
+			want:        false,
+		},
+		{
+			name:        "auto proceeds",
+			autoEnabled: true,
+			ctx:         ctxWithSwitch("auto"),
+			want:        true,
+		},
+		{
+			name:        "nil hook config defaults to auto",
+			autoEnabled: true,
+			ctx:         &hooks.Context{},
+			want:        true,
+		},
+		{
+			name:        "prompt non-interactive falls back to auto",
+			autoEnabled: true,
+			ctx:         ctxWithSwitch("prompt"),
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := confirmSwitchAction(tt.autoEnabled, tt.ctx, promptStartContainers, true)
+			if got != tt.want {
+				t.Errorf("confirmSwitchAction(%v, ...) = %v, want %v", tt.autoEnabled, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDockerAutoFlagDefaults(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	if got := dockerAutoStart(nil, true); !got {
+		t.Error("dockerAutoStart(nil, true) = false, want default true")
+	}
+	if got := dockerAutoStop(nil, false); got {
+		t.Error("dockerAutoStop(nil, false) = true, want default false")
+	}
+
+	cfg := &config.Config{}
+	cfg.Plugins.Docker.AutoStart = boolPtr(false)
+	cfg.Plugins.Docker.AutoStop = boolPtr(true)
+	if got := dockerAutoStart(cfg, true); got {
+		t.Error("dockerAutoStart with explicit false = true, want false")
+	}
+	if got := dockerAutoStop(cfg, false); !got {
+		t.Error("dockerAutoStop with explicit true = false, want true")
 	}
 }

--- a/plugins/docker/external.go
+++ b/plugins/docker/external.go
@@ -115,7 +115,7 @@ func (s *externalStrategy) Up(worktreePath string, detach bool) error {
 	}
 
 	// compose up returned non-zero — check whether only non-blocking services failed.
-	statuses, probeErr := probeServiceHealth(s.composePath(), s.ext.EnvFileName(), s.envForWorktree(worktreePath))
+	statuses, probeErr := probeServiceHealth(s.composePath(), s.ext.EnvFileName(), s.envForWorktree(worktreePath), probeTimeout)
 	if probeErr != nil {
 		// Probe failed — surface the original cmd error rather than swallowing it.
 		return cmdErr

--- a/plugins/docker/external.go
+++ b/plugins/docker/external.go
@@ -27,20 +27,8 @@ func newExternalStrategy(cfg *config.Config) *externalStrategy {
 }
 
 func (s *externalStrategy) OnPreSwitch(ctx *hooks.Context) error {
-	if !s.getAutoStop() {
+	if !confirmSwitchAction(s.getAutoStop(), ctx, promptStopContainers, false) {
 		return nil
-	}
-
-	action := resolveFromConfig(s.getContainerSwitch(ctx))
-	if action == ContainerSwitchOff {
-		return nil
-	}
-
-	if action == ContainerSwitchPrompt {
-		yes, err := cli.Confirm("Stop containers in previous worktree?", false)
-		if err != nil || !yes {
-			return nil
-		}
 	}
 
 	return s.stopServices()
@@ -61,20 +49,8 @@ func (s *externalStrategy) OnPostSwitch(ctx *hooks.Context) error {
 	// Export the env var into the user's shell so manual docker compose commands work
 	s.emitEnvDirective(worktreePath)
 
-	if !s.getAutoStart() {
+	if !confirmSwitchAction(s.getAutoStart(), ctx, promptStartContainers, true) {
 		return nil
-	}
-
-	action := resolveFromConfig(s.getContainerSwitch(ctx))
-	if action == ContainerSwitchOff {
-		return nil
-	}
-
-	if action == ContainerSwitchPrompt {
-		yes, err := cli.Confirm("Start containers for this worktree?", true)
-		if err != nil || !yes {
-			return nil
-		}
 	}
 
 	return s.startServices(worktreePath)
@@ -363,25 +339,11 @@ func (s *externalStrategy) relativeWorktreePath(absPath string) string {
 	return rel
 }
 
-func (s *externalStrategy) getContainerSwitch(ctx *hooks.Context) string {
-	if ctx.Config != nil {
-		return ctx.Config.Switch.ContainerSwitch
-	}
-	return ""
-}
-
 func (s *externalStrategy) getAutoStart() bool {
-	if s.cfg != nil && s.cfg.Plugins.Docker.AutoStart != nil {
-		return *s.cfg.Plugins.Docker.AutoStart
-	}
-	// External mode defaults to true for auto_start
-	return true
+	return dockerAutoStart(s.cfg, true)
 }
 
 func (s *externalStrategy) getAutoStop() bool {
-	if s.cfg != nil && s.cfg.Plugins.Docker.AutoStop != nil {
-		return *s.cfg.Plugins.Docker.AutoStop
-	}
 	// External mode defaults to true for auto_stop (unlike local's false)
-	return true
+	return dockerAutoStop(s.cfg, true)
 }

--- a/plugins/docker/local.go
+++ b/plugins/docker/local.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/config"
 	"github.com/lost-in-the/grove/internal/hooks"
 )
@@ -20,50 +19,26 @@ func newLocalStrategy(cfg *config.Config) *localStrategy {
 }
 
 func (s *localStrategy) OnPreSwitch(ctx *hooks.Context) error {
-	if !s.getAutoStop() {
-		return nil
-	}
-
-	action := resolveFromConfig(s.getContainerSwitch(ctx))
-	if action == ContainerSwitchOff {
-		return nil
-	}
-
 	worktreePath := s.getWorktreePath(ctx.PrevWorktree)
 	if !hasDockerCompose(worktreePath) {
 		return nil
 	}
 
-	if action == ContainerSwitchPrompt {
-		yes, err := cli.Confirm("Stop containers in previous worktree?", false)
-		if err != nil || !yes {
-			return nil
-		}
+	if !confirmSwitchAction(s.getAutoStop(), ctx, promptStopContainers, false) {
+		return nil
 	}
 
 	return s.down(worktreePath)
 }
 
 func (s *localStrategy) OnPostSwitch(ctx *hooks.Context) error {
-	if !s.getAutoStart() {
-		return nil
-	}
-
-	action := resolveFromConfig(s.getContainerSwitch(ctx))
-	if action == ContainerSwitchOff {
-		return nil
-	}
-
 	worktreePath := s.getWorktreePath(ctx.Worktree)
 	if !hasDockerCompose(worktreePath) {
 		return nil
 	}
 
-	if action == ContainerSwitchPrompt {
-		yes, err := cli.Confirm("Start containers for this worktree?", true)
-		if err != nil || !yes {
-			return nil
-		}
+	if !confirmSwitchAction(s.getAutoStart(), ctx, promptStartContainers, true) {
+		return nil
 	}
 
 	return s.up(worktreePath, false)
@@ -169,24 +144,11 @@ func (s *localStrategy) up(worktreePath string, detach bool) error {
 }
 
 func (s *localStrategy) getAutoStart() bool {
-	if s.cfg != nil && s.cfg.Plugins.Docker.AutoStart != nil {
-		return *s.cfg.Plugins.Docker.AutoStart
-	}
-	return true
-}
-
-func (s *localStrategy) getContainerSwitch(ctx *hooks.Context) string {
-	if ctx.Config != nil {
-		return ctx.Config.Switch.ContainerSwitch
-	}
-	return ""
+	return dockerAutoStart(s.cfg, true)
 }
 
 func (s *localStrategy) getAutoStop() bool {
-	if s.cfg != nil && s.cfg.Plugins.Docker.AutoStop != nil {
-		return *s.cfg.Plugins.Docker.AutoStop
-	}
-	return false
+	return dockerAutoStop(s.cfg, false)
 }
 
 func (s *localStrategy) getWorktreePath(name string) string {

--- a/plugins/docker/mount_drift.go
+++ b/plugins/docker/mount_drift.go
@@ -116,15 +116,20 @@ func shortID(id string) string {
 	return id
 }
 
+// composePsQArgs builds the `docker` argument list for `compose ps -q <service>`,
+// layering env files via composeEnvFileArgs so a non-default env_file doesn't
+// make compose ignore .env (issue #98). Extracted for unit testing.
+func composePsQArgs(composePath, envFile, service string) []string {
+	args := []string{"compose"}
+	args = append(args, composeEnvFileArgs(composePath, envFile)...)
+	return append(args, "ps", "-q", service)
+}
+
 // containerIDForService runs `docker compose ps -q <service>` and returns the
 // (single) container ID. Multi-replica compose configs return multiple IDs;
 // we take the first since drift detection only needs one sample of the mount.
 func containerIDForService(composePath, envFile, service string) (string, error) {
-	args := []string{"compose"}
-	if envFile != "" && envFile != ".env" {
-		args = append(args, "--env-file", envFile)
-	}
-	args = append(args, "ps", "-q", service)
+	args := composePsQArgs(composePath, envFile, service)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/plugins/docker/mount_drift_test.go
+++ b/plugins/docker/mount_drift_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -184,5 +185,41 @@ func TestParseInspectMounts_RealisticOutput(t *testing.T) {
 	want := filepath.Clean("/Users/leah/work/proj-feature-x")
 	if got != want {
 		t.Errorf("source = %q, want %q", got, want)
+	}
+}
+
+// Regression test for the drift-check path reintroducing issue #98: a lone
+// --env-file makes compose v2 ignore .env, so the args must layer .env
+// underneath the configured env file via composeEnvFileArgs.
+func TestComposePsQArgs_LayersDefaultEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("FOO=bar\n"), 0o644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	got := composePsQArgs(dir, ".env.local", "web")
+	want := []string{"compose", "--env-file", ".env", "--env-file", ".env.local", "ps", "-q", "web"}
+	if len(got) != len(want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestComposePsQArgs_DefaultEnvFileOmitsFlag(t *testing.T) {
+	dir := t.TempDir()
+
+	got := composePsQArgs(dir, ".env", "web")
+	want := []string{"compose", "ps", "-q", "web"}
+	if len(got) != len(want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("args[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
 	}
 }

--- a/plugins/docker/plugin.go
+++ b/plugins/docker/plugin.go
@@ -81,7 +81,7 @@ func (p *Plugin) Init(cfg *config.Config) error {
 	// Check if docker is available (LookPath result cached across Init calls).
 	if !dockerAvailable() {
 		p.enabled = false
-		return fmt.Errorf("docker or docker-compose not found in PATH")
+		return fmt.Errorf("docker CLI (with compose v2) not found in PATH")
 	}
 
 	// Select strategy based on mode

--- a/plugins/docker/service_health.go
+++ b/plugins/docker/service_health.go
@@ -130,13 +130,17 @@ func finalizeUpResult(cmdErr error, statuses []ServiceStatus, nonBlocking []stri
 // probeTimeout is longer than statusTimeout (300ms) because Up() can tolerate a
 // slower probe — docker compose ps can be slow on busy systems (NFS, heavy disk I/O)
 // and 1s caused false-empty probes that fed the silent-failure bug in finalizeUpResult.
+// Display paths (grove ls, grove which) must pass statusTimeout instead so a slow
+// daemon can't blow the <500ms command budget; a timed-out probe degrades to
+// "configured" via classifyExternalStatusFromHealth.
 const probeTimeout = 3 * time.Second
 
 // probeServiceHealth runs `docker compose ps --all --format json` and returns parsed statuses.
 // composePath is the directory containing the compose file; envFile is the env file name
-// (e.g., ".env" or ".env.local") to pass via --env-file.
-func probeServiceHealth(composePath, envFile string, env []string) ([]ServiceStatus, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+// (e.g., ".env" or ".env.local") to pass via --env-file. timeout bounds the compose call:
+// probeTimeout for correctness paths (Up), statusTimeout for display paths.
+func probeServiceHealth(composePath, envFile string, env []string, timeout time.Duration) ([]ServiceStatus, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	args := []string{"compose"}

--- a/plugins/docker/status.go
+++ b/plugins/docker/status.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/lost-in-the/grove/internal/config"
@@ -35,30 +36,43 @@ func (p *Plugin) WorktreeStatuses(worktreePaths []string) map[string]plugins.Sta
 }
 
 // localStatuses checks each worktree for a compose file and running containers.
+// The per-worktree docker compose ps calls are independent, so they run
+// concurrently — a serial loop would cost N x statusTimeout in the worst case,
+// blowing the <500ms budget for grove ls as soon as 2+ worktrees have compose files.
 func localStatuses(_ *localStrategy, paths []string) map[string]plugins.StatusEntry {
 	result := make(map[string]plugins.StatusEntry)
 
+	var mu sync.Mutex
+	var wg sync.WaitGroup
 	for _, path := range paths {
 		if !hasDockerCompose(path) {
 			continue
 		}
 
-		// Has compose file — at minimum "configured"
-		entry := plugins.StatusEntry{
-			ProviderName: "docker",
-			Level:        plugins.StatusInfo,
-			Short:        "compose",
-			Detail:       "Compose file found",
-		}
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
 
-		if running, count := composeRunningCount(path); running {
-			entry.Level = plugins.StatusActive
-			entry.Short = fmt.Sprintf("up (%d)", count)
-			entry.Detail = fmt.Sprintf("%d container(s) running", count)
-		}
+			// Has compose file — at minimum "configured"
+			entry := plugins.StatusEntry{
+				ProviderName: "docker",
+				Level:        plugins.StatusInfo,
+				Short:        "compose",
+				Detail:       "Compose file found",
+			}
 
-		result[path] = entry
+			if running, count := composeRunningCount(path); running {
+				entry.Level = plugins.StatusActive
+				entry.Short = fmt.Sprintf("up (%d)", count)
+				entry.Detail = fmt.Sprintf("%d container(s) running", count)
+			}
+
+			mu.Lock()
+			result[path] = entry
+			mu.Unlock()
+		}(path)
 	}
+	wg.Wait()
 
 	return result
 }
@@ -74,7 +88,8 @@ func externalStatuses(s *externalStrategy, paths []string) map[string]plugins.St
 	// ignored here: status display is informational and a nil result downgrades to
 	// "configured" via classifyExternalStatusFromHealth, which is correct for
 	// "stack not running yet" — surfacing the error would just be noise on the dashboard.
-	statuses, _ := probeServiceHealth(composePath, s.ext.EnvFileName(), nil)
+	// statusTimeout (not probeTimeout) keeps grove ls within the <500ms budget.
+	statuses, _ := probeServiceHealth(composePath, s.ext.EnvFileName(), nil, statusTimeout)
 
 	for _, path := range paths {
 		matches := pathMatchesEnv(path, activeWorktree, composePath)
@@ -256,7 +271,8 @@ func externalServiceInfo(cfg *config.Config, currentPath string) *ServiceInfo {
 
 	// Use the same probeServiceHealth + classifyHealth path as externalStatuses so
 	// that non_blocking_services is honored and both code paths agree on verdict.
-	statuses, _ := probeServiceHealth(composePath, ext.EnvFileName(), nil)
+	// statusTimeout (not probeTimeout) keeps grove which within the <500ms budget.
+	statuses, _ := probeServiceHealth(composePath, ext.EnvFileName(), nil, statusTimeout)
 	healthy, _ := classifyHealth(statuses, ext.NonBlockingServices)
 	runningCount := 0
 	for _, s := range statuses {

--- a/plugins/docker/status_test.go
+++ b/plugins/docker/status_test.go
@@ -106,6 +106,41 @@ func TestLocalStatuses_WithComposeFile(t *testing.T) {
 	}
 }
 
+// localStatuses probes worktrees concurrently — verify every compose-bearing
+// worktree still gets an entry and non-compose worktrees are skipped. Run with
+// -race this also guards the shared result map against unsynchronized writes.
+func TestLocalStatuses_MultipleWorktrees(t *testing.T) {
+	composeDirs := make([]string, 3)
+	for i := range composeDirs {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte("services: {}"), 0644); err != nil {
+			t.Fatalf("failed to create compose file: %v", err)
+		}
+		composeDirs[i] = dir
+	}
+	noCompose := t.TempDir()
+
+	paths := append(append([]string{}, composeDirs...), noCompose)
+	result := localStatuses(&localStrategy{cfg: &config.Config{}}, paths)
+
+	if len(result) != len(composeDirs) {
+		t.Fatalf("expected %d entries, got %d: %v", len(composeDirs), len(result), result)
+	}
+	for _, dir := range composeDirs {
+		entry, ok := result[dir]
+		if !ok {
+			t.Errorf("missing entry for compose worktree %s", dir)
+			continue
+		}
+		if entry.ProviderName != "docker" {
+			t.Errorf("expected ProviderName 'docker', got %q", entry.ProviderName)
+		}
+	}
+	if _, ok := result[noCompose]; ok {
+		t.Errorf("unexpected entry for worktree without compose file")
+	}
+}
+
 func TestExternalStatuses_NoMatch(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_DIR=/other/path\n"), 0644); err != nil {

--- a/plugins/tracker/github.go
+++ b/plugins/tracker/github.go
@@ -363,7 +363,9 @@ func DetectRepo() (string, error) {
 // GetPRForBranch looks up the open PR for a given branch name.
 // Returns nil with no error if no PR exists for the branch.
 func (g *GitHubAdapter) GetPRForBranch(branch string) (*PullRequest, error) {
-	args := []string{"pr", "view", "--head", branch, "--json", "number,title,state,url"}
+	// gh pr view takes the branch as a positional argument — it has no --head
+	// flag (that belongs to gh pr list).
+	args := []string{"pr", "view", branch, "--json", "number,title,state,url"}
 	if g.repo != "" {
 		args = append(args, "--repo", g.repo)
 	}

--- a/plugins/tracker/github.go
+++ b/plugins/tracker/github.go
@@ -27,9 +27,119 @@ func (g *GitHubAdapter) Name() string {
 	return "github"
 }
 
+// issueJSONFields is the gh --json field list matching ghIssue. Keep in sync
+// with the ghIssue struct below.
+const issueJSONFields = "number,title,body,state,author,labels,createdAt,updatedAt,url"
+
+// ghIssue mirrors the JSON fields requested from gh for issues.
+type ghIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	State  string `json:"state"`
+	Author struct {
+		Login string `json:"login"`
+	} `json:"author"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	URL       string    `json:"url"`
+}
+
+// toIssue converts a gh issue response into the tracker Issue type.
+func (gh ghIssue) toIssue() *Issue {
+	labels := make([]string, len(gh.Labels))
+	for i, l := range gh.Labels {
+		labels[i] = l.Name
+	}
+
+	return &Issue{
+		Number:    gh.Number,
+		Title:     gh.Title,
+		Body:      gh.Body,
+		State:     strings.ToLower(gh.State),
+		Author:    gh.Author.Login,
+		Labels:    labels,
+		CreatedAt: gh.CreatedAt,
+		UpdatedAt: gh.UpdatedAt,
+		URL:       gh.URL,
+	}
+}
+
+// prJSONFields is the gh --json field list matching ghPR. Keep in sync with
+// the ghPR struct below.
+const prJSONFields = "number,title,body,state,author,labels,headRefName,baseRefName,isDraft,commits,additions,deletions,reviewDecision,createdAt,updatedAt,url"
+
+// ghPR mirrors the JSON fields requested from gh for pull requests.
+type ghPR struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	State  string `json:"state"`
+	Author struct {
+		Login string `json:"login"`
+	} `json:"author"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	HeadRefName string `json:"headRefName"`
+	BaseRefName string `json:"baseRefName"`
+	IsDraft     bool   `json:"isDraft"`
+	Commits     []struct {
+		Oid             string `json:"oid"`
+		MessageHeadline string `json:"messageHeadline"`
+	} `json:"commits"`
+	Additions      int       `json:"additions"`
+	Deletions      int       `json:"deletions"`
+	ReviewDecision string    `json:"reviewDecision"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+	URL            string    `json:"url"`
+}
+
+// toPullRequest converts a gh PR response into the tracker PullRequest type,
+// flattening labels and truncating commit SHAs to 7 characters.
+func (gh ghPR) toPullRequest() *PullRequest {
+	labels := make([]string, len(gh.Labels))
+	for i, l := range gh.Labels {
+		labels[i] = l.Name
+	}
+
+	commits := make([]PRCommit, len(gh.Commits))
+	for i, c := range gh.Commits {
+		sha := c.Oid
+		if len(sha) > 7 {
+			sha = sha[:7]
+		}
+		commits[i] = PRCommit{SHA: sha, Message: c.MessageHeadline}
+	}
+
+	return &PullRequest{
+		Number:         gh.Number,
+		Title:          gh.Title,
+		Body:           gh.Body,
+		State:          strings.ToLower(gh.State),
+		Author:         gh.Author.Login,
+		Labels:         labels,
+		Branch:         gh.HeadRefName,
+		BaseBranch:     gh.BaseRefName,
+		IsDraft:        gh.IsDraft,
+		CommitCount:    len(gh.Commits),
+		Commits:        commits,
+		Additions:      gh.Additions,
+		Deletions:      gh.Deletions,
+		ReviewDecision: gh.ReviewDecision,
+		CreatedAt:      gh.CreatedAt,
+		UpdatedAt:      gh.UpdatedAt,
+		URL:            gh.URL,
+	}
+}
+
 // FetchIssue retrieves an issue by number.
 func (g *GitHubAdapter) FetchIssue(number int) (*Issue, error) {
-	args := []string{"issue", "view", strconv.Itoa(number), "--json", "number,title,body,state,author,labels,createdAt,updatedAt,url"}
+	args := []string{"issue", "view", strconv.Itoa(number), "--json", issueJSONFields}
 	if g.repo != "" {
 		args = append(args, "--repo", g.repo)
 	}
@@ -39,47 +149,17 @@ func (g *GitHubAdapter) FetchIssue(number int) (*Issue, error) {
 		return nil, fmt.Errorf("fetch issue %d: %w", number, err)
 	}
 
-	var ghIssue struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		State  string `json:"state"`
-		Author struct {
-			Login string `json:"login"`
-		} `json:"author"`
-		Labels []struct {
-			Name string `json:"name"`
-		} `json:"labels"`
-		CreatedAt time.Time `json:"createdAt"`
-		UpdatedAt time.Time `json:"updatedAt"`
-		URL       string    `json:"url"`
-	}
-
-	if err := json.Unmarshal(output, &ghIssue); err != nil {
+	var gh ghIssue
+	if err := json.Unmarshal(output, &gh); err != nil {
 		return nil, fmt.Errorf("parse issue response: %w", err)
 	}
 
-	labels := make([]string, len(ghIssue.Labels))
-	for i, l := range ghIssue.Labels {
-		labels[i] = l.Name
-	}
-
-	return &Issue{
-		Number:    ghIssue.Number,
-		Title:     ghIssue.Title,
-		Body:      ghIssue.Body,
-		State:     strings.ToLower(ghIssue.State),
-		Author:    ghIssue.Author.Login,
-		Labels:    labels,
-		CreatedAt: ghIssue.CreatedAt,
-		UpdatedAt: ghIssue.UpdatedAt,
-		URL:       ghIssue.URL,
-	}, nil
+	return gh.toIssue(), nil
 }
 
 // FetchPR retrieves a pull request by number.
 func (g *GitHubAdapter) FetchPR(number int) (*PullRequest, error) {
-	args := []string{"pr", "view", strconv.Itoa(number), "--json", "number,title,body,state,author,labels,headRefName,baseRefName,isDraft,commits,additions,deletions,reviewDecision,createdAt,updatedAt,url"}
+	args := []string{"pr", "view", strconv.Itoa(number), "--json", prJSONFields}
 	if g.repo != "" {
 		args = append(args, "--repo", g.repo)
 	}
@@ -89,74 +169,17 @@ func (g *GitHubAdapter) FetchPR(number int) (*PullRequest, error) {
 		return nil, fmt.Errorf("fetch pr %d: %w", number, err)
 	}
 
-	var ghPR struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		State  string `json:"state"`
-		Author struct {
-			Login string `json:"login"`
-		} `json:"author"`
-		Labels []struct {
-			Name string `json:"name"`
-		} `json:"labels"`
-		HeadRefName string `json:"headRefName"`
-		BaseRefName string `json:"baseRefName"`
-		IsDraft     bool   `json:"isDraft"`
-		Commits     []struct {
-			Oid             string `json:"oid"`
-			MessageHeadline string `json:"messageHeadline"`
-		} `json:"commits"`
-		Additions      int       `json:"additions"`
-		Deletions      int       `json:"deletions"`
-		ReviewDecision string    `json:"reviewDecision"`
-		CreatedAt      time.Time `json:"createdAt"`
-		UpdatedAt      time.Time `json:"updatedAt"`
-		URL            string    `json:"url"`
-	}
-
-	if err := json.Unmarshal(output, &ghPR); err != nil {
+	var gh ghPR
+	if err := json.Unmarshal(output, &gh); err != nil {
 		return nil, fmt.Errorf("parse pr response: %w", err)
 	}
 
-	labels := make([]string, len(ghPR.Labels))
-	for i, l := range ghPR.Labels {
-		labels[i] = l.Name
-	}
-
-	commits := make([]PRCommit, len(ghPR.Commits))
-	for i, c := range ghPR.Commits {
-		sha := c.Oid
-		if len(sha) > 7 {
-			sha = sha[:7]
-		}
-		commits[i] = PRCommit{SHA: sha, Message: c.MessageHeadline}
-	}
-
-	return &PullRequest{
-		Number:         ghPR.Number,
-		Title:          ghPR.Title,
-		Body:           ghPR.Body,
-		State:          strings.ToLower(ghPR.State),
-		Author:         ghPR.Author.Login,
-		Labels:         labels,
-		Branch:         ghPR.HeadRefName,
-		BaseBranch:     ghPR.BaseRefName,
-		IsDraft:        ghPR.IsDraft,
-		CommitCount:    len(ghPR.Commits),
-		Commits:        commits,
-		Additions:      ghPR.Additions,
-		Deletions:      ghPR.Deletions,
-		ReviewDecision: ghPR.ReviewDecision,
-		CreatedAt:      ghPR.CreatedAt,
-		UpdatedAt:      ghPR.UpdatedAt,
-		URL:            ghPR.URL,
-	}, nil
+	return gh.toPullRequest(), nil
 }
 
 // ListIssues retrieves issues with optional filtering.
 func (g *GitHubAdapter) ListIssues(opts ListOptions) ([]*Issue, error) {
-	args := []string{"issue", "list", "--json", "number,title,body,state,author,labels,createdAt,updatedAt,url"}
+	args := []string{"issue", "list", "--json", issueJSONFields}
 
 	if opts.State != "" && opts.State != "all" {
 		args = append(args, "--state", opts.State)
@@ -187,44 +210,14 @@ func (g *GitHubAdapter) ListIssues(opts ListOptions) ([]*Issue, error) {
 		return nil, fmt.Errorf("list issues: %w", err)
 	}
 
-	var ghIssues []struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		State  string `json:"state"`
-		Author struct {
-			Login string `json:"login"`
-		} `json:"author"`
-		Labels []struct {
-			Name string `json:"name"`
-		} `json:"labels"`
-		CreatedAt time.Time `json:"createdAt"`
-		UpdatedAt time.Time `json:"updatedAt"`
-		URL       string    `json:"url"`
-	}
-
+	var ghIssues []ghIssue
 	if err := json.Unmarshal(output, &ghIssues); err != nil {
 		return nil, fmt.Errorf("parse issues response: %w", err)
 	}
 
 	issues := make([]*Issue, len(ghIssues))
 	for i, gh := range ghIssues {
-		labels := make([]string, len(gh.Labels))
-		for j, l := range gh.Labels {
-			labels[j] = l.Name
-		}
-
-		issues[i] = &Issue{
-			Number:    gh.Number,
-			Title:     gh.Title,
-			Body:      gh.Body,
-			State:     strings.ToLower(gh.State),
-			Author:    gh.Author.Login,
-			Labels:    labels,
-			CreatedAt: gh.CreatedAt,
-			UpdatedAt: gh.UpdatedAt,
-			URL:       gh.URL,
-		}
+		issues[i] = gh.toIssue()
 	}
 
 	return issues, nil
@@ -232,7 +225,7 @@ func (g *GitHubAdapter) ListIssues(opts ListOptions) ([]*Issue, error) {
 
 // ListPRs retrieves pull requests with optional filtering.
 func (g *GitHubAdapter) ListPRs(opts ListOptions) ([]*PullRequest, error) {
-	args := []string{"pr", "list", "--json", "number,title,body,state,author,labels,headRefName,baseRefName,isDraft,commits,additions,deletions,reviewDecision,createdAt,updatedAt,url"}
+	args := []string{"pr", "list", "--json", prJSONFields}
 
 	if opts.State != "" && opts.State != "all" {
 		args = append(args, "--state", opts.State)
@@ -263,71 +256,14 @@ func (g *GitHubAdapter) ListPRs(opts ListOptions) ([]*PullRequest, error) {
 		return nil, fmt.Errorf("list prs: %w", err)
 	}
 
-	var ghPRs []struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		State  string `json:"state"`
-		Author struct {
-			Login string `json:"login"`
-		} `json:"author"`
-		Labels []struct {
-			Name string `json:"name"`
-		} `json:"labels"`
-		HeadRefName string `json:"headRefName"`
-		BaseRefName string `json:"baseRefName"`
-		IsDraft     bool   `json:"isDraft"`
-		Commits     []struct {
-			Oid             string `json:"oid"`
-			MessageHeadline string `json:"messageHeadline"`
-		} `json:"commits"`
-		Additions      int       `json:"additions"`
-		Deletions      int       `json:"deletions"`
-		ReviewDecision string    `json:"reviewDecision"`
-		CreatedAt      time.Time `json:"createdAt"`
-		UpdatedAt      time.Time `json:"updatedAt"`
-		URL            string    `json:"url"`
-	}
-
+	var ghPRs []ghPR
 	if err := json.Unmarshal(output, &ghPRs); err != nil {
 		return nil, fmt.Errorf("parse prs response: %w", err)
 	}
 
 	prs := make([]*PullRequest, len(ghPRs))
 	for i, gh := range ghPRs {
-		labels := make([]string, len(gh.Labels))
-		for j, l := range gh.Labels {
-			labels[j] = l.Name
-		}
-
-		commits := make([]PRCommit, len(gh.Commits))
-		for j, c := range gh.Commits {
-			sha := c.Oid
-			if len(sha) > 7 {
-				sha = sha[:7]
-			}
-			commits[j] = PRCommit{SHA: sha, Message: c.MessageHeadline}
-		}
-
-		prs[i] = &PullRequest{
-			Number:         gh.Number,
-			Title:          gh.Title,
-			Body:           gh.Body,
-			State:          strings.ToLower(gh.State),
-			Author:         gh.Author.Login,
-			Labels:         labels,
-			Branch:         gh.HeadRefName,
-			BaseBranch:     gh.BaseRefName,
-			IsDraft:        gh.IsDraft,
-			CommitCount:    len(gh.Commits),
-			Commits:        commits,
-			Additions:      gh.Additions,
-			Deletions:      gh.Deletions,
-			ReviewDecision: gh.ReviewDecision,
-			CreatedAt:      gh.CreatedAt,
-			UpdatedAt:      gh.UpdatedAt,
-			URL:            gh.URL,
-		}
+		prs[i] = gh.toPullRequest()
 	}
 
 	return prs, nil
@@ -376,23 +312,14 @@ func (g *GitHubAdapter) GetPRForBranch(branch string) (*PullRequest, error) {
 		return nil, nil
 	}
 
-	var ghPR struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		State  string `json:"state"`
-		URL    string `json:"url"`
-	}
-
-	if err := json.Unmarshal(output, &ghPR); err != nil {
+	// Only a subset of prJSONFields is requested; the remaining ghPR fields
+	// stay at their zero values.
+	var gh ghPR
+	if err := json.Unmarshal(output, &gh); err != nil {
 		return nil, fmt.Errorf("parse pr response: %w", err)
 	}
 
-	return &PullRequest{
-		Number: ghPR.Number,
-		Title:  ghPR.Title,
-		State:  strings.ToLower(ghPR.State),
-		URL:    ghPR.URL,
-	}, nil
+	return gh.toPullRequest(), nil
 }
 
 // GetRepoViewURL returns the base HTTPS URL of the GitHub repository.

--- a/plugins/tracker/github_test.go
+++ b/plugins/tracker/github_test.go
@@ -1,8 +1,86 @@
 package tracker
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
+
+// installFakeGh shadows the real gh CLI with a script that mimics gh's
+// argument handling for `pr view`: any --head flag is rejected (the real
+// gh pr view has no such flag), and the branch must be positional.
+func installFakeGh(t *testing.T, script string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script not supported on windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// fakeGhPRView mimics real gh: `pr view` rejects --head (unknown flag) and
+// returns PR JSON only when the branch is passed positionally.
+const fakeGhPRView = `#!/bin/sh
+if [ "$1 $2" != "pr view" ]; then
+  echo "unexpected command: $@" >&2
+  exit 1
+fi
+shift 2
+for arg in "$@"; do
+  if [ "$arg" = "--head" ]; then
+    echo "unknown flag: --head" >&2
+    exit 1
+  fi
+done
+if [ "$1" = "feature-branch" ]; then
+  echo '{"number":42,"title":"Test PR","state":"OPEN","url":"https://github.com/test-org/test-repo/pull/42"}'
+  exit 0
+fi
+echo "no pull requests found for branch \"$1\"" >&2
+exit 1
+`
+
+// Regression test for the --head bug: gh pr view has no --head flag, so the
+// old invocation always errored and GetPRForBranch always returned nil.
+func TestGetPRForBranch_PositionalBranch(t *testing.T) {
+	installFakeGh(t, fakeGhPRView)
+
+	adapter := NewGitHubAdapter("test-org/test-repo")
+	pr, err := adapter.GetPRForBranch("feature-branch")
+	if err != nil {
+		t.Fatalf("GetPRForBranch() error = %v", err)
+	}
+	if pr == nil {
+		t.Fatal("GetPRForBranch() = nil, want PR #42")
+	}
+	if pr.Number != 42 {
+		t.Errorf("pr.Number = %d, want 42", pr.Number)
+	}
+	if pr.State != "open" {
+		t.Errorf("pr.State = %q, want %q", pr.State, "open")
+	}
+	if pr.URL != "https://github.com/test-org/test-repo/pull/42" {
+		t.Errorf("pr.URL = %q", pr.URL)
+	}
+}
+
+func TestGetPRForBranch_NoPR(t *testing.T) {
+	installFakeGh(t, fakeGhPRView)
+
+	adapter := NewGitHubAdapter("test-org/test-repo")
+	pr, err := adapter.GetPRForBranch("branch-without-pr")
+	if err != nil {
+		t.Fatalf("GetPRForBranch() error = %v, want nil (no PR is not an error)", err)
+	}
+	if pr != nil {
+		t.Errorf("GetPRForBranch() = %+v, want nil", pr)
+	}
+}
 
 func TestNewGitHubAdapter(t *testing.T) {
 	adapter := NewGitHubAdapter("owner/repo")

--- a/plugins/tracker/github_test.go
+++ b/plugins/tracker/github_test.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -209,5 +210,92 @@ func TestDetectRepo_Integration(t *testing.T) {
 
 	if repo == "" {
 		t.Error("DetectRepo() returned empty string")
+	}
+}
+
+func TestGhIssue_ToIssue(t *testing.T) {
+	raw := `{
+		"number": 7,
+		"title": "Test Issue",
+		"body": "body text",
+		"state": "OPEN",
+		"author": {"login": "octocat"},
+		"labels": [{"name": "bug"}, {"name": "help wanted"}],
+		"url": "https://github.com/test-org/test-repo/issues/7"
+	}`
+	var gh ghIssue
+	if err := json.Unmarshal([]byte(raw), &gh); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	issue := gh.toIssue()
+	if issue.Number != 7 {
+		t.Errorf("Number = %d, want 7", issue.Number)
+	}
+	if issue.State != "open" {
+		t.Errorf("State = %q, want %q (should be lowercased)", issue.State, "open")
+	}
+	if issue.Author != "octocat" {
+		t.Errorf("Author = %q, want octocat", issue.Author)
+	}
+	if len(issue.Labels) != 2 || issue.Labels[0] != "bug" || issue.Labels[1] != "help wanted" {
+		t.Errorf("Labels = %v, want [bug, help wanted]", issue.Labels)
+	}
+}
+
+func TestGhPR_ToPullRequest(t *testing.T) {
+	raw := `{
+		"number": 42,
+		"title": "Test PR",
+		"state": "MERGED",
+		"author": {"login": "octocat"},
+		"labels": [{"name": "enhancement"}],
+		"headRefName": "feature-branch",
+		"baseRefName": "main",
+		"isDraft": true,
+		"commits": [
+			{"oid": "0123456789abcdef0123456789abcdef01234567", "messageHeadline": "first"},
+			{"oid": "abc1234", "messageHeadline": "short sha kept as-is"}
+		],
+		"additions": 10,
+		"deletions": 3,
+		"reviewDecision": "APPROVED",
+		"url": "https://github.com/test-org/test-repo/pull/42"
+	}`
+	var gh ghPR
+	if err := json.Unmarshal([]byte(raw), &gh); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	pr := gh.toPullRequest()
+	if pr.Number != 42 {
+		t.Errorf("Number = %d, want 42", pr.Number)
+	}
+	if pr.State != "merged" {
+		t.Errorf("State = %q, want %q (should be lowercased)", pr.State, "merged")
+	}
+	if pr.Branch != "feature-branch" || pr.BaseBranch != "main" {
+		t.Errorf("Branch = %q, BaseBranch = %q", pr.Branch, pr.BaseBranch)
+	}
+	if !pr.IsDraft {
+		t.Error("IsDraft = false, want true")
+	}
+	if pr.CommitCount != 2 || len(pr.Commits) != 2 {
+		t.Fatalf("CommitCount = %d, Commits = %v", pr.CommitCount, pr.Commits)
+	}
+	if pr.Commits[0].SHA != "0123456" {
+		t.Errorf("Commits[0].SHA = %q, want truncated %q", pr.Commits[0].SHA, "0123456")
+	}
+	if pr.Commits[1].SHA != "abc1234" {
+		t.Errorf("Commits[1].SHA = %q, want %q", pr.Commits[1].SHA, "abc1234")
+	}
+	if pr.Additions != 10 || pr.Deletions != 3 {
+		t.Errorf("Additions = %d, Deletions = %d", pr.Additions, pr.Deletions)
+	}
+	if pr.ReviewDecision != "APPROVED" {
+		t.Errorf("ReviewDecision = %q, want APPROVED", pr.ReviewDecision)
+	}
+	if len(pr.Labels) != 1 || pr.Labels[0] != "enhancement" {
+		t.Errorf("Labels = %v, want [enhancement]", pr.Labels)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the verified plugin findings from the repo audit (issue #119) plus the docker-status portion of the perf audit (#120).

- **tracker**: `GetPRForBranch` used the nonexistent `gh pr view --head` flag, so PR lookup always failed and `grove browse` silently fell back to the compare page. The branch is now passed positionally, with a regression test whose fake `gh` rejects `--head` the way the real CLI does.
- **docker**: status display now uses the 300ms status timeout instead of the 3s probe timeout, keeping `grove ls` inside the <500ms budget in external mode; the mount-drift check now layers `.env` under the configured env file via the shared `composeEnvFileArgs` path instead of a hand-rolled `--env-file`; stale compose-v1 wording removed from the Init error.
- **DRY**: deduplicated the switch-hook gate/prompt flow between local and external strategies, and the duplicated GitHub response structs/mapping in the tracker.

Closes #119. Refs #120 (docker portion; git-exec portions land separately).

Notes:
- `GetPRForBranch` still treats every `gh` failure as "no PR" (pre-existing); tightening error handling was out of scope.
- CHANGELOG entries for the audit fixes are deferred to a single follow-up to avoid six PRs conflicting in the Unreleased section.

## Type of Change

- [x] Bug fix
- [x] Refactoring (no functional change)

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter is clean (`make lint`)
- [x] Documentation updated (if applicable — see CONTRIBUTING.md)
- [x] Commit messages follow conventional commits (`type(scope): description`)
