### PR TITLE
docs: align command, agent, and configuration references with the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ export GROVE_TUI=0               # disable dashboard; bare `grove` prints usage
 | `grove context` | Rich status: ahead/behind, stash count, recent commits | ✓ | — |
 | `grove test <name>` | Run configured tests in another worktree without switching (aliases: `tt`) | — | — |
 | `grove ps` | List active isolated Docker slots (aliases: `agent-status`) | ✓ | — |
-| `grove up` | Start Docker stack; `--isolated [--slot N]` for per-agent stacks (aliases: `u`) | — | ✓ |
-| `grove down` | Stop Docker stack; `--slot N` for isolated stacks | — | ✓ |
+| `grove up` | Start Docker stack; `--isolated` for per-agent stacks (aliases: `u`) | — | ✓ |
+| `grove down` | Stop Docker stack; isolated stacks are auto-detected | — | ✓ |
 | `grove rm [name]` | Remove worktree + branch + tmux + Docker (aliases: `remove`, `delete`) | — | ✓ |
 | `grove doctor [worktree]` | Health check; inspect output before `grove new` in unknown repos | — | — |
 
@@ -102,11 +102,15 @@ allowing any worktree creation or switching. Do not assume a repo's hooks are sa
 ### Review a GitHub PR non-destructively
 
 ```bash
-grove fetch pr/42                   # creates worktree grove-{project}-pr-42 (needs `gh`)
-grove to grove-project-pr-42 --peek # cd only — skips hooks and tmux entirely
+grove fetch pr/42          # creates worktree pr-42-<title-slug> (needs `gh`)
+                           # fetch prints the generated name — use that, don't guess it
+grove to pr-42-fix-login-bug --peek # cd only — skips hooks and tmux entirely
 # read files, run grep, etc.
-grove rm grove-project-pr-42        # teardown
+grove rm pr-42-fix-login-bug        # teardown
 ```
+
+`grove fetch` names the worktree `pr-<N>-<title-slug>` (slug from the PR title). Take
+the exact name from fetch's own output or `grove ls`, never hardcode it.
 
 ### New feature branch
 
@@ -115,8 +119,8 @@ Clean up when done: `grove rm auth`.
 
 ### Run tests in another worktree without leaving current
 
-`grove test cache-redesign` runs the configured test command there. Pass extra args
-after `--`: `grove test cache-redesign -- -run TestFoo`.
+`grove test cache-redesign` runs the configured test command there. Extra args are
+appended verbatim (no `--` separator): `grove test cache-redesign -run TestFoo`.
 
 ### Cheap state probes
 
@@ -132,9 +136,9 @@ unique port offsets:
 
 ```bash
 grove ps --json                     # discover active slots: [{slot, worktree, compose_project, url}]
-grove up --isolated --slot 2        # start an isolated stack on slot 2
+grove up --isolated                 # start an isolated stack (auto-allocates a slot)
 # ... work in this worktree ...
-grove down --slot 2                 # release slot when done
+grove down                          # release the stack (isolated stacks auto-detected)
 ```
 
 The `[plugins.docker.external.agent] max_slots` config value caps the number of

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ grove down               # stop the current worktree's isolated stack
 ```toml
 [plugins.docker.external.agent]
 max_slots = 5
-url_pattern = "http://localhost:{port}"
+url_pattern = "http://localhost:{slot}"  # {slot} = slot number; empty disables URL display
 ```
 
 See [plugins/docker/README.md](plugins/docker/README.md) for the full reference.

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -218,7 +218,7 @@ grove new <name>
 
 What happens:
 1. Creates a git worktree at `../{project}-{name}/`
-2. Creates a branch named `{name}` (configurable via `[naming] pattern`)
+2. Creates a branch named `{name}` (override with `--branch`; `[naming] pattern` controls the directory name, not the branch)
 3. Fires `post_create` hooks (copy credentials, symlink deps, etc.)
 4. Creates a tmux session named `{project}-{name}` (if tmux mode is not `off`)
 
@@ -330,9 +330,11 @@ What happens:
 
 ```bash
 grove fetch pr/42
-# Fetched branch: feature/auth-refactor (PR #42)
-# Created worktree: myapp-pr-42
+# Created worktree 'pr-42-auth-refactor' from branch 'feature/auth-refactor'
 ```
+
+The worktree is named `pr-<N>-<title-slug>` (issue fetches use `issue-<N>-<title-slug>`).
+Take the exact name from fetch's output or `grove ls` — don't guess it.
 
 Interactive browsers: `grove prs`, `grove issues` — TUI lists with fuzzy search, press Enter to fetch.
 
@@ -400,11 +402,11 @@ Protected worktrees (`main`, `develop`, or any name in `[protection] protected`)
 
 **Remove stale worktrees in bulk:**
 ```bash
-grove trim           # removes worktrees not accessed in 30 days
-grove trim --days 7  # shorter threshold
+grove trim                 # removes worktrees not accessed in 30 days
+grove trim --older-than 7  # shorter threshold
 ```
 
-The `clean` alias also works (`grove clean --days 7`), but `trim` is the canonical name.
+The `clean` alias also works (`grove clean --older-than 7`), but `trim` is the canonical name.
 
 Stale = `LastAccessedAt` older than threshold and no dirty changes. Protected worktrees are skipped.
 
@@ -555,23 +557,22 @@ Multiple agents can each run their own independent Docker stack with port offset
 
 ```bash
 grove up --isolated          # allocate next available slot
-grove up --isolated --slot 3 # specific slot
 
 grove agent-status           # table of active stacks
 grove agent-status --json    # machine-readable
 
-grove down --slot 2          # stop specific stack
+grove down                   # stop the stack (isolated stacks auto-detected from cwd)
 grove ps                     # show running stacks with reference IDs and URLs
 ```
 
-Each isolated stack gets a unique compose project name (`{project}-{worktree}-slot-{N}`) and port-offset containers.
+Each isolated stack gets a unique compose project name (`{project}-agent-{N}`) and port-offset containers.
 
 Configure max concurrent stacks:
 ```toml
 [plugins.docker.external.agent]
 max_slots = 5
 network = "shared"
-url_pattern = "http://localhost:{port}"
+url_pattern = "http://localhost:{slot}"  # {slot} is the slot number; empty disables URL display
 ```
 
 See §7 for agent workflow patterns using isolated stacks.
@@ -598,10 +599,10 @@ Config is loaded in layers (later overrides earlier):
 dirty_handling = "prompt"
 
 [naming]
-# Branch name pattern when creating worktrees
-# Tokens: {type}, {description}
-# Default creates branch matching the worktree short name
-# pattern = "{type}/{description}"
+# Worktree directory naming template
+# Must contain {project} and {name} exactly once each; literals limited to [A-Za-z0-9._-]
+# Branch names are not affected (the branch is named after the worktree, or --branch)
+# pattern = "{project}-{name}"  # default
 
 [tmux]
 # "auto" (default) | "manual" | "off"
@@ -638,7 +639,7 @@ auto_stop = false
 # [plugins.docker.external.agent]
 # max_slots = 5
 # network = "shared"
-# url_pattern = "http://localhost:{port}"
+# url_pattern = "http://localhost:{slot}"  # {slot} = slot number; empty disables URL display
 
 [protection]
 # Worktrees that require --force to remove
@@ -720,14 +721,17 @@ grove up --isolated               # gets slot 2
 
 # Check what's running
 grove agent-status --json
-# [{"slot":1,"project":"myapp-agent-task-1-slot-1","status":"running","ports":[3101,3111]},
-#  {"slot":2,"project":"myapp-agent-task-2-slot-2","status":"running","ports":[3102,3112]}]
+# [{"slot":1,"worktree":"agent-task-1","compose_project":"myapp-agent-1","url":"http://localhost:3101"},
+#  {"slot":2,"worktree":"agent-task-2","compose_project":"myapp-agent-2","url":"http://localhost:3102"}]
+# (`url` is omitted when no url_pattern is configured)
 
-# When done, clean up
-grove down --slot 1
+# When done, clean up (run `grove down` inside each worktree — its stack is auto-detected)
+cd ../myapp-agent-task-1
+grove down
 grove rm agent-task-1
 
-grove down --slot 2
+cd ../myapp-agent-task-2
+grove down
 grove rm agent-task-2
 ```
 
@@ -740,17 +744,18 @@ export GROVE_AGENT_MODE=1
 
 # Fetch the PR branch as a new worktree (no switch, no hooks that affect active stack)
 grove fetch pr/42
+# Created worktree 'pr-42-fix-login-bug' ... — use the exact name it prints
 
 # Peek into it without firing hooks
-grove to pr-42 --peek
+grove to pr-42-fix-login-bug --peek
 
 # Run tests in the PR worktree without leaving current context
-grove test pr-42
-# or with extra args:
-grove test pr-42 -- --tag focus
+grove test pr-42-fix-login-bug
+# or with extra args (appended verbatim — no `--` separator):
+grove test pr-42-fix-login-bug --tag focus
 
 # When done
-grove rm pr-42
+grove rm pr-42-fix-login-bug
 ```
 
 ### Configuring for Agent Use

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -1247,7 +1247,7 @@ When no Docker is configured, the `services` field is `null`/omitted.
 
 ## State Commands
 
-> No user-facing state commands are currently registered. The `internal/state` package exposes freeze/resume logic, but no cobra commands wire it to the CLI. See the [Planned Commands](#planned-not-yet-implemented) section for the design.
+> No user-facing state commands are currently registered, and no freeze/resume logic is implemented — the `internal/state` package only tracks worktree metadata. See the [Planned Commands](#planned-not-yet-implemented) section for the freeze/resume design.
 
 ---
 
@@ -2412,7 +2412,7 @@ The annotation honors the same opt-outs as `grove`'s other update surfaces (env 
 
 ## Planned (not yet implemented)
 
-These commands are referenced in `internal/state` but not yet wired to user-facing cobra commands. The spec is preserved here so the design is recoverable when implementation lands.
+These commands are not implemented — no freeze/resume logic exists in code (a future-API sketch lives in `internal/state/README.md`). The spec is preserved here so the design is recoverable when implementation lands.
 
 ### grove freeze
 

--- a/docs/COMMAND_SPECIFICATIONS.md
+++ b/docs/COMMAND_SPECIFICATIONS.md
@@ -512,9 +512,9 @@ Flags:
 2. **Check dirty state** (unless `--peek`):
    - Inspect the *current* worktree for uncommitted changes (`git status --porcelain`)
    - Behavior controlled by `switch.dirty_handling` in `.grove/config.toml`:
-     - `"refuse"` (default): Block the switch, list dirty files, suggest committing/stashing or changing config
+     - `"prompt"` (default): In interactive mode (TTY), show dirty files and ask "Switch anyway?". In non-interactive mode, fall back to refuse behavior
      - `"auto-stash"`: Automatically run `git stash push -m "grove: auto-stash before switch to {name}"`, then proceed
-     - `"prompt"`: In interactive mode (TTY), show dirty files and ask "Switch anyway?". In non-interactive mode, fall back to refuse behavior
+     - `"refuse"`: Block the switch, list dirty files, suggest committing/stashing or changing config
    - If the dirty check itself fails (e.g., git error), treat the worktree as clean and proceed — never block the user on a failed status check
    - `--peek` always bypasses dirty checks (peek is a lightweight switch with no side effects)
 
@@ -1261,16 +1261,12 @@ When no Docker is configured, the `services` field is `null`/omitted.
 
 **Usage:**
 ```
-grove up [services...] [flags]
-
-Arguments:
-  services    Specific services to start (default: all)
+grove up [flags]
 
 Flags:
   -d, --detach    Run in background (default: true)
-      --build     Build images before starting
-      --isolated  Start an isolated stack (for parallel agents)
-      --slot N    Use a specific slot number (implies --isolated)
+      --isolated  Start an isolated stack with its own containers and database
+                  (for parallel agents; a slot is allocated automatically)
 ```
 
 **Behavior:**
@@ -1306,13 +1302,10 @@ All containers running. Web available at http://localhost:3001
 
 **Usage:**
 ```
-grove down [services...] [flags]
+grove down
 
-Arguments:
-  services    Specific services to stop (default: all)
-
-Flags:
-  -v, --volumes    Also remove volumes
+(no flags — if the worktree has an isolated stack running, it is
+auto-detected and torn down)
 ```
 
 **Output:**
@@ -1339,8 +1332,7 @@ Arguments:
   service    Service to show logs for (default: all)
 
 Flags:
-  -f, --follow    Follow log output
-  -n, --tail N    Number of lines to show (default: 100)
+  -f, --follow    Follow log output (default: true; pass -f=false to disable)
 ```
 
 **Behavior:**
@@ -1925,38 +1917,39 @@ Add a [test] section to .grove/config.toml:
 grove config [flags]
 
 Flags:
-      --edit     Open config file in $EDITOR
-      --path     Just print config file path
-  -j, --json     Output as JSON
+  -e, --edit     Open config file in $EDITOR
+  -g, --global   Use global config (~/.config/grove/config.toml) instead of project config
+      --hooks    Work with hooks config (.grove/hooks.toml) instead of main config
 ```
+
+Show mode prints a single `Config file:` path — the project config by default,
+or the global config with `--global`. Combine `--hooks` with `-e` to edit
+`.grove/hooks.toml`; `--hooks` alone prints its contents.
 
 **Output (Default):**
 ```
-Configuration for 'grove'
+Configuration
+  Config file: ~/projects/grove/.grove/config.toml
 
-Global: ~/.config/grove/config.toml
-Local:  ~/projects/grove/.grove/config.toml (not found)
+General:
+  alias: w
+  projects_dir: ~/projects
+  default_base_branch: main
 
-Settings:
-  alias:            w
-  projects_dir:     ~/projects
-  default_branch:   main
+[switch]:
+  dirty_handling: prompt
 
-Switch:
-  dirty_handling:   prompt
+[naming]:
+  pattern: {project}-{name}
 
-Naming:
-  pattern:          {project}-{name}
+[tmux]:
+  mode: auto
+  prefix:
 
-Tmux:
-  prefix:           (none, uses naming pattern)
-  layout:           default
-
-Docker:
-  enabled:          true
-  auto_up:          true
-  port_base:        3000
-  port_range:       100
+[plugins.docker]:
+  enabled: true
+  auto_start: true
+  auto_stop: false
 ```
 
 ---

--- a/docs/CONFIGURATION_REFERENCE.md
+++ b/docs/CONFIGURATION_REFERENCE.md
@@ -136,9 +136,10 @@ Controls tmux session management. Requires tmux to be installed.
 # "off"    — disable tmux integration entirely
 mode = "auto"                      # string: auto | manual | off
 
-# Prefix for tmux session names. If set, sessions are named "{prefix}-{worktree}".
-# Default: "" (no prefix; session name equals the full worktree name)
-prefix = ""                        # string
+# DEPRECATED/INERT: parsed and shown by `grove config`, but never applied.
+# Tmux session names always use the canonical "{project}-{name}" form
+# regardless of this value (see the [naming] section above).
+prefix = ""                        # string (no effect)
 
 # How grove handles directory drift when switching tmux sessions.
 # "reset"  — cd the session to the worktree root on switch (default)
@@ -167,7 +168,9 @@ Configures `grove test` command behavior.
 command = "go test ./..."          # string
 
 # Docker Compose service name to run tests inside.
-# When set, grove runs the command via `docker compose exec <service> <command>`.
+# When set, grove runs the command in an ephemeral container via
+# `docker compose run --rm <service> bash -cil <command>`
+# (with --no-deps unless include_deps is set, and -v when bind_mount is set).
 # Requires the docker plugin to be configured.
 service = "app"                    # string
 
@@ -282,7 +285,7 @@ enabled = true                     # bool
 auto_start = true                  # bool
 
 # Automatically stop services when switching away from a worktree.
-# Default: false (local mode), true (external mode)
+# Default: false
 auto_stop = false                  # bool
 
 # Auto-start Docker on `grove new` (runs `docker compose up` after worktree creation).
@@ -407,13 +410,13 @@ template_path = "~/work/compose-dev/agent-compose.yml"  # string (required when 
 template_overlays = ["overrides/dev.yml"]  # string array (optional)
 
 # URL pattern for accessing agent services.
-# {port} is replaced with the allocated port.
-# Default: "http://localhost:{port}"
-url_pattern = "http://localhost:{port}"  # string
+# {slot} is replaced with the slot number (grove does not allocate ports).
+# Default: "" (empty — no URL is displayed)
+url_pattern = "http://localhost:{slot}"  # string
 
 # External Docker network that agent stacks attach to.
 # The network must already exist before grove can create agent stacks.
-# Default: "shared"
+# Default: "" (empty — the network-existence check is skipped)
 network = "shared"                 # string
 ```
 
@@ -915,7 +918,7 @@ enabled       = true
 max_slots     = 8
 services      = ["web", "worker"]
 template_path = "~/work/compose-dev/agent-compose.yml"
-url_pattern   = "http://localhost:{port}"
+url_pattern   = "http://localhost:{slot}"
 network       = "shared"
 ```
 

--- a/docs/DATA_FLOWS.md
+++ b/docs/DATA_FLOWS.md
@@ -15,7 +15,7 @@ Config
   ProjectsDir   string           # default: ~/projects
   DefaultBranch string           # default: "main"
   Switch        SwitchConfig     # dirty_handling: "prompt" | "auto-stash" | "refuse"
-  Naming        NamingConfig     # pattern: "{type}/{description}"
+  Naming        NamingConfig     # pattern: "{project}-{name}" (worktree directory template)
   Tmux          TmuxConfig       # mode: "auto" | "manual" | "off", prefix: ""
   Plugins       PluginsConfig    # docker plugin config
   Protection    ProtectionConfig # protected/immutable worktree lists
@@ -24,6 +24,7 @@ Config
   NoColor        bool            # runtime only (GROVE_NO_COLOR)
   Debug          bool            # runtime only (GROVE_DEBUG)
   NonInteractive bool            # runtime only (GROVE_NONINTERACTIVE)
+  AgentMode      bool            # runtime only (GROVE_AGENT_MODE)
 ```
 
 **Load chain** (each layer overrides the previous):
@@ -32,15 +33,17 @@ Config
 graph LR
     A[LoadDefaults] --> B[Global config]
     B --> C[Project config]
-    C --> D[Env var overrides]
-    D --> E[Validate]
+    C --> D[Local overlay]
+    D --> E[Env var overrides]
+    E --> F[Validate]
 ```
 
 1. **Defaults** -- `LoadDefaults()` in `defaults.go` returns hardcoded defaults
 2. **Global config** -- `~/.config/grove/config.toml` (overridden by `GROVE_CONFIG` env var)
 3. **Project config** -- `.grove/config.toml` in the project root (or `groveDir/config.toml` when loaded via `LoadFromGroveDir`)
-4. **Environment overrides** -- `GROVE_NO_COLOR`, `GROVE_DEBUG`, `GROVE_NONINTERACTIVE` (runtime-only, not persisted)
-5. **Validation** -- `Validate()` in `validate.go` checks required fields and enum values
+4. **Local overlay** -- `.grove/config.local.toml` (gitignored, per-developer overrides)
+5. **Environment overrides** -- `GROVE_NO_COLOR`, `GROVE_DEBUG`, `GROVE_NONINTERACTIVE`, `GROVE_AGENT_MODE` (runtime-only, not persisted)
+6. **Validation** -- `Validate()` in `validate.go` checks required fields and enum values
 
 **Merge behavior:** `mergeConfigs()` does field-by-field override -- non-zero/non-nil values in the override replace the base. Protection lists (`Protected`, `Immutable`) use **deduplicated union** semantics -- project-level protections are merged with global protections so that global protections are never silently lost (CF-5 resolved).
 

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -37,8 +37,6 @@ Plugins register hooks to run at specific lifecycle events:
 - `post-create` - After worktree creation
 - `pre-switch` - Before switching away from worktree
 - `post-switch` - After switching to worktree
-- `pre-freeze` - Before freezing worktree
-- `post-resume` - After resuming frozen worktree
 - `pre-remove` - Before removing worktree
 - `post-remove` - After worktree removal
 
@@ -148,14 +146,14 @@ service    = "app"                    # required: compose service name
 command    = "bundle install --quiet" # required: shell command run inside the container
 mode       = "run"                    # optional: "run" (default, ephemeral) | "exec" (existing container)
 timeout    = 300                      # optional: seconds (default 60); applied by executor, not the handler
-on_failure = "warn"                   # optional: "fail" (default) | "warn" | "ignore"
+on_failure = "warn"                   # optional: "warn" (default) | "fail" | "ignore"
 ```
 
 Field reference (matches `HookAction` in `internal/hooks/config.go`):
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `service` | yes | Compose service name; supports `${VAR}` interpolation |
+| `service` | yes | Compose service name; supports `{{.variable}}` interpolation (e.g. `{{.worktree}}`, `{{.branch}}`) |
 | `command` | yes | Shell command run inside the container |
 | `mode` | no | `"run"` brings up service deps on demand; `"exec"` requires a running container and fails with a hint if the stack is down |
 | `timeout` | no | Per-action timeout (seconds), enforced by the hook executor |
@@ -250,26 +248,31 @@ func (p *MyPlugin) onPostSwitch(ctx *hooks.Context) error {
 
 ### 3. Register Plugin
 
-Add your plugin to the main initialization in `cmd/grove/main.go`:
+Lifecycle plugins are registered once per process by `registerPlugins()` in
+`cmd/grove/commands/context.go` (invoked from the `RequireGroveContext`
+middleware). Add your plugin there, registering it with the `plugins.Manager`
+and hooking into `hooks.GlobalRegistry()`:
 
 ```go
+// cmd/grove/commands/context.go, inside registerPlugins()
 import (
     myplugin "github.com/lost-in-the/grove/plugins/myplugin"
 )
 
-func initializePlugins(cfg *config.Config, registry *hooks.Registry) error {
-    p := myplugin.New()
-    if err := p.Init(cfg); err != nil {
-        return fmt.Errorf("myplugin: %w", err)
+myPlugin := myplugin.New()
+if err := mgr.Register(myPlugin); err != nil {
+    // plugin unavailable — skip (registration failures are non-fatal)
+    return mgr
+}
+if myPlugin.Enabled() {
+    if err := myPlugin.RegisterHooks(hooks.GlobalRegistry()); err != nil {
+        log.Printf("failed to register myplugin hooks: %v", err)
     }
-    if p.Enabled() {
-        if err := p.RegisterHooks(registry); err != nil {
-            return fmt.Errorf("myplugin hooks: %w", err)
-        }
-    }
-    return nil
 }
 ```
+
+Note: `plugins.Manager.Register` calls your plugin's `Init(cfg)` for you, and
+registration failures are logged/skipped rather than aborting the command.
 
 ### 4. Add Tests
 


### PR DESCRIPTION
## Summary

Documentation-only: realigns command specs, agent guides, and configuration/plugin/data-flow references with the actual code (audit issues #122, #123). Highlights:

- Removed/corrected flags that don't exist (`grove up/down --slot`, `grove config --path`/`--json`, `grove trim --days` → `--older-than`, `grove test` `--` handling).
- Corrected defaults (`switch.dirty_handling` is `prompt`, docker `on_failure` is `warn`, `auto_stop` effective default), `url_pattern` `{port}` → `{slot}`, `[tmux] prefix` marked inert, removed nonexistent `pre-freeze`/`post-resume` hooks, fixed the naming-pattern description and `config.local.toml` layering in DATA_FLOWS, plugin registration location.

Closes #122. Closes #123.

Intentionally not touched (out of scope, follow-up candidates): `plugins/docker/README.md` has the same `{port}` drift; `internal/state/README.md` documents a removed Freeze/Resume API; one historical dated plan doc under `docs/superpowers/plans/` left as a point-in-time record.

## Type of Change

- [x] Documentation

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter is clean (`make lint`)
- [x] Documentation updated (if applicable — see CONTRIBUTING.md)
- [x] Commit messages follow conventional commits (`type(scope): description`)
