### PR TITLE
fix(core): worktree resolution, config layering, state races, tmux targets, update check

### DIFF
--- a/cmd/grove/commands/root.go
+++ b/cmd/grove/commands/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -105,7 +106,15 @@ Use 'grove install --help' for details.`,
 			return nil
 		}
 		updatecheck.MaybeNotify(os.Stderr, version.Version)
-		updatecheck.RefreshAsync()
+		// Wait (bounded) for the async refresh: the process exits right
+		// after this hook, and exiting kills the goroutine before it can
+		// fetch and write the cache. The wait is a no-op when the cache is
+		// fresh (the goroutine returns immediately without touching the
+		// network).
+		select {
+		case <-updatecheck.RefreshAsync():
+		case <-time.After(updatecheck.RefreshWaitBudget):
+		}
 		return nil
 	},
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,12 +55,16 @@ dirty_handling = "auto-stash"
 			},
 		},
 		{
-			name:       "empty config uses defaults",
+			// A file that doesn't set a field must leave it at the zero
+			// value — defaults enter the merge chain once, in Load/
+			// LoadFromGroveDir, so mergeConfigs can tell "file set this"
+			// apart from "default filled this".
+			name:       "empty config leaves fields unset",
 			configData: ``,
 			wantErr:    false,
 			validate: func(t *testing.T, cfg *Config) {
-				if cfg.Alias != "w" {
-					t.Errorf("Expected default alias 'w', got '%s'", cfg.Alias)
+				if cfg.Alias != "" {
+					t.Errorf("Expected unset alias, got '%s'", cfg.Alias)
 				}
 			},
 		},
@@ -1527,5 +1531,62 @@ non_blocking_services = ["asset_precompile", "db_seed"]
 		if ext.NonBlockingServices[i] != w {
 			t.Errorf("NonBlockingServices[%d]: got %q want %q", i, ext.NonBlockingServices[i], w)
 		}
+	}
+}
+
+// TestLoadFromPaths_HigherLayerDoesNotResetLowerLayerSettings is the
+// regression test for per-file default seeding: the mere existence of a
+// project config must not reset explicit global settings the project file
+// doesn't mention back to built-in defaults.
+func TestLoadFromPaths_HigherLayerDoesNotResetLowerLayerSettings(t *testing.T) {
+	t.Setenv("GROVE_CONFIG", "")
+
+	tmpDir := t.TempDir()
+
+	globalPath := filepath.Join(tmpDir, "global", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(globalPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	globalToml := `default_base_branch = "develop"
+
+[tmux]
+mode = "off"
+
+[plugins.docker]
+enabled = false
+`
+	if err := os.WriteFile(globalPath, []byte(globalToml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectPath := filepath.Join(tmpDir, "proj", ".grove", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(projectPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Project file mentions ONLY project_name.
+	if err := os.WriteFile(projectPath, []byte("project_name = \"myproj\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadFromPaths(LoadDefaults(), globalPath, projectPath, "")
+	if err != nil {
+		t.Fatalf("loadFromPaths() error = %v", err)
+	}
+
+	if cfg.ProjectName != "myproj" {
+		t.Errorf("ProjectName = %q, want %q", cfg.ProjectName, "myproj")
+	}
+	if cfg.DefaultBranch != "develop" {
+		t.Errorf("DefaultBranch = %q, want global %q (clobbered by project layer's phantom defaults)", cfg.DefaultBranch, "develop")
+	}
+	if cfg.Tmux.Mode != "off" {
+		t.Errorf("Tmux.Mode = %q, want global %q", cfg.Tmux.Mode, "off")
+	}
+	if cfg.Plugins.Docker.Enabled == nil || *cfg.Plugins.Docker.Enabled {
+		t.Errorf("Plugins.Docker.Enabled = %v, want global false", cfg.Plugins.Docker.Enabled)
+	}
+	// And defaults still fill fields no layer set.
+	if cfg.Alias != "w" {
+		t.Errorf("Alias = %q, want default %q", cfg.Alias, "w")
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -45,9 +45,16 @@ func LoadDefaults() *Config {
 	}
 }
 
-// LoadConfigFromPath loads configuration from a specific file path
+// LoadConfigFromPath parses a single config file into a zero-value Config.
+//
+// Fields the file does not mention stay at their zero values — deliberately
+// NOT seeded from LoadDefaults(). mergeConfigs treats non-empty / non-nil
+// fields as explicit overrides, so seeding defaults here would make every
+// config file appear to set every field, silently resetting lower-priority
+// layers' explicit settings back to the defaults. Defaults enter the merge
+// chain exactly once, as the base config in Load/LoadFromGroveDir.
 func LoadConfigFromPath(path string) (*Config, error) {
-	cfg := LoadDefaults()
+	cfg := &Config{}
 
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,8 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 )
 
 const dockerModeExternal = "external"
@@ -114,15 +112,14 @@ func validateExternalRequiredFields(ext *ExternalComposeConfig) error {
 	return nil
 }
 
-// validateExternalPath validates the external docker path exists and is a directory
+// validateExternalPath validates the external docker path exists and is a
+// directory. In the standard load path ext.Path is already absolute
+// (resolveProjectPaths runs before Validate); expandTildePath keeps Validate
+// safe for raw, unresolved configs without duplicating the expansion logic.
 func validateExternalPath(ext *ExternalComposeConfig) error {
-	path := ext.Path
-	if strings.HasPrefix(path, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("plugins.docker.external.path: failed to expand ~: %w", err)
-		}
-		path = filepath.Join(home, path[2:])
+	path, err := expandTildePath(ext.Path)
+	if err != nil {
+		return fmt.Errorf("plugins.docker.external.path: %w", err)
 	}
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -55,9 +55,12 @@ default_base_branch = "develop"
 		if cfg.DefaultBranch != "develop" {
 			t.Errorf("DefaultBranch = %q, want %q", cfg.DefaultBranch, "develop")
 		}
-		// Defaults should be preserved for unset values
-		if cfg.Tmux.Mode != "auto" {
-			t.Errorf("Tmux.Mode = %q, want default %q", cfg.Tmux.Mode, "auto")
+		// Unset values must stay at zero — defaults are applied once as the
+		// base of the merge chain, not per file. Seeding defaults here would
+		// make every file look like it explicitly set every field, clobbering
+		// lower-priority layers in mergeConfigs.
+		if cfg.Tmux.Mode != "" {
+			t.Errorf("Tmux.Mode = %q, want unset (zero value)", cfg.Tmux.Mode)
 		}
 	})
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -53,7 +53,7 @@ type DetectionRule struct {
 // DefaultRules returns the built-in detection rules, checked in order.
 // Multiple rules can match, resulting in a "mixed" project type.
 func DefaultRules() []DetectionRule {
-	return []DetectionRule{
+	rules := []DetectionRule{
 		{
 			Marker:   "Gemfile",
 			Type:     "rails",
@@ -87,12 +87,21 @@ func DefaultRules() []DetectionRule {
 			Symlinks: []string{".venv"},
 			Commands: []string{"pip install -e ."},
 		},
-		{
-			Marker: "docker-compose.yml",
+	}
+
+	// Docker matches every compose filename FindComposeFile accepts (see
+	// composeFiles in compose.go), so the detected Type agrees with
+	// HasDocker for modern names like compose.yaml, not just the legacy
+	// docker-compose.yml. Duplicate matches dedupe via resolveProjectType.
+	for _, marker := range composeFiles {
+		rules = append(rules, DetectionRule{
+			Marker: marker,
 			Type:   "docker",
 			Copy:   []string{".env"},
-		},
+		})
 	}
+
+	return rules
 }
 
 // Detect scans the given directory for marker files and returns a ProjectProfile

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -257,3 +257,34 @@ func assertContains(t *testing.T, slice []string, item string) {
 	}
 	t.Errorf("expected %v to contain %q", slice, item)
 }
+
+func TestDetect_ModernComposeFilenames(t *testing.T) {
+	// Regression: the docker rule only matched docker-compose.yml, while
+	// HasDocker/FindComposeFile accept four filenames — so compose.yaml-only
+	// repos were typed "unknown" despite HasDocker being true.
+	for _, filename := range []string{"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"} {
+		t.Run(filename, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, filename, "services:\n  app:\n    image: x\n")
+
+			profile := Detect(dir)
+			if profile.Type != "docker" {
+				t.Errorf("Type = %q, want %q", profile.Type, "docker")
+			}
+			if !profile.HasDocker {
+				t.Error("HasDocker = false, want true")
+			}
+		})
+	}
+}
+
+func TestDetect_MixedWithModernComposeFilename(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Gemfile", "source 'https://rubygems.org'")
+	writeFile(t, dir, "compose.yaml", "services:\n  app:\n    image: x\n")
+
+	profile := Detect(dir)
+	if profile.Type != "mixed" {
+		t.Errorf("Type = %q, want %q", profile.Type, "mixed")
+	}
+}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -50,12 +50,15 @@ func (b *BranchManager) GetStatus(branch string, excludeWorktree string) (*Branc
 	}
 	status.IsMerged = merged
 
-	// Check if branch has a remote tracking branch
-	status.HasRemote = b.hasRemoteTracking(branch)
+	// Resolve the upstream once and reuse it for both the has-remote check
+	// and the unpushed count — previously two identical `git rev-parse`
+	// executions per branch.
+	upstream := b.getUpstream(branch)
+	status.HasRemote = upstream != ""
 
 	// Count unpushed commits if there's a remote
 	if status.HasRemote {
-		count, err := b.countUnpushedCommits(branch)
+		count, err := b.countUnpushedCommits(branch, upstream)
 		if err != nil {
 			// Non-fatal - might not have upstream set
 			count = 0
@@ -82,7 +85,7 @@ func (b *BranchManager) Delete(branch string, force bool) error {
 
 	output, err := cmdexec.CombinedOutput(context.TODO(), "git", []string{"-C", b.repoPath, "branch", flag, branch}, "", cmdexec.GitLocal)
 	if err != nil {
-		return fmt.Errorf("failed to delete branch: %s", strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to delete branch: %s: %w", strings.TrimSpace(string(output)), err)
 	}
 	return nil
 }
@@ -187,11 +190,6 @@ func (b *BranchManager) isBranchMerged(branch string) (bool, error) {
 	return false, nil
 }
 
-// hasRemoteTracking checks if a branch has a remote tracking branch
-func (b *BranchManager) hasRemoteTracking(branch string) bool {
-	return b.getUpstream(branch) != ""
-}
-
 // getUpstream returns the upstream tracking branch for a local branch.
 // Returns empty string if no upstream is set (not an error condition).
 func (b *BranchManager) getUpstream(branch string) string {
@@ -203,9 +201,10 @@ func (b *BranchManager) getUpstream(branch string) string {
 	return strings.TrimSpace(string(output))
 }
 
-// countUnpushedCommits returns the number of commits not pushed to upstream
-func (b *BranchManager) countUnpushedCommits(branch string) (int, error) {
-	upstream := b.getUpstream(branch)
+// countUnpushedCommits returns the number of commits not pushed to upstream.
+// The upstream ref is taken as a parameter so callers that already resolved
+// it (GetStatus) don't pay a second `git rev-parse` exec.
+func (b *BranchManager) countUnpushedCommits(branch, upstream string) (int, error) {
 	if upstream == "" {
 		return 0, nil
 	}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -383,4 +384,24 @@ func TestGetUnpushedCommits(t *testing.T) {
 			t.Errorf("GetUnpushedCommits() = %v, want nil", commits)
 		}
 	})
+}
+
+func TestDelete_WrapsUnderlyingError(t *testing.T) {
+	// Regression: Delete discarded the exec error, returning only git's
+	// output text — empty-output failures produced a bare, causeless message
+	// and callers couldn't errors.As/Is on the underlying error.
+	dir := initTestRepo(t, "main")
+
+	mgr, err := NewBranchManager(dir)
+	if err != nil {
+		t.Fatalf("NewBranchManager() error = %v", err)
+	}
+
+	delErr := mgr.Delete("does-not-exist", false)
+	if delErr == nil {
+		t.Fatal("expected error deleting nonexistent branch")
+	}
+	if errors.Unwrap(delErr) == nil {
+		t.Errorf("Delete() error %q does not wrap the underlying error (missing %%w)", delErr)
+	}
 }

--- a/internal/grove/project.go
+++ b/internal/grove/project.go
@@ -27,6 +27,15 @@ func FindRoot(startDir string) (string, error) {
 		return "", err
 	}
 
+	// Resolve symlinks so the walk compares like with like against the git
+	// root: `git rev-parse --show-toplevel` returns the symlink-resolved
+	// path (e.g. /private/var on macOS) while os.Getwd may return the
+	// logical $PWD path (/var). Without this the boundary check below never
+	// fires and the walk can escape the repository. Same rule as diagnose.go.
+	if resolved, err := filepath.EvalSymlinks(absDir); err == nil {
+		absDir = resolved
+	}
+
 	// Determine git repo root to limit search scope.
 	// Without this boundary, the walk can escape the repo and find
 	// unrelated .grove directories (e.g., ~/.grove from debug logging).
@@ -129,12 +138,6 @@ func isWorktreeByWalkingUp(startDir string) (bool, error) {
 		}
 		current = parent
 	}
-}
-
-// StateDir returns the path to the state.json file for the current project.
-// Returns empty string if not in a grove project.
-func StateDir() (string, error) {
-	return FindRoot("")
 }
 
 // ConfigPath returns the path to the config.toml file for the current project.

--- a/internal/grove/project_test.go
+++ b/internal/grove/project_test.go
@@ -9,7 +9,9 @@ import (
 
 func TestFindRoot(t *testing.T) {
 	t.Run("finds .grove in current directory", func(t *testing.T) {
-		tmpDir := t.TempDir()
+		// FindRoot resolves symlinks in the start dir (macOS t.TempDir lives
+		// under symlinked /var), so resolve the expected path the same way.
+		tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
 		groveDir := filepath.Join(tmpDir, ".grove")
 		if err := os.MkdirAll(groveDir, 0755); err != nil {
 			t.Fatalf("failed to create .grove dir: %v", err)
@@ -25,7 +27,7 @@ func TestFindRoot(t *testing.T) {
 	})
 
 	t.Run("finds .grove in parent directory", func(t *testing.T) {
-		tmpDir := t.TempDir()
+		tmpDir, _ := filepath.EvalSymlinks(t.TempDir())
 		groveDir := filepath.Join(tmpDir, ".grove")
 		subDir := filepath.Join(tmpDir, "sub", "nested")
 
@@ -348,4 +350,47 @@ func TestProjectRoot(t *testing.T) {
 			t.Errorf("ProjectRoot() = %q, want empty", root)
 		}
 	})
+}
+
+// TestFindRoot_SymlinkedPathDoesNotEscapeRepo: git returns the symlink-
+// resolved repo root while the walk may start from a logical (symlinked)
+// path. Without resolving both sides, the git-root boundary never fires and
+// the walk escapes the repository, adopting an unrelated .grove above it
+// (macOS: /tmp -> /private/tmp, /var -> /private/var).
+func TestFindRoot_SymlinkedPathDoesNotEscapeRepo(t *testing.T) {
+	base := t.TempDir()
+
+	realDir := filepath.Join(base, "real")
+	repoDir := filepath.Join(realDir, "repo")
+	subDir := filepath.Join(repoDir, "sub")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stray .grove ABOVE the repository — must never be adopted.
+	if err := os.MkdirAll(filepath.Join(realDir, ".grove"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+
+	// Enter the repo through a symlink so the logical path differs from
+	// git's resolved path.
+	linkDir := filepath.Join(base, "link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := FindRoot(filepath.Join(linkDir, "repo", "sub"))
+	if err != nil {
+		t.Fatalf("FindRoot() error = %v", err)
+	}
+	if found != "" {
+		t.Errorf("FindRoot() = %q, want empty — walk escaped the repo and found the stray .grove", found)
+	}
 }

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/lost-in-the/grove/internal/grove"
 )
 
 // FindOverride returns the first matching override for a branch/worktree name, or nil
@@ -153,6 +155,13 @@ func GetHooksConfigPaths(groveDir ...string) (string, string, error) {
 	var projectHooks string
 	if len(groveDir) > 0 && groveDir[0] != "" {
 		projectHooks = filepath.Join(groveDir[0], "hooks.toml")
+	} else if root, rootErr := grove.FindRoot(""); rootErr == nil && root != "" {
+		// Discover the project's .grove directory the same way the rest of
+		// grove does (walk up from cwd, bounded by the git root) instead of
+		// assuming cwd is the project root — otherwise project hooks are
+		// silently skipped when running from a subdirectory or a secondary
+		// worktree.
+		projectHooks = filepath.Join(root, "hooks.toml")
 	} else {
 		cwd, err := os.Getwd()
 		if err != nil {

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -1,11 +1,14 @@
 package hooks
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/grove"
 )
 
@@ -162,6 +165,24 @@ func GetHooksConfigPaths(groveDir ...string) (string, string, error) {
 		// silently skipped when running from a subdirectory or a secondary
 		// worktree.
 		projectHooks = filepath.Join(root, "hooks.toml")
+
+		// Grove-created secondary worktrees get their own .grove containing
+		// only a config.toml symlink (grove.EnsureConfigSymlink) — never
+		// hooks.toml — so FindRoot's walk stops at the worktree's own
+		// .grove before it ever reaches the main worktree. When there's no
+		// hooks.toml at the discovered root, fall back to the main
+		// worktree's .grove (resolved via git's common dir, which always
+		// points at the main worktree's .git regardless of which worktree
+		// cwd is in) so project hooks aren't silently skipped from inside a
+		// linked worktree. A worktree-local hooks.toml, if one exists,
+		// still takes precedence.
+		if _, statErr := os.Stat(projectHooks); statErr != nil {
+			if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+				if mainHooks, ok := mainWorktreeHooksPath(cwd); ok && mainHooks != projectHooks {
+					projectHooks = mainHooks
+				}
+			}
+		}
 	} else {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -171,6 +192,31 @@ func GetHooksConfigPaths(groveDir ...string) (string, string, error) {
 	}
 
 	return globalHooks, projectHooks, nil
+}
+
+// mainWorktreeHooksPath resolves the main worktree's hooks.toml path from
+// cwd via `git rev-parse --git-common-dir`, which returns the main
+// worktree's .git directory regardless of which worktree cwd is in. Returns
+// ok=false if cwd isn't a git repo, the common dir can't be resolved, or the
+// main worktree has no hooks.toml.
+func mainWorktreeHooksPath(cwd string) (string, bool) {
+	out, err := cmdexec.Output(context.TODO(), "git", []string{"-C", cwd, "rev-parse", "--git-common-dir"}, "", cmdexec.GitLocal)
+	if err != nil {
+		return "", false
+	}
+	commonDir := strings.TrimSpace(string(out))
+	if commonDir == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(cwd, commonDir)
+	}
+
+	mainHooks := filepath.Join(filepath.Dir(commonDir), ".grove", "hooks.toml")
+	if _, err := os.Stat(mainHooks); err != nil {
+		return "", false
+	}
+	return mainHooks, true
 }
 
 // LoadHooksConfig loads hooks configuration from global and project paths.

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -486,6 +487,81 @@ func TestHasActionsForEvent(t *testing.T) {
 				t.Errorf("HasActionsForEvent(%q) = %v, want %v", tt.event, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetHooksConfigPaths_SecondaryWorktreeFallsBackToMain(t *testing.T) {
+	// Regression: grove-created secondary worktrees get their own .grove
+	// containing only a config.toml symlink (EnsureConfigSymlink), never
+	// hooks.toml. FindRoot therefore resolves to the WORKTREE's .grove and
+	// project hooks were silently skipped from inside any secondary worktree.
+	// When hooks.toml is absent at the discovered root, the lookup must fall
+	// through to the main worktree's .grove.
+	mainDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run(mainDir, "git", "init")
+	run(mainDir, "git", "commit", "--allow-empty", "-m", "init")
+
+	// Main worktree has .grove with config.toml and hooks.toml.
+	mainGrove := filepath.Join(mainDir, ".grove")
+	if err := os.MkdirAll(mainGrove, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainGrove, "config.toml"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mainHooks := filepath.Join(mainGrove, "hooks.toml")
+	if err := os.WriteFile(mainHooks, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Secondary worktree with a .grove holding only the config.toml symlink,
+	// exactly as grove.EnsureConfigSymlink leaves it after `grove new`.
+	wtDir := mainDir + "-wt"
+	run(mainDir, "git", "worktree", "add", wtDir, "-b", "test-branch")
+	defer func() { _ = os.RemoveAll(wtDir) }()
+	wtGrove := filepath.Join(wtDir, ".grove")
+	if err := os.MkdirAll(wtGrove, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(mainGrove, "config.toml"), filepath.Join(wtGrove, "config.toml")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(wtDir)
+
+	_, projectPath, err := GetHooksConfigPaths()
+	if err != nil {
+		t.Fatalf("GetHooksConfigPaths() error = %v", err)
+	}
+	if projectPath != mainHooks {
+		t.Errorf("project hooks path = %q, want %q (main worktree's hooks.toml)", projectPath, mainHooks)
+	}
+
+	// A worktree-local hooks.toml, when present, must win over main's.
+	wtHooks := filepath.Join(wtGrove, "hooks.toml")
+	if err := os.WriteFile(wtHooks, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, projectPath, err = GetHooksConfigPaths()
+	if err != nil {
+		t.Fatalf("GetHooksConfigPaths() error = %v", err)
+	}
+	if projectPath != wtHooks {
+		t.Errorf("project hooks path = %q, want %q (worktree-local hooks.toml takes precedence)", projectPath, wtHooks)
 	}
 }
 

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -488,3 +488,32 @@ func TestHasActionsForEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestGetHooksConfigPaths_DiscoversProjectRootFromSubdir(t *testing.T) {
+	// Regression: without an explicit groveDir the project hooks.toml was
+	// resolved against the bare cwd, so hooks silently didn't run from
+	// subdirectories. The fallback must walk up like the rest of grove.
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	groveDir := filepath.Join(tmpDir, ".grove")
+	subDir := filepath.Join(tmpDir, "src", "nested")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(subDir)
+
+	_, projectPath, err := GetHooksConfigPaths()
+	if err != nil {
+		t.Fatalf("GetHooksConfigPaths() error = %v", err)
+	}
+	want := filepath.Join(groveDir, "hooks.toml")
+	if projectPath != want {
+		t.Errorf("project hooks path = %q, want %q (discovered from project root, not cwd)", projectPath, want)
+	}
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -8,88 +8,35 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
-	"time"
 )
 
-var (
-	mu      sync.Mutex
-	logFile *os.File
-	enabled bool
-)
-
-// Init opens the log file if GROVE_LOG is set.
-// Call once at startup; safe to call multiple times.
-func Init() {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if logFile != nil {
-		return
-	}
-
-	val := os.Getenv("GROVE_LOG")
-	if val == "" {
-		return
-	}
-
-	path := val
-	if path == "1" || path == "true" {
+// std is the package-level CLI logger instance.
+var std = &Logger{
+	EnvVar: "GROVE_LOG",
+	Label:  "log",
+	Banner: "grove session",
+	DefaultPath: func() (string, error) {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "grove: warning: cannot resolve home dir for log: %v\n", err)
-			return
+			return "", fmt.Errorf("cannot resolve home dir: %w", err)
 		}
 		groveDir := filepath.Join(home, ".grove")
 		if err := os.MkdirAll(groveDir, 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "grove: warning: cannot create ~/.grove for log: %v\n", err)
-			return
+			return "", fmt.Errorf("cannot create %s: %w", groveDir, err)
 		}
-		path = filepath.Join(groveDir, "grove.log")
-	}
-
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "grove: warning: failed to open log %s: %v\n", path, err)
-		return
-	}
-
-	logFile = f
-	enabled = true
-
-	ts := time.Now().Format("15:04:05.000")
-	_, _ = fmt.Fprintf(logFile, "%s  === grove session started at %s ===\n", ts, time.Now().Format(time.RFC3339))
+		return filepath.Join(groveDir, "grove.log"), nil
+	},
 }
+
+// Init opens the log file if GROVE_LOG is set.
+// Call once at startup; safe to call multiple times.
+func Init() { std.Init() }
 
 // Close flushes and closes the log file.
-func Close() {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if logFile != nil {
-		_ = logFile.Close()
-		logFile = nil
-		enabled = false
-	}
-}
+func Close() { std.Close() }
 
 // Printf writes a formatted message to the log.
-func Printf(format string, args ...any) {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if !enabled {
-		return
-	}
-
-	ts := time.Now().Format("15:04:05.000")
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintf(logFile, "%s  %s\n", ts, msg)
-}
+func Printf(format string, args ...any) { std.Printf(format, args...) }
 
 // Enabled returns true when logging is active.
-func Enabled() bool {
-	mu.Lock()
-	defer mu.Unlock()
-	return enabled
-}
+func Enabled() bool { return std.Enabled() }

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,0 +1,106 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// timestampFormat is the per-line timestamp layout used by Printf and the
+// session banner.
+const timestampFormat = "15:04:05.000"
+
+// Logger is a mutex-guarded, append-only debug log gated by an environment
+// variable. It backs both this package's default CLI log (GROVE_LOG) and
+// internal/tuilog's TUI debug log (GROVE_DEBUG) so the two stay in sync
+// instead of drifting as copy-pasted implementations.
+//
+// The env var's value selects the destination: "1"/"true" use DefaultPath,
+// anything else is treated as an explicit file path, empty disables logging.
+type Logger struct {
+	mu      sync.Mutex
+	file    *os.File
+	enabled bool
+
+	// EnvVar gates logging and optionally carries an explicit path.
+	EnvVar string
+	// Label names the log in stderr warnings (e.g. "log", "debug log").
+	Label string
+	// Banner is the session-start banner text (e.g. "grove session").
+	Banner string
+	// DefaultPath returns the log path used when EnvVar is "1"/"true".
+	// It should create any required parent directories.
+	DefaultPath func() (string, error)
+}
+
+// Init opens the log file if the gating env var is set.
+// Call once at startup; safe to call multiple times.
+func (l *Logger) Init() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.file != nil {
+		return
+	}
+
+	val := os.Getenv(l.EnvVar)
+	if val == "" {
+		return
+	}
+
+	path := val
+	if path == "1" || path == "true" {
+		p, err := l.DefaultPath()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "grove: warning: cannot resolve default %s path: %v\n", l.Label, err)
+			return
+		}
+		path = p
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grove: warning: failed to open %s %s: %v\n", l.Label, path, err)
+		return
+	}
+
+	l.file = f
+	l.enabled = true
+
+	ts := time.Now().Format(timestampFormat)
+	_, _ = fmt.Fprintf(l.file, "%s  === %s started at %s ===\n", ts, l.Banner, time.Now().Format(time.RFC3339))
+}
+
+// Close flushes and closes the log file.
+func (l *Logger) Close() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.file != nil {
+		_ = l.file.Close()
+		l.file = nil
+		l.enabled = false
+	}
+}
+
+// Printf writes a formatted message to the log.
+func (l *Logger) Printf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.enabled {
+		return
+	}
+
+	ts := time.Now().Format(timestampFormat)
+	msg := fmt.Sprintf(format, args...)
+	_, _ = fmt.Fprintf(l.file, "%s  %s\n", ts, msg)
+}
+
+// Enabled returns true when logging is active.
+func (l *Logger) Enabled() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.enabled
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -39,14 +39,23 @@ type WorktreeState struct {
 
 // Manager handles state management for Grove
 type Manager struct {
-	groveDir         string // Path to .grove directory
-	stateFile        string
-	lockFile         string // .grove/state.lock
-	mu               sync.RWMutex
-	state            *State
-	removedWorktrees map[string]bool // tracks explicit removals for merge in save()
-	batchDepth       int             // > 0 while inside Batch — setters defer their save()
-	batchDirty       bool            // a setter ran during the current batch
+	groveDir  string // Path to .grove directory
+	stateFile string
+	lockFile  string // .grove/state.lock
+	mu        sync.RWMutex
+	state     *State
+
+	// Mutation tracking for save()'s cross-process merge: the on-disk state
+	// is authoritative for everything this process didn't explicitly touch,
+	// so setters record what they changed and save() replays exactly that
+	// on top of a fresh disk read.
+	removedWorktrees  map[string]bool // worktree entries explicitly removed
+	dirtyWorktrees    map[string]bool // worktree entries added/updated
+	projectDirty      bool            // Project was set by this process
+	lastWorktreeDirty bool            // LastWorktree was set/cleared by this process
+
+	batchDepth int  // > 0 while inside Batch — setters defer their save()
+	batchDirty bool // a setter ran during the current batch
 }
 
 // NewManager creates a new state manager for a grove project
@@ -70,6 +79,7 @@ func NewManager(groveDir string) (*Manager, error) {
 		lockFile:         lockFile,
 		state:            newEmptyState(),
 		removedWorktrees: make(map[string]bool),
+		dirtyWorktrees:   make(map[string]bool),
 	}
 
 	// Load existing state if it exists
@@ -100,6 +110,7 @@ func (m *Manager) SetProject(name string) error {
 	defer m.mu.Unlock()
 
 	m.state.Project = name
+	m.projectDirty = true
 	return m.saveOrDefer()
 }
 
@@ -127,6 +138,7 @@ func (m *Manager) SetLastWorktree(name string) error {
 	defer m.mu.Unlock()
 
 	m.state.LastWorktree = name
+	m.lastWorktreeDirty = true
 	return m.saveOrDefer()
 }
 
@@ -143,6 +155,7 @@ func (m *Manager) AddWorktree(name string, ws *WorktreeState) error {
 	defer m.mu.Unlock()
 
 	m.state.Worktrees[name] = ws
+	m.dirtyWorktrees[name] = true
 	return m.saveOrDefer()
 }
 
@@ -172,12 +185,14 @@ func (m *Manager) RemoveWorktree(name string) error {
 	defer m.mu.Unlock()
 
 	delete(m.state.Worktrees, name)
+	delete(m.dirtyWorktrees, name)
 	m.removedWorktrees[name] = true
 
 	// Clear LastWorktree if it pointed at the removed entry, so callers
 	// like `grove last` don't return a name that no longer exists.
 	if m.state.LastWorktree == name {
 		m.state.LastWorktree = ""
+		m.lastWorktreeDirty = true
 	}
 
 	return m.saveOrDefer()
@@ -208,12 +223,15 @@ func (m *Manager) RenameWorktree(oldName, newName string) error {
 	// Move entry to new key, marking the old name as explicitly removed
 	// so save()'s disk-merge doesn't resurrect it.
 	delete(m.state.Worktrees, oldName)
+	delete(m.dirtyWorktrees, oldName)
 	m.removedWorktrees[oldName] = true
 	m.state.Worktrees[newName] = ws
+	m.dirtyWorktrees[newName] = true
 
 	// Update LastWorktree if it pointed to the old name
 	if m.state.LastWorktree == oldName {
 		m.state.LastWorktree = newName
+		m.lastWorktreeDirty = true
 	}
 
 	return m.saveOrDefer()
@@ -234,6 +252,7 @@ func (m *Manager) TouchWorktree(name string) error {
 	}
 
 	ws.LastAccessedAt = time.Now()
+	m.dirtyWorktrees[name] = true
 	return m.saveOrDefer()
 }
 
@@ -337,8 +356,14 @@ func (m *Manager) load() error {
 }
 
 // save writes the state to disk with file locking and atomic rename.
-// It merges with the current on-disk state to avoid clobbering concurrent changes
-// from other grove processes (e.g., two simultaneous grove new commands).
+// It merges with the current on-disk state to avoid clobbering concurrent
+// changes from other grove processes (e.g., a `grove rm` in another shell
+// while the TUI holds a long-lived Manager): the freshly-read disk state is
+// the base, and only the mutations this process explicitly made (tracked in
+// removedWorktrees/dirtyWorktrees and the scalar dirty flags) are replayed
+// on top. Everything this process didn't touch — including entries other
+// processes removed and their LastWorktree/Project updates — stays as disk
+// has it.
 func (m *Manager) save() error {
 	f, err := m.fileLock()
 	if err != nil {
@@ -346,16 +371,40 @@ func (m *Manager) save() error {
 	}
 	defer m.fileUnlock(f)
 
-	// Re-read current disk state under the lock to preserve entries
-	// added by other processes since we loaded.
+	// Re-read current disk state under the lock and rebase our tracked
+	// mutations onto it. A missing or corrupt state file falls through to
+	// writing the in-memory state as-is.
 	if diskData, err := os.ReadFile(m.stateFile); err == nil {
 		var diskState State
 		if err := json.Unmarshal(diskData, &diskState); err == nil {
-			for name, ws := range diskState.Worktrees {
-				if _, exists := m.state.Worktrees[name]; !exists && !m.removedWorktrees[name] {
-					m.state.Worktrees[name] = ws
+			merged := &diskState
+			if merged.Worktrees == nil {
+				merged.Worktrees = make(map[string]*WorktreeState)
+			}
+			merged.Version = m.state.Version
+
+			for name := range m.removedWorktrees {
+				delete(merged.Worktrees, name)
+			}
+			for name := range m.dirtyWorktrees {
+				if ws, ok := m.state.Worktrees[name]; ok {
+					merged.Worktrees[name] = ws
 				}
 			}
+			if m.projectDirty {
+				merged.Project = m.state.Project
+			}
+			if m.lastWorktreeDirty {
+				merged.LastWorktree = m.state.LastWorktree
+			}
+			// Never persist a LastWorktree pointing at an entry removed in
+			// this save (e.g. another process set it while we removed the
+			// worktree).
+			if m.removedWorktrees[merged.LastWorktree] {
+				merged.LastWorktree = ""
+			}
+
+			m.state = merged
 		}
 	}
 
@@ -373,8 +422,11 @@ func (m *Manager) save() error {
 		return fmt.Errorf("failed to save state file: %w", err)
 	}
 
-	// Disk is now authoritative — clear the tracking set.
+	// Disk is now authoritative — clear the mutation tracking.
 	m.removedWorktrees = make(map[string]bool)
+	m.dirtyWorktrees = make(map[string]bool)
+	m.projectDirty = false
+	m.lastWorktreeDirty = false
 
 	return nil
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -561,3 +561,80 @@ func setupTestManager(t *testing.T) *Manager {
 	}
 	return mgr
 }
+
+// TestCrossProcessRemovalNotResurrected: a manager that loaded state before
+// another manager removed an entry must not write the deleted entry back on
+// its next save. Disk is authoritative for entries this manager didn't touch.
+func TestCrossProcessRemovalNotResurrected(t *testing.T) {
+	stateDir := t.TempDir()
+
+	// Seed state with "foo"
+	seed, _ := NewManager(stateDir)
+	if err := seed.AddWorktree("foo", &WorktreeState{Path: "/foo", Branch: "foo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// B loads state (including foo) before A's removal lands
+	mgrB, _ := NewManager(stateDir)
+
+	// A removes foo (simulating `grove rm foo` in another shell)
+	mgrA, _ := NewManager(stateDir)
+	if err := mgrA.RemoveWorktree("foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	// B saves for an unrelated reason — must NOT resurrect foo
+	if err := mgrB.AddWorktree("bar", &WorktreeState{Path: "/bar", Branch: "bar"}); err != nil {
+		t.Fatal(err)
+	}
+
+	check, _ := NewManager(stateDir)
+	if ws, _ := check.GetWorktree("foo"); ws != nil {
+		t.Errorf("removed worktree 'foo' was resurrected by another manager's save")
+	}
+	if ws, _ := check.GetWorktree("bar"); ws == nil {
+		t.Errorf("worktree 'bar' missing after save")
+	}
+}
+
+// TestCrossProcessScalarsNotClobbered: LastWorktree/Project written by another
+// process must survive a save from a manager that didn't touch them.
+func TestCrossProcessScalarsNotClobbered(t *testing.T) {
+	stateDir := t.TempDir()
+
+	seed, _ := NewManager(stateDir)
+	if err := seed.AddWorktree("bar", &WorktreeState{Path: "/bar", Branch: "bar"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.SetLastWorktree("old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.SetProject("oldproj"); err != nil {
+		t.Fatal(err)
+	}
+
+	// B loads with LastWorktree "old" / Project "oldproj" in memory
+	mgrB, _ := NewManager(stateDir)
+
+	// A updates the scalars
+	mgrA, _ := NewManager(stateDir)
+	if err := mgrA.SetLastWorktree("x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgrA.SetProject("newproj"); err != nil {
+		t.Fatal(err)
+	}
+
+	// B saves without touching the scalars — must not revert them
+	if err := mgrB.TouchWorktree("bar"); err != nil {
+		t.Fatal(err)
+	}
+
+	check, _ := NewManager(stateDir)
+	if got, _ := check.GetLastWorktree(); got != "x" {
+		t.Errorf("LastWorktree = %q, want %q (clobbered by stale in-memory value)", got, "x")
+	}
+	if got := check.GetProject(); got != "newproj" {
+		t.Errorf("Project = %q, want %q (clobbered by stale in-memory value)", got, "newproj")
+	}
+}

--- a/internal/tmux/session.go
+++ b/internal/tmux/session.go
@@ -46,7 +46,7 @@ func ShouldUseControlMode(controlModeCfg *bool) bool {
 // AttachSessionControlMode attaches to a session using tmux -CC (control mode).
 // This is for iTerm2 integration where -CC goes before the subcommand.
 func AttachSessionControlMode(name string) error {
-	return attachSession(name, "-CC", "attach-session", "-t", name)
+	return attachSession(name, "-CC", "attach-session", "-t", exactTarget(name))
 }
 
 var (
@@ -73,7 +73,7 @@ func CreateSession(name, path string) error {
 // AttachSession attaches to an existing session.
 // This is interactive (blocks until detach) — no timeout applied.
 func AttachSession(name string) error {
-	return attachSession(name, "attach-session", "-t", name)
+	return attachSession(name, "attach-session", "-t", exactTarget(name))
 }
 
 // attachSession is the shared implementation for AttachSession and AttachSessionControlMode.
@@ -115,7 +115,7 @@ func SwitchSession(name string) error {
 		return fmt.Errorf("not inside tmux session")
 	}
 
-	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"switch-client", "-t", name}, "", cmdexec.Tmux)
+	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"switch-client", "-t", exactTarget(name)}, "", cmdexec.Tmux)
 	if err != nil {
 		return fmt.Errorf("failed to switch session: %s: %w", string(output), err)
 	}
@@ -133,7 +133,7 @@ func RenameSession(oldName, newName string) error {
 		return fmt.Errorf("new session name cannot be empty")
 	}
 
-	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"rename-session", "-t", oldName, newName}, "", cmdexec.Tmux)
+	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"rename-session", "-t", exactTarget(oldName), newName}, "", cmdexec.Tmux)
 	if err != nil {
 		return fmt.Errorf("failed to rename tmux session: %s: %w", string(output), err)
 	}
@@ -148,7 +148,7 @@ func KillSession(name string) error {
 		return fmt.Errorf("session name cannot be empty")
 	}
 
-	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"kill-session", "-t", name}, "", cmdexec.Tmux)
+	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"kill-session", "-t", exactTarget(name)}, "", cmdexec.Tmux)
 	if err != nil {
 		return fmt.Errorf("failed to kill session: %s: %w", string(output), err)
 	}
@@ -156,9 +156,26 @@ func KillSession(name string) error {
 	return nil
 }
 
+// exactTarget prefixes a session name with "=" so tmux resolves the -t
+// target by exact match. Without it tmux falls back to prefix matching when
+// no exact name exists, so e.g. `kill-session -t grove-test` could act on a
+// live "grove-test-ui" session. Use only for session targets (has-session,
+// kill-session, attach-session, switch-client, rename-session).
+func exactTarget(name string) string {
+	return "=" + name
+}
+
+// exactPaneTarget is exactTarget for pane-targeting commands (display-message,
+// send-keys): those parse the target as session:window.pane, and a bare
+// "=name" is rejected — the trailing ":" marks the whole string as the
+// session part and selects the session's active pane.
+func exactPaneTarget(name string) string {
+	return "=" + name + ":"
+}
+
 // SessionExists checks if a session exists
 func SessionExists(name string) (bool, error) {
-	err := cmdexec.Run(context.TODO(), "tmux", []string{"has-session", "-t", name}, "", cmdexec.Tmux)
+	err := cmdexec.Run(context.TODO(), "tmux", []string{"has-session", "-t", exactTarget(name)}, "", cmdexec.Tmux)
 	if err != nil {
 		// Exit code 1 means session doesn't exist
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -299,7 +316,7 @@ type PaneInfo struct {
 
 // GetPaneInfo returns the current path and command for a session's active pane
 func GetPaneInfo(sessionName string) (*PaneInfo, error) {
-	output, err := cmdexec.Output(context.TODO(), "tmux", []string{"display-message", "-t", sessionName, "-p", "#{pane_current_path}|#{pane_current_command}"}, "", cmdexec.Tmux)
+	output, err := cmdexec.Output(context.TODO(), "tmux", []string{"display-message", "-t", exactPaneTarget(sessionName), "-p", "#{pane_current_path}|#{pane_current_command}"}, "", cmdexec.Tmux)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pane info: %w", err)
 	}
@@ -328,7 +345,7 @@ func (p *PaneInfo) IsShell() bool {
 
 // SendKeys sends keys to the active pane of a tmux session
 func SendKeys(sessionName string, keys string) error {
-	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"send-keys", "-t", sessionName, keys, "Enter"}, "", cmdexec.Tmux)
+	output, err := cmdexec.CombinedOutput(context.TODO(), "tmux", []string{"send-keys", "-t", exactPaneTarget(sessionName), keys, "Enter"}, "", cmdexec.Tmux)
 	if err != nil {
 		return fmt.Errorf("failed to send keys: %s: %w", string(output), err)
 	}
@@ -392,9 +409,13 @@ func DisplayPopup(sessionName, width, height string) error {
 	if height != "" {
 		args = append(args, "-h", height)
 	}
-	// Session name is single-quoted to prevent shell injection. Tmux session
-	// names follow {project}-{name} and cannot contain single quotes.
-	args = append(args, "-E", fmt.Sprintf("tmux attach-session -t '%s'", sessionName))
+	// The -E command runs through a shell, so the target is single-quoted
+	// with embedded single quotes escaped ('\'' idiom) — session names are
+	// derived from unvalidated project/worktree names and may contain
+	// quotes. exactTarget's "=" prefix keeps tmux from prefix-matching a
+	// different session.
+	escaped := strings.ReplaceAll(exactTarget(sessionName), "'", `'\''`)
+	args = append(args, "-E", fmt.Sprintf("tmux attach-session -t '%s'", escaped))
 
 	cmd := exec.Command("tmux", args...)
 	cmd.Stdin = os.Stdin

--- a/internal/tmux/session_test.go
+++ b/internal/tmux/session_test.go
@@ -524,3 +524,41 @@ func TestAttachSessionControlMode_NonExistent(t *testing.T) {
 		t.Error("AttachSessionControlMode(nonexistent) expected error, got nil")
 	}
 }
+
+func TestSessionTargets_ExactMatchOnly(t *testing.T) {
+	// Regression: tmux falls back to PREFIX matching for -t targets, so with
+	// only "grove-exacttest-ui" alive, SessionExists("grove-exacttest")
+	// returned true and KillSession("grove-exacttest") killed the other
+	// worktree's session. All targets must use the "=" exact-match prefix.
+	if !IsTmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+
+	longer := "grove-exacttest-ui"
+	shorter := "grove-exacttest"
+	_ = KillSession(longer)
+	_ = KillSession(shorter)
+
+	if err := CreateSession(longer, "/tmp"); err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	defer func() { _ = KillSession(longer) }()
+
+	exists, err := SessionExists(shorter)
+	if err != nil {
+		t.Fatalf("SessionExists() error = %v", err)
+	}
+	if exists {
+		t.Errorf("SessionExists(%q) = true, but only %q exists (prefix match leak)", shorter, longer)
+	}
+
+	// KillSession on the absent shorter name must NOT kill the longer session.
+	_ = KillSession(shorter)
+	stillThere, err := SessionExists(longer)
+	if err != nil {
+		t.Fatalf("SessionExists() error = %v", err)
+	}
+	if !stillThere {
+		t.Errorf("KillSession(%q) killed %q via prefix matching", shorter, longer)
+	}
+}

--- a/internal/tuilog/log.go
+++ b/internal/tuilog/log.go
@@ -8,83 +8,34 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
-	"time"
+
+	"github.com/lost-in-the/grove/internal/log"
 )
 
-var (
-	mu      sync.Mutex
-	logFile *os.File
-	enabled bool
-)
+// std is the TUI debug logger — a second instance of the shared
+// log.Logger with its own env var and default path.
+var std = &log.Logger{
+	EnvVar: "GROVE_DEBUG",
+	Label:  "debug log",
+	Banner: "grove TUI session",
+	DefaultPath: func() (string, error) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve home dir: %w", err)
+		}
+		return filepath.Join(home, ".grove-debug.log"), nil
+	},
+}
 
 // Init opens the debug log if GROVE_DEBUG is set.
 // Call once at TUI startup; safe to call multiple times.
-func Init() {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if logFile != nil {
-		return
-	}
-
-	val := os.Getenv("GROVE_DEBUG")
-	if val == "" {
-		return
-	}
-
-	path := val
-	if path == "1" || path == "true" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "grove: warning: cannot resolve home dir for debug log: %v\n", err)
-			return
-		}
-		path = filepath.Join(home, ".grove-debug.log")
-	}
-
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "grove: warning: failed to open debug log %s: %v\n", path, err)
-		return
-	}
-
-	logFile = f
-	enabled = true
-
-	ts := time.Now().Format("15:04:05.000")
-	_, _ = fmt.Fprintf(logFile, "%s  === grove TUI session started at %s ===\n", ts, time.Now().Format(time.RFC3339))
-}
+func Init() { std.Init() }
 
 // Close flushes and closes the log file.
-func Close() {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if logFile != nil {
-		_ = logFile.Close()
-		logFile = nil
-		enabled = false
-	}
-}
+func Close() { std.Close() }
 
 // Printf writes a formatted message to the debug log.
-func Printf(format string, args ...any) {
-	mu.Lock()
-	defer mu.Unlock()
-
-	if !enabled {
-		return
-	}
-
-	ts := time.Now().Format("15:04:05.000")
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintf(logFile, "%s  %s\n", ts, msg)
-}
+func Printf(format string, args ...any) { std.Printf(format, args...) }
 
 // Enabled returns true when debug logging is active.
-func Enabled() bool {
-	mu.Lock()
-	defer mu.Unlock()
-	return enabled
-}
+func Enabled() bool { return std.Enabled() }

--- a/internal/updatecheck/check.go
+++ b/internal/updatecheck/check.go
@@ -81,12 +81,30 @@ func cachedReleaseFromPath(currentVersion, path string) (latest, url string, ava
 // CheckInterval is the default minimum gap between two refreshes.
 const CheckInterval = 24 * time.Hour
 
-// RefreshAsync starts a detached goroutine that refreshes the cache if the
-// interval has elapsed. Never blocks. Failures are silent.
-func RefreshAsync() {
-	go refreshFromPathWithFetcher(DefaultCachePath(), CheckInterval, func() (Release, error) {
-		return FetchLatest(context.Background())
-	})
+// RefreshWaitBudget caps how long a short-lived CLI command should wait on
+// RefreshAsync's channel before exiting. When the cache is fresh the refresh
+// returns immediately, so the cap only bites on the (at most daily) run that
+// actually hits the network — keeping commands within the <500ms budget.
+const RefreshWaitBudget = 300 * time.Millisecond
+
+// RefreshAsync starts a goroutine that refreshes the cache if the interval
+// has elapsed, and returns a channel that is closed when the refresh
+// completes (or was skipped). Never blocks. Failures are silent.
+//
+// Short-lived CLI processes MUST wait (bounded, e.g. RefreshWaitBudget) on
+// the returned channel: goroutines die when main returns, so a fire-and-
+// forget refresh would be killed before the HTTPS round trip finishes and
+// the cache would never be written. Long-lived callers (the TUI) can ignore
+// the channel.
+func RefreshAsync() <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		refreshFromPathWithFetcher(DefaultCachePath(), CheckInterval, func() (Release, error) {
+			return FetchLatest(context.Background())
+		})
+	}()
+	return done
 }
 
 // refreshFromPathWithFetcher is the testable core: deterministic, no goroutine,
@@ -108,17 +126,28 @@ func refreshFromPathWithFetcher(path string, interval time.Duration, fetcher fun
 }
 
 // CheckNow synchronously fetches the latest release and prints the result to w.
-// Bypasses the cache and the interval. Used by --check-update.
+// Bypasses the cache and the interval for the fetch, but seeds the cache with
+// the result so later commands' MaybeNotify works from it. Used by --check-update.
 func CheckNow(w io.Writer, currentVersion string) error {
-	return checkNowWithDeps(w, currentVersion, func() (Release, error) {
+	return checkNowWithDeps(w, currentVersion, DefaultCachePath(), func() (Release, error) {
 		return FetchLatest(context.Background())
 	})
 }
 
-func checkNowWithDeps(w io.Writer, currentVersion string, fetcher func() (Release, error)) error {
+func checkNowWithDeps(w io.Writer, currentVersion, cachePath string, fetcher func() (Release, error)) error {
 	rel, err := fetcher()
 	if err != nil {
 		return err
+	}
+	// Write-through to the cache: without this, a manual --check-update
+	// couldn't seed the cache for later notifications. Failure is non-fatal —
+	// the synchronous output below is the primary result.
+	if cachePath != "" {
+		_ = WriteCacheToPath(cachePath, Cache{
+			LastCheckedAt: time.Now(),
+			LatestVersion: rel.Version(),
+			LatestURL:     rel.HTMLURL,
+		})
 	}
 	if !renderUpdateBox(w, currentVersion, rel.Version(), rel.HTMLURL) {
 		_, _ = fmt.Fprintf(w, upToDateMessage, currentVersion)

--- a/internal/updatecheck/check.go
+++ b/internal/updatecheck/check.go
@@ -116,6 +116,14 @@ func refreshFromPathWithFetcher(path string, interval time.Duration, fetcher fun
 	}
 	rel, err := fetcher()
 	if err != nil {
+		// Record the attempt even on failure, preserving any previously
+		// cached release info. Otherwise a host where the fetch always
+		// fails or times out (offline, firewalled, slow DNS/TLS) never
+		// gets a written cache, so every subsequent command re-attempts
+		// the network fetch and blocks for the full RefreshWaitBudget
+		// instead of the interval applying to failures too.
+		c.LastCheckedAt = time.Now()
+		_ = WriteCacheToPath(path, c)
 		return
 	}
 	_ = WriteCacheToPath(path, Cache{

--- a/internal/updatecheck/check_test.go
+++ b/internal/updatecheck/check_test.go
@@ -150,7 +150,7 @@ func TestCheckNow_FetchesAndPrintsNotification(t *testing.T) {
 		return Release{TagName: "v0.6.0", HTMLURL: "https://x"}, nil
 	}
 	var buf bytes.Buffer
-	if err := checkNowWithDeps(&buf, "0.5.0", fetcher); err != nil {
+	if err := checkNowWithDeps(&buf, "0.5.0", "", fetcher); err != nil {
 		t.Fatalf("checkNowWithDeps: %v", err)
 	}
 	if !strings.Contains(buf.String(), "0.6.0") {
@@ -163,7 +163,7 @@ func TestCheckNow_UpToDateMessage(t *testing.T) {
 		return Release{TagName: "v0.5.0", HTMLURL: "https://x"}, nil
 	}
 	var buf bytes.Buffer
-	if err := checkNowWithDeps(&buf, "0.5.0", fetcher); err != nil {
+	if err := checkNowWithDeps(&buf, "0.5.0", "", fetcher); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(buf.String(), "up to date") {
@@ -174,7 +174,7 @@ func TestCheckNow_UpToDateMessage(t *testing.T) {
 func TestCheckNow_FetchFailureReturnsError(t *testing.T) {
 	fetcher := func() (Release, error) { return Release{}, errFakeNetwork }
 	var buf bytes.Buffer
-	if err := checkNowWithDeps(&buf, "0.5.0", fetcher); err == nil {
+	if err := checkNowWithDeps(&buf, "0.5.0", "", fetcher); err == nil {
 		t.Error("expected error on fetch failure")
 	}
 }
@@ -296,5 +296,31 @@ func TestCachedRelease_DevVersionUnavailable(t *testing.T) {
 	}
 	if latest != "" || url != "" {
 		t.Errorf("expected zero values for dev version, got latest=%q url=%q", latest, url)
+	}
+}
+
+func TestCheckNow_SeedsCache(t *testing.T) {
+	// Regression: --check-update fetched synchronously but never wrote the
+	// cache, so a manual check couldn't seed later MaybeNotify calls.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	fetcher := func() (Release, error) {
+		return Release{TagName: "v0.6.0", HTMLURL: "https://x"}, nil
+	}
+
+	var buf bytes.Buffer
+	if err := checkNowWithDeps(&buf, "0.5.0", path, fetcher); err != nil {
+		t.Fatalf("checkNowWithDeps: %v", err)
+	}
+
+	c, err := ReadCacheFromPath(path)
+	if err != nil {
+		t.Fatalf("cache not written: %v", err)
+	}
+	if c.LatestVersion != "0.6.0" {
+		t.Errorf("cached LatestVersion = %q, want %q", c.LatestVersion, "0.6.0")
+	}
+	if c.LastCheckedAt.IsZero() {
+		t.Error("cached LastCheckedAt is zero")
 	}
 }

--- a/internal/updatecheck/check_test.go
+++ b/internal/updatecheck/check_test.go
@@ -145,6 +145,64 @@ func TestRefresh_FetchFailureLeavesCacheAlone(t *testing.T) {
 
 var errFakeNetwork = fmt.Errorf("simulated network failure")
 
+func TestRefresh_FetchFailureRecordsAttempt(t *testing.T) {
+	// Regression: a failed fetch never wrote LastCheckedAt, so on hosts where
+	// the fetch always fails (offline, firewalled, >RefreshWaitBudget latency)
+	// the cache was never seeded and EVERY subsequent command re-attempted the
+	// network fetch — blocking the full RefreshWaitBudget each time instead of
+	// at most once per interval.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+
+	calls := 0
+	fetcher := func() (Release, error) {
+		calls++
+		return Release{}, errFakeNetwork
+	}
+
+	// First refresh with no cache at all: fetch fails, attempt must be recorded.
+	refreshFromPathWithFetcher(path, 24*time.Hour, fetcher)
+	if calls != 1 {
+		t.Fatalf("fetcher calls = %d, want 1", calls)
+	}
+	got, err := ReadCacheFromPath(path)
+	if err != nil {
+		t.Fatalf("cache not readable after failed fetch: %v", err)
+	}
+	if got.LastCheckedAt.IsZero() {
+		t.Fatal("LastCheckedAt is zero after failed fetch; attempt was not recorded")
+	}
+
+	// Second refresh within the interval must not hit the network again.
+	refreshFromPathWithFetcher(path, 24*time.Hour, fetcher)
+	if calls != 1 {
+		t.Errorf("fetcher calls = %d after second refresh, want 1 (attempt timestamp should suppress retry)", calls)
+	}
+}
+
+func TestRefresh_FetchFailurePreservesReleaseInfoWithAttempt(t *testing.T) {
+	// A failed fetch must record the attempt WITHOUT discarding previously
+	// cached release info — MaybeNotify still needs it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-check.json")
+	_ = WriteCacheToPath(path, Cache{
+		LastCheckedAt: time.Now().Add(-48 * time.Hour),
+		LatestVersion: "0.5.0",
+		LatestURL:     "https://example/old",
+	})
+
+	fetcher := func() (Release, error) { return Release{}, errFakeNetwork }
+	refreshFromPathWithFetcher(path, 24*time.Hour, fetcher)
+
+	got, _ := ReadCacheFromPath(path)
+	if got.LatestVersion != "0.5.0" || got.LatestURL != "https://example/old" {
+		t.Errorf("release info clobbered on failed fetch: got %+v", got)
+	}
+	if time.Since(got.LastCheckedAt) > time.Minute {
+		t.Errorf("LastCheckedAt not refreshed on failed fetch: %v", got.LastCheckedAt)
+	}
+}
+
 func TestCheckNow_FetchesAndPrintsNotification(t *testing.T) {
 	fetcher := func() (Release, error) {
 		return Release{TagName: "v0.6.0", HTMLURL: "https://x"}, nil

--- a/internal/worktree/bootstrap.go
+++ b/internal/worktree/bootstrap.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/lost-in-the/grove/internal/cli"
@@ -96,7 +97,9 @@ func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts Bootstr
 
 	// Per-project (config-driven) post-create hooks last — these may target
 	// containers via docker:compose handlers and need them already running.
-	hookExecutor, hookErr := hooks.NewExecutor()
+	// The main worktree's .grove dir is passed explicitly so hooks.toml is
+	// found regardless of the caller's cwd (subdirectory, secondary worktree).
+	hookExecutor, hookErr := hooks.NewExecutor(filepath.Join(opts.MainPath, ".grove"))
 	if hookErr != nil {
 		log.Printf("hooks: failed to load config during bootstrap: %v", hookErr)
 		if w != nil {
@@ -104,9 +107,14 @@ func BootstrapWorktree(stateMgr *state.Manager, cfg *config.Config, opts Bootstr
 		}
 	} else if hookExecutor.HasHooksForEvent(hooks.EventPostCreate) {
 		hookCtx := &hooks.ExecutionContext{
-			Event:        hooks.EventPostCreate,
-			Worktree:     opts.Name,
-			WorktreeFull: opts.ProjectName + "-" + opts.Name,
+			Event:    hooks.EventPostCreate,
+			Worktree: opts.Name,
+			// WorktreeFull is contractually the real directory name
+			// ({{.worktree_full}} in hooks.toml). Derive it from the path —
+			// the canonical {project}-{name} concatenation is wrong under a
+			// custom [naming] pattern or for adopted directories, and every
+			// other producer (rm, TUI) uses filepath.Base(wt.Path).
+			WorktreeFull: filepath.Base(opts.WorktreePath),
 			Branch:       opts.Branch,
 			Project:      opts.ProjectName,
 			MainPath:     opts.MainPath,

--- a/internal/worktree/bootstrap_test.go
+++ b/internal/worktree/bootstrap_test.go
@@ -189,3 +189,63 @@ required = true
 		})
 	}
 }
+
+// TestBootstrapWorktree_WorktreeFullMatchesDirectory guards the
+// {{.worktree_full}} contract: it must be the real directory name
+// (filepath.Base of the worktree path), not the canonical
+// {project}-{name} concatenation, which diverges under a custom
+// [naming] pattern or for adopted directories.
+//
+// It also covers hooks.toml discovery: BootstrapWorktree passes the main
+// worktree's .grove dir to the executor explicitly, so the hook must run
+// even though the test's cwd is nowhere near the project.
+func TestBootstrapWorktree_WorktreeFullMatchesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	mainDir := filepath.Join(tmpDir, "main")
+	groveDir := filepath.Join(mainDir, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatalf("mkdir grove: %v", err)
+	}
+	// Directory name deliberately does NOT match {project}-{name}
+	// ("test-proj-feature") — as with a custom pattern like {project}_{name}.
+	wtPath := filepath.Join(tmpDir, "test-proj_feature")
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+
+	hooksToml := `[hooks]
+[[hooks.post_create]]
+type = "command"
+command = "printf '%s' '{{.worktree_full}}' > worktree_full.txt"
+working_dir = "new"
+`
+	if err := os.WriteFile(filepath.Join(groveDir, "hooks.toml"), []byte(hooksToml), 0644); err != nil {
+		t.Fatalf("write hooks.toml: %v", err)
+	}
+
+	stateMgr, err := state.NewManager(groveDir)
+	if err != nil {
+		t.Fatalf("state mgr: %v", err)
+	}
+
+	opts := BootstrapOpts{
+		Name:         "feature",
+		Branch:       "feature",
+		WorktreePath: wtPath,
+		MainPath:     mainDir,
+		ProjectName:  "test-proj",
+	}
+
+	if err := BootstrapWorktree(stateMgr, config.LoadDefaults(), opts, nil); err != nil {
+		t.Fatalf("BootstrapWorktree: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(wtPath, "worktree_full.txt"))
+	if err != nil {
+		t.Fatalf("post-create hook did not run (worktree_full.txt missing): %v", err)
+	}
+	want := filepath.Base(wtPath)
+	if got := strings.TrimSpace(string(data)); got != want {
+		t.Errorf("{{.worktree_full}} = %q, want directory name %q", got, want)
+	}
+}

--- a/internal/worktree/naming.go
+++ b/internal/worktree/naming.go
@@ -35,8 +35,10 @@ type projectConfig struct {
 const DefaultNamePattern = "{project}-{name}"
 
 // namePatternLiterals restricts literal (non-placeholder) characters to ones
-// that are safe in directory names, git branch names, tmux targets, and
-// GitHub URLs.
+// that are safe in directory names, git branch names, and GitHub URLs.
+// Note '.' and ':' are NOT safe in tmux targets — the pattern only governs
+// directory names; tmux session names are sanitized separately (see
+// TmuxSessionName).
 var namePatternLiterals = regexp.MustCompile(`^[A-Za-z0-9._-]*$`)
 
 // ValidateNamePattern checks that a worktree naming pattern is usable:
@@ -79,14 +81,15 @@ func InterpolateNamePattern(pattern, project, name string) string {
 	return strings.ReplaceAll(full, "{name}", name)
 }
 
-// detectProjectName determines the project name using priority:
+// detectProjectNameAt determines the project name using priority:
 // 1. .grove/config.toml -> project_name (from main worktree)
 // 2. Git remote origin URL -> repo name (from main worktree)
 // 3. Main worktree directory name as fallback
-func (m *Manager) detectProjectName() string {
-	// Get the main worktree path (first in the list)
-	mainWorktreePath := m.getMainWorktreePath()
-
+//
+// The main worktree path is taken as a parameter so callers that already
+// parsed `git worktree list --porcelain` (e.g. listLight) don't trigger a
+// redundant exec via getMainWorktreePath.
+func (m *Manager) detectProjectNameAt(mainWorktreePath string) string {
 	// Priority 1: Check .grove/config.toml in main worktree
 	configPath := filepath.Join(mainWorktreePath, ".grove", "config.toml")
 	if data, err := os.ReadFile(configPath); err == nil {
@@ -182,9 +185,18 @@ func (m *Manager) getNamePattern() string {
 	if m.namePattern != "" {
 		return m.namePattern
 	}
+	return m.namePatternAt(m.getMainWorktreePath())
+}
+
+// namePatternAt is getNamePattern with the main worktree path already in
+// hand, so priming a cold cache doesn't re-exec `git worktree list`.
+func (m *Manager) namePatternAt(mainWorktreePath string) string {
+	if m.namePattern != "" {
+		return m.namePattern
+	}
 	m.namePattern = DefaultNamePattern
 
-	groveDir := filepath.Join(m.getMainWorktreePath(), ".grove")
+	groveDir := filepath.Join(mainWorktreePath, ".grove")
 	cfg, err := config.LoadFromGroveDir(groveDir)
 	if err != nil || cfg == nil {
 		return m.namePattern
@@ -205,11 +217,7 @@ func (m *Manager) getNamePattern() string {
 // Tmux session names intentionally do NOT follow the pattern — they always
 // use the canonical {project}-{name} form (see TmuxSessionName).
 func (m *Manager) FullName(name string) string {
-	if m.projectName == "" {
-		m.projectName = m.detectProjectName()
-	}
-
-	return InterpolateNamePattern(m.getNamePattern(), m.projectName, name)
+	return InterpolateNamePattern(m.getNamePattern(), m.GetProjectName(), name)
 }
 
 // ShortName inverts the naming pattern: given a full worktree directory name,
@@ -217,10 +225,7 @@ func (m *Manager) FullName(name string) string {
 // returned unchanged (e.g. worktrees created before a pattern change or by
 // raw `git worktree add`).
 func (m *Manager) ShortName(fullName string) string {
-	if m.projectName == "" {
-		m.projectName = m.detectProjectName()
-	}
-	short, _ := shortNameFromFull(fullName, m.projectName, m.getNamePattern())
+	short, _ := shortNameFromFull(fullName, m.GetProjectName(), m.getNamePattern())
 	return short
 }
 

--- a/internal/worktree/naming_test.go
+++ b/internal/worktree/naming_test.go
@@ -120,7 +120,7 @@ func TestDetectProjectName(t *testing.T) {
 			}
 
 			m := &Manager{repoRoot: repoRoot}
-			got := m.detectProjectName()
+			got := m.detectProjectNameAt(m.getMainWorktreePath())
 
 			if got != tt.want {
 				t.Errorf("detectProjectName() = %q, want %q", got, tt.want)
@@ -261,7 +261,7 @@ func TestDetectProjectNameFromConfig(t *testing.T) {
 	}
 
 	m := &Manager{repoRoot: tmpDir}
-	got := m.detectProjectName()
+	got := m.detectProjectNameAt(m.getMainWorktreePath())
 
 	// Should use config value, not remote
 	want := "my-custom-project"

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -19,7 +19,7 @@ const (
 
 // Worktree represents a git worktree
 type Worktree struct {
-	Name             string // Short name (derived from path)
+	Name             string // Full directory name (basename of Path, e.g. "grove-testing")
 	Path             string // Absolute path to worktree
 	Branch           string // Branch name or "detached"
 	Commit           string // Commit hash (full)
@@ -279,12 +279,14 @@ func (m *Manager) listLight() ([]*Worktree, error) {
 	// The main worktree is always the first `worktree <path>` line —
 	// extract it from the output we already have rather than running
 	// `git worktree list --porcelain` a second time via getMainWorktreePath.
+	// The *At helpers reuse that path too, so priming the project-name and
+	// name-pattern caches doesn't re-exec `git worktree list` either.
 	raw := string(output)
 	mainPath := mainWorktreePathFromPorcelain(raw)
 	if mainPath == "" {
 		mainPath = m.repoRoot
 	}
-	return parseWorktreeList(raw, mainPath, m.GetProjectName(), m.getNamePattern()), nil
+	return parseWorktreeList(raw, mainPath, m.projectNameAt(mainPath), m.namePatternAt(mainPath)), nil
 }
 
 // mainWorktreePathFromPorcelain returns the first worktree path in the output
@@ -361,26 +363,23 @@ func (m *Manager) ListNames() ([]string, error) {
 	return names, nil
 }
 
-// Remove removes a worktree
+// Remove removes a worktree.
+//
+// The name is resolved with Find, so it accepts exactly the same identifiers
+// (short name, display name, branch, full name, or path basename). Callers
+// like `grove rm` run their safety checks against Find's result — resolving
+// with a narrower matcher here could delete a different worktree than the
+// one that was validated.
 func (m *Manager) Remove(name string) error {
 	if name == "" {
 		return fmt.Errorf("worktree name cannot be empty")
 	}
 
-	// Find the worktree by name. listLight skips per-worktree dirty checks
-	// — Remove only needs the target's path/IsMain/IsPrunable to decide what
-	// to do.
-	trees, err := m.listLight()
+	// Find uses listLight, which skips per-worktree dirty checks — Remove
+	// only needs the target's path/IsMain/IsPrunable to decide what to do.
+	targetTree, err := m.Find(name)
 	if err != nil {
-		return fmt.Errorf("failed to list worktrees: %w", err)
-	}
-
-	var targetTree *Worktree
-	for _, tree := range trees {
-		if tree.Name == name || tree.ShortName == name || tree.DisplayName() == name {
-			targetTree = tree
-			break
-		}
+		return err
 	}
 
 	if targetTree == nil {
@@ -586,18 +585,36 @@ func (m *Manager) GetProjectName() string {
 		return m.projectName
 	}
 
-	m.projectName = m.detectProjectName()
+	return m.projectNameAt(m.getMainWorktreePath())
+}
+
+// projectNameAt is GetProjectName with the main worktree path already in
+// hand, so priming a cold cache doesn't re-exec `git worktree list`.
+func (m *Manager) projectNameAt(mainWorktreePath string) string {
+	if m.projectName == "" {
+		m.projectName = m.detectProjectNameAt(mainWorktreePath)
+	}
 	return m.projectName
 }
 
+// tmuxNameSanitizer rewrites characters tmux mangles in session names: tmux
+// silently converts '.' and ':' to '_' when creating a session, but treats
+// them as window/pane separators when resolving `-t` targets. Applying the
+// same rewrite here keeps the Go-side name identical to the session tmux
+// actually stores, so exists/kill/attach target the right session.
+var tmuxNameSanitizer = strings.NewReplacer(".", "_", ":", "_")
+
 // TmuxSessionName returns the tmux session name for a worktree.
 // The main/root worktree uses just the project name (e.g. "myapp"),
-// while branch worktrees use project-name (e.g. "myapp-testing").
+// while branch worktrees use the canonical project-name form (e.g.
+// "myapp-testing"), regardless of the [naming] directory pattern.
+// Characters tmux rewrites in session names ('.' and ':') are replaced
+// with '_' so the returned name matches what tmux stores.
 func TmuxSessionName(project, worktreeName string) string {
 	if worktreeName == "root" {
-		return project
+		return tmuxNameSanitizer.Replace(project)
 	}
-	return fmt.Sprintf("%s-%s", project, worktreeName)
+	return tmuxNameSanitizer.Replace(fmt.Sprintf("%s-%s", project, worktreeName))
 }
 
 // GetRepoRoot returns the repository root path

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -981,3 +981,73 @@ func TestGetCommitInfo(t *testing.T) {
 		t.Error("Branch should not be empty")
 	}
 }
+
+func TestRemoveByBranchName(t *testing.T) {
+	// Regression: Remove used a narrower name matcher than Find, so
+	// `grove rm <branch>` passed all pre-flight checks (run against Find's
+	// result) and then failed with "not found" — after pre-remove hooks had
+	// already fired. Remove must resolve names exactly like Find.
+	tmpDir, _ := setupTestRepo(t)
+
+	m := &Manager{repoRoot: tmpDir}
+
+	// Slash-containing branch: the derived worktree name ("agent-slot-db")
+	// differs from the branch name ("feat/agent-slot-db").
+	if err := m.Create("agent-slot-db", "feat/agent-slot-db"); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	wt, err := m.Find("feat/agent-slot-db")
+	if err != nil || wt == nil {
+		t.Fatalf("Find(branch) expected worktree, got error=%v, wt=%v", err, wt)
+	}
+
+	if err := m.Remove("feat/agent-slot-db"); err != nil {
+		t.Fatalf("Remove(branch) error = %v — Remove must accept every identifier Find accepts", err)
+	}
+
+	wtAfter, _ := m.Find("feat/agent-slot-db")
+	if wtAfter != nil {
+		t.Error("Worktree should not exist after Remove() by branch name")
+	}
+}
+
+func TestTmuxSessionNameSanitizesTmuxUnsafeChars(t *testing.T) {
+	// Regression: tmux rewrites '.' and ':' to '_' when creating a session
+	// but parses them as window/pane separators in -t targets, so unsanitized
+	// names never match the session tmux actually stores.
+	tests := []struct {
+		name        string
+		project     string
+		worktree    string
+		wantSession string
+	}{
+		{
+			name:        "dot in project name",
+			project:     "my.app",
+			worktree:    "testing",
+			wantSession: "my_app-testing",
+		},
+		{
+			name:        "dot in project name for root",
+			project:     "next.js",
+			worktree:    "root",
+			wantSession: "next_js",
+		},
+		{
+			name:        "colon in worktree name",
+			project:     "myapp",
+			worktree:    "fix:urgent",
+			wantSession: "myapp-fix_urgent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TmuxSessionName(tt.project, tt.worktree)
+			if got != tt.wantSession {
+				t.Errorf("TmuxSessionName(%q, %q) = %q, want %q", tt.project, tt.worktree, got, tt.wantSession)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the verified core-internals findings from the repo audit (#115, #117, #118) plus the core portions of #116 (tmux), #119 (update check), and #120 (git exec perf). 13 commits, each scoped to one fix:

- **worktree**: `Remove` now resolves names with the same matcher as `Find`, so `grove rm <branch>` can no longer validate one worktree and delete/fail on another (#115); `WorktreeFull` is derived from the real directory name instead of hardcoded `{project}-{name}`, honoring the configured naming pattern; `groveDir` is now actually passed to hooks.
- **config** (#117): each config layer is parsed into a zero-value struct instead of a defaults-seeded one, so a project/local file no longer resets explicit global settings (e.g. `tmux.control_mode`, docker booleans) back to defaults.
- **state**: `save()` rebases tracked mutations onto fresh disk state, so concurrent grove processes no longer resurrect removed worktrees or clobber `LastWorktree`.
- **tmux** (#116): session targets use tmux exact-match syntax (`=name`), so `grove-foo` can no longer kill/attach `grove-foo-bar`; the popup target is escaped.
- **grove**: `FindRoot` resolves symlinks so the git-root boundary holds under symlinked cwds (macOS `/tmp`, `/var`). Note: user-visible paths on macOS may now display as `/private/...` — consistent with `diagnose.go`.
- **hooks**: project `hooks.toml` is discovered via `FindRoot` (not bare cwd), with a `git rev-parse --git-common-dir` fallback so linked worktrees find the main worktree's hooks instead of silently skipping them.
- **updatecheck** (#119): the detached refresh goroutine died with the process, so the cache never persisted and every command re-paid the check; refreshes now complete synchronously within the existing wait budget in `PersistentPostRunE`, and failed/timed-out attempts record the attempt so offline hosts don't block 300ms on every command.
- **git/detect/log** (#120 + misc): `GetStatus` reuses the resolved upstream instead of double-execing `git rev-parse @{upstream}`; `listLight` no longer runs `git worktree list --porcelain` three times per cold call; compose detection matches all four compose filenames; `BranchManager.Delete` wraps its error; `internal/log`/`internal/tuilog` now share one Logger implementation; stale `Name`/`StateDir` doc comments corrected.

Closes #115. Closes #117. Closes #118. Refs #116, #119, #120.

Deferred (noted for follow-up): threading GroveContext's loaded config into `worktree.NewManager` (would drop a per-Manager config re-parse; needs command call-site changes); consolidating the three main-worktree-resolution helpers; docs follow-ups for the tmux sanitization rules and hooks discovery (docs are owned by #126's branch).

## Type of Change

- [x] Bug fix
- [x] Refactoring (no functional change)

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter is clean (`make lint`)
- [x] Documentation updated (if applicable — see CONTRIBUTING.md)
- [x] Commit messages follow conventional commits (`type(scope): description`)
