### PR TITLE
fix(commands): fetch bootstrap, rm protection, command bugs, epilogue dedup

### DIFF
--- a/cmd/grove/commands/adopt.go
+++ b/cmd/grove/commands/adopt.go
@@ -64,6 +64,23 @@ Examples:
 			return nil
 		}
 
+		// Verify the target belongs to THIS repository. gitBranchAt succeeds
+		// in any git repository (or subdirectory of one), so without this
+		// check adopt would register an unrelated repo in this project's
+		// state, symlink this project's config into it, and fire this
+		// project's post-create hooks there.
+		targetCommon, err := gitCommonDirAt(target)
+		if err != nil {
+			return fmt.Errorf("resolve git dir for %s: %w", target, err)
+		}
+		rootCommon, err := gitCommonDirAt(ctx.ProjectRoot)
+		if err != nil {
+			return fmt.Errorf("resolve git dir for %s: %w", ctx.ProjectRoot, err)
+		}
+		if targetCommon != rootCommon {
+			return fmt.Errorf("%s is not a worktree of this repository (git dir: %s, expected: %s)", target, targetCommon, rootCommon)
+		}
+
 		mgr, err := ctx.WorktreeManager()
 		if err != nil {
 			return err
@@ -125,6 +142,25 @@ func resolveAdoptTarget(cwd string, args []string) (string, error) {
 		return resolved, nil
 	}
 	return abs, nil
+}
+
+// gitCommonDirAt returns the absolute, symlink-resolved path of the git
+// common directory (the shared .git dir) for the repository containing dir.
+// Two directories belong to the same repository iff their common dirs match.
+func gitCommonDirAt(dir string) (string, error) {
+	out, err := cmdexec.Output(context.TODO(), "git", []string{"rev-parse", "--git-common-dir"}, dir, cmdexec.GitLocal)
+	if err != nil {
+		return "", err
+	}
+	p := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(dir, p)
+	}
+	p = filepath.Clean(p)
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved, nil
+	}
+	return p, nil
 }
 
 // gitBranchAt returns the current branch name of the git worktree at dir.

--- a/cmd/grove/commands/adopt.go
+++ b/cmd/grove/commands/adopt.go
@@ -64,9 +64,9 @@ Examples:
 			return nil
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("worktree manager: %w", err)
+			return err
 		}
 
 		// Strip the naming pattern so the state key matches grove's convention

--- a/cmd/grove/commands/adopt_test.go
+++ b/cmd/grove/commands/adopt_test.go
@@ -128,3 +128,60 @@ func TestAdopt_StripProjectPrefixForName(t *testing.T) {
 		})
 	}
 }
+
+func TestGitCommonDirAt_DistinguishesRepositories(t *testing.T) {
+	base := t.TempDir()
+
+	repo := filepath.Join(base, "repo")
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	runAdoptGit(t, repo, "init")
+	runAdoptGit(t, repo, "commit", "--allow-empty", "-m", "init")
+
+	// Linked worktree of the same repository must share the common dir.
+	wt := filepath.Join(base, "repo-wt")
+	runAdoptGit(t, repo, "worktree", "add", wt)
+
+	repoCommon, err := gitCommonDirAt(repo)
+	if err != nil {
+		t.Fatalf("gitCommonDirAt(repo): %v", err)
+	}
+	wtCommon, err := gitCommonDirAt(wt)
+	if err != nil {
+		t.Fatalf("gitCommonDirAt(wt): %v", err)
+	}
+	if repoCommon != wtCommon {
+		t.Errorf("worktree common dir %q != repo common dir %q", wtCommon, repoCommon)
+	}
+
+	// A subdirectory of the worktree also resolves to the same repo.
+	sub := filepath.Join(wt, "sub")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	subCommon, err := gitCommonDirAt(sub)
+	if err != nil {
+		t.Fatalf("gitCommonDirAt(sub): %v", err)
+	}
+	if subCommon != repoCommon {
+		t.Errorf("subdir common dir %q != repo common dir %q", subCommon, repoCommon)
+	}
+
+	// An unrelated repository must NOT match — this is the membership check
+	// grove adopt relies on to reject foreign repos.
+	other := filepath.Join(base, "other")
+	if err := os.MkdirAll(other, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	runAdoptGit(t, other, "init")
+	runAdoptGit(t, other, "commit", "--allow-empty", "-m", "init")
+
+	otherCommon, err := gitCommonDirAt(other)
+	if err != nil {
+		t.Fatalf("gitCommonDirAt(other): %v", err)
+	}
+	if otherCommon == repoCommon {
+		t.Errorf("unrelated repo shares common dir %q — membership check would pass foreign repos", otherCommon)
+	}
+}

--- a/cmd/grove/commands/apply.go
+++ b/cmd/grove/commands/apply.go
@@ -65,9 +65,9 @@ Examples:
 
 		cfg := ctx.Config
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Get current worktree (target). Only path + display name are needed

--- a/cmd/grove/commands/attach.go
+++ b/cmd/grove/commands/attach.go
@@ -27,9 +27,9 @@ This is a tmux-only command — it does not emit cd: directives.`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		stderr := cli.NewStderr()
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		var targetTree *worktree.Worktree

--- a/cmd/grove/commands/browse.go
+++ b/cmd/grove/commands/browse.go
@@ -29,9 +29,9 @@ func browseRunE(
 		useFzf, _ := cmd.Flags().GetBool("fzf")
 
 		if !useFzf && term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("GROVE_TUI") != "0" {
-			mgr, err := worktree.NewManager(ctx.ProjectRoot)
+			mgr, err := ctx.WorktreeManager()
 			if err != nil {
-				return fmt.Errorf("failed to initialize worktree manager: %w", err)
+				return err
 			}
 			_, _, err = runTUI(mgr, ctx.State, ctx.ProjectRoot, ctx.PluginManager)
 			return err
@@ -333,9 +333,9 @@ Examples:
 			return fmt.Errorf("failed to detect repository: %w\n\nMake sure you're in a git repository with a GitHub remote", err)
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		tree, err := mgr.GetCurrent()

--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -67,9 +67,9 @@ Examples:
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		w := cli.NewStdout()
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		cfg := ctx.Config

--- a/cmd/grove/commands/clean.go
+++ b/cmd/grove/commands/clean.go
@@ -16,8 +16,6 @@ import (
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/git"
 	"github.com/lost-in-the/grove/internal/log"
-	"github.com/lost-in-the/grove/internal/tmux"
-	"github.com/lost-in-the/grove/internal/worktree"
 )
 
 var (
@@ -196,29 +194,19 @@ Examples:
 		removedBranches := []string{}
 
 		for _, c := range cleanable {
-			// Remove worktree
-			if err := mgr.Remove(c.Name); err != nil {
+			// Shared removal sequence (same as `grove rm`): pre-remove hooks
+			// — including the plugin hook that stops agent Docker stacks —
+			// git removal, state cleanup, and tmux session kill.
+			if err := removeWorktreeWithHooks(ctx, mgr, w, projectName, c.Name, c.Path, c.Branch); err != nil {
 				cli.Warning(w, "Failed to remove '%s': %v", c.Name, err)
 				failed++
 				continue
 			}
 
-			// Remove from state
-			if err := ctx.State.RemoveWorktree(c.Name); err != nil {
-				log.Printf("failed to remove worktree %q from state: %v", c.Name, err)
-			}
+			// User + plugin post-remove hooks (branch deletion is batched
+			// after the loop, unlike `grove rm`)
+			firePostRemoveHooks(ctx, w, projectName, c.Name, c.Path, c.Branch)
 
-			// Kill tmux session if exists
-			sessionName := worktree.TmuxSessionName(projectName, c.Name)
-			if tmux.IsTmuxAvailable() {
-				if exists, _ := tmux.SessionExists(sessionName); exists {
-					if err := tmux.KillSession(sessionName); err != nil {
-						cli.Warning(w, "Worktree removed but failed to kill tmux session '%s': %v", sessionName, err)
-					}
-				}
-			}
-
-			cli.Success(w, "Removed '%s'", c.Name)
 			removed++
 
 			// Track branch for later deletion

--- a/cmd/grove/commands/compare.go
+++ b/cmd/grove/commands/compare.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/output"
-	"github.com/lost-in-the/grove/internal/worktree"
 )
 
 var (
@@ -78,9 +77,9 @@ Examples:
 			targetName = args[0]
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Get current worktree

--- a/cmd/grove/commands/config.go
+++ b/cmd/grove/commands/config.go
@@ -1,12 +1,14 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
 
 	"github.com/lost-in-the/grove/internal/cli"
@@ -53,6 +55,12 @@ Examples:
 				return fmt.Errorf("failed to get home directory: %w", err)
 			}
 			configPath = filepath.Join(homeDir, ".config", "grove", filename)
+			// GROVE_CONFIG overrides the global main-config path during
+			// loading (config.Load) — reflect that here so the file shown
+			// is the file actually read.
+			if env := os.Getenv("GROVE_CONFIG"); env != "" && !configHooks {
+				configPath = env
+			}
 		} else {
 			groveDir, err := grove.FindRoot("")
 			if err != nil || groveDir == "" {
@@ -95,9 +103,22 @@ Examples:
 			return showHooksConfig(configPath)
 		}
 
-		cfg, err := config.Load()
-		if err != nil {
-			return fmt.Errorf("failed to load config: %w", err)
+		var cfg *config.Config
+		if configGlobal {
+			// --global promises "global config only": show defaults + the
+			// global file, not the merged view (which would display project
+			// overrides under the global file's path).
+			var err error
+			cfg, err = loadGlobalOnlyConfig(configPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			var err error
+			cfg, err = config.Load()
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
 		}
 
 		w := cli.NewStdout()
@@ -139,6 +160,18 @@ Examples:
 
 		return nil
 	},
+}
+
+// loadGlobalOnlyConfig returns defaults overlaid with just the global config
+// file — no project config, no local overlay, no env overrides. Used by
+// `grove config --global` so the displayed values match the file shown.
+// A missing file yields plain defaults.
+func loadGlobalOnlyConfig(globalPath string) (*config.Config, error) {
+	cfg := config.LoadDefaults()
+	if _, err := toml.DecodeFile(globalPath, cfg); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to load global config: %w", err)
+	}
+	return cfg, nil
 }
 
 // formatBoolPtr safely formats a *bool, returning the default if nil.

--- a/cmd/grove/commands/config_test.go
+++ b/cmd/grove/commands/config_test.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadGlobalOnlyConfig_ReadsOnlyGlobalFile(t *testing.T) {
+	dir := t.TempDir()
+	globalPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(globalPath, []byte("default_base_branch = \"trunk\"\n"), 0644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	cfg, err := loadGlobalOnlyConfig(globalPath)
+	if err != nil {
+		t.Fatalf("loadGlobalOnlyConfig: %v", err)
+	}
+	if cfg.DefaultBranch != "trunk" {
+		t.Errorf("DefaultBranch = %q, want %q (value from the global file)", cfg.DefaultBranch, "trunk")
+	}
+}
+
+func TestLoadGlobalOnlyConfig_MissingFileYieldsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := loadGlobalOnlyConfig(filepath.Join(dir, "nope.toml"))
+	if err != nil {
+		t.Fatalf("expected defaults for missing file, got error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil defaults config")
+	}
+}
+
+func TestLoadGlobalOnlyConfig_CorruptFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	globalPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(globalPath, []byte("not [valid toml"), 0644); err != nil {
+		t.Fatalf("write corrupt config: %v", err)
+	}
+	if _, err := loadGlobalOnlyConfig(globalPath); err == nil {
+		t.Error("expected error for corrupt global config")
+	}
+}

--- a/cmd/grove/commands/context.go
+++ b/cmd/grove/commands/context.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lost-in-the/grove/internal/plugins"
 	"github.com/lost-in-the/grove/internal/shell"
 	"github.com/lost-in-the/grove/internal/state"
+	"github.com/lost-in-the/grove/internal/worktree"
 	"github.com/lost-in-the/grove/plugins/docker"
 )
 
@@ -27,6 +28,24 @@ type GroveContext struct {
 	State         *state.Manager   // State manager instance
 	Config        *config.Config   // Loaded configuration
 	PluginManager *plugins.Manager // Plugin manager for status queries
+
+	wtMgr *worktree.Manager // Memoized worktree manager (via WorktreeManager)
+}
+
+// WorktreeManager returns a lazily constructed, memoized worktree.Manager
+// rooted at the project root. Commands should use this instead of calling
+// worktree.NewManager(ctx.ProjectRoot) inline so construction and error
+// wrapping live in one place.
+func (c *GroveContext) WorktreeManager() (*worktree.Manager, error) {
+	if c.wtMgr != nil {
+		return c.wtMgr, nil
+	}
+	mgr, err := worktree.NewManager(c.ProjectRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize worktree manager: %w", err)
+	}
+	c.wtMgr = mgr
+	return mgr, nil
 }
 
 // RequireGroveContext wraps a command function to require grove project context.

--- a/cmd/grove/commands/context_cmd.go
+++ b/cmd/grove/commands/context_cmd.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/output"
-	"github.com/lost-in-the/grove/internal/worktree"
 	"github.com/lost-in-the/grove/internal/worktreeinfo"
 )
 
@@ -72,9 +71,9 @@ JSON schema:
   stash_count       number of stashes
   recent_commits    last 5 commits [{sha, message}]`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		tree, err := mgr.GetCurrent()

--- a/cmd/grove/commands/down.go
+++ b/cmd/grove/commands/down.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -32,15 +31,17 @@ Examples:
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		w := cli.NewStdout()
 
-		// Get current directory (docker-compose works in cwd)
-		cwd, err := os.Getwd()
+		// Resolve the worktree root — slot detection keys on the worktree
+		// directory basename, so cwd must be normalized (running from a
+		// subdirectory would otherwise target the shared stack).
+		root, err := currentWorktreeRoot(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get current directory: %w", err)
+			return err
 		}
 
 		// Create docker plugin — auto-detect isolated stacks
 		plugin := docker.New()
-		if docker.HasActiveAgentSlot(ctx.Config, cwd) {
+		if docker.HasActiveAgentSlot(ctx.Config, root) {
 			plugin.SetIsolated(true)
 		}
 		if err := plugin.Init(ctx.Config); err != nil {
@@ -50,7 +51,7 @@ Examples:
 		// Stop containers — no spinner: docker compose writes its own progress
 		stderr := cli.NewStderr()
 		cli.Step(stderr, "Stopping containers...")
-		if err := plugin.Down(cwd); err != nil {
+		if err := plugin.Down(root); err != nil {
 			return fmt.Errorf("failed to stop containers: %w", err)
 		}
 

--- a/cmd/grove/commands/fetch.go
+++ b/cmd/grove/commands/fetch.go
@@ -5,13 +5,11 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/log"
-	"github.com/lost-in-the/grove/internal/state"
 	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/worktree"
 	"github.com/lost-in-the/grove/plugins/tracker"
@@ -48,16 +46,14 @@ func createFetchedWorktree(mgr *worktree.Manager, itemType, worktreeName, branch
 	return mgr.Create(worktreeName, branchName)
 }
 
-func setupFetchedWorktree(ctx *GroveContext, mgr *worktree.Manager, w *cli.Writer, wt *worktree.Worktree, worktreeName, branchName string) {
-	now := time.Now()
-	wsState := &state.WorktreeState{
-		Path:           wt.Path,
-		Branch:         branchName,
-		CreatedAt:      now,
-		LastAccessedAt: now,
-	}
-	if err := ctx.State.AddWorktree(worktreeName, wsState); err != nil {
-		log.Printf("failed to add worktree %q to state: %v", worktreeName, err)
+func setupFetchedWorktree(ctx *GroveContext, mgr *worktree.Manager, w *cli.Writer, worktreeName, branchName string) error {
+	// Run the same bootstrap as `grove new`/`grove open`: config symlink,
+	// state registration, file setup, post-create hooks, docker auto-start.
+	// Fetched worktrees previously only registered state, leaving them
+	// silently unprovisioned (#112).
+	wt, err := setupCreatedWorktree(ctx, mgr, worktreeName, branchName, worktreeSetupOpts{}, w)
+	if err != nil {
+		return err
 	}
 
 	if tmux.IsTmuxAvailable() {
@@ -85,6 +81,7 @@ func setupFetchedWorktree(ctx *GroveContext, mgr *worktree.Manager, w *cli.Write
 	} else {
 		fmt.Printf("\nTo switch to this worktree:\n  grove to %s\n", worktreeName)
 	}
+	return nil
 }
 
 // fetchItem creates a worktree from a GitHub PR or issue.
@@ -123,15 +120,7 @@ func fetchItem(ctx *GroveContext, itemType string, number int) error {
 		cli.Success(w, "Created worktree '%s' with new branch '%s'", worktreeName, branchName)
 	}
 
-	wt, err := mgr.Find(worktreeName)
-	if err != nil {
-		return fmt.Errorf("failed to find created worktree: %w", err)
-	}
-	if wt != nil {
-		setupFetchedWorktree(ctx, mgr, w, wt, worktreeName, branchName)
-	}
-
-	return nil
+	return setupFetchedWorktree(ctx, mgr, w, worktreeName, branchName)
 }
 
 var fetchCmd = &cobra.Command{

--- a/cmd/grove/commands/fetch.go
+++ b/cmd/grove/commands/fetch.go
@@ -103,9 +103,9 @@ func fetchItem(ctx *GroveContext, itemType string, number int) error {
 
 	gh := tracker.NewGitHubAdapter(repo)
 
-	mgr, err := worktree.NewManager(ctx.ProjectRoot)
+	mgr, err := ctx.WorktreeManager()
 	if err != nil {
-		return fmt.Errorf("failed to initialize worktree manager: %w", err)
+		return err
 	}
 
 	worktreeName, branchName, err := fetchItemMetadata(gh, w, itemType, number)

--- a/cmd/grove/commands/fork.go
+++ b/cmd/grove/commands/fork.go
@@ -99,7 +99,9 @@ Examples:
 			if err == nil && ws != nil && ws.Mirror != "" {
 				// For environment worktrees, fork from the mirror's HEAD
 				baseRef = ws.Mirror
-				cli.Info(w, "Forking from environment worktree (mirror: %s)", ws.Mirror)
+				if !forkJSON {
+					cli.Info(w, "Forking from environment worktree (mirror: %s)", ws.Mirror)
+				}
 			}
 		}
 
@@ -128,7 +130,7 @@ Examples:
 			// Determine WIP handling strategy
 			if !forkMoveWIP && !forkCopyWIP && !forkNoWIP {
 				// Prompt user if interactive
-				if !isInteractive() {
+				if !cli.IsInteractive() {
 					return fmt.Errorf("uncommitted changes detected; use --move-wip, --copy-wip, or --no-wip")
 				}
 
@@ -195,7 +197,9 @@ Examples:
 			return fmt.Errorf("failed to find created worktree")
 		}
 
-		cli.Success(w, "Created worktree '%s' with branch '%s'", name, newBranchName)
+		if !forkJSON {
+			cli.Success(w, "Created worktree '%s' with branch '%s'", name, newBranchName)
+		}
 
 		// Symlink config.toml from main worktree
 		if err := grove.EnsureConfigSymlink(ctx.ProjectRoot, newTree.Path); err != nil {
@@ -208,21 +212,23 @@ Examples:
 		if len(wipPatch) > 0 && (forkMoveWIP || forkCopyWIP) {
 			newWipHandler := worktree.NewWIPHandler(newTree.Path)
 			if err := newWipHandler.ApplyPatch(wipPatch); err != nil {
-				cli.Warning(w, "Failed to apply changes to fork: %v", err)
-				cli.Warning(w, "Changes are preserved in the source worktree")
+				cli.Warning(stderr, "Failed to apply changes to fork: %v", err)
+				cli.Warning(stderr, "Changes are preserved in the source worktree")
 			} else {
-				if forkCopyWIP {
+				if forkCopyWIP && !forkJSON {
 					cli.Success(w, "Copied uncommitted changes to fork")
 				}
 				// Reset source worktree only after successful patch application
 				if forkMoveWIP {
 					if output, err := cmdexec.CombinedOutput(context.TODO(), "git", []string{"-C", currentTree.Path, "checkout", "--", "."}, "", cmdexec.GitLocal); err != nil {
-						cli.Warning(w, "changes applied to fork but failed to reset source: %v\n%s", err, output)
+						cli.Warning(stderr, "changes applied to fork but failed to reset source: %v\n%s", err, output)
 					} else {
 						if output, err := cmdexec.CombinedOutput(context.TODO(), "git", []string{"-C", currentTree.Path, "clean", "-fd"}, "", cmdexec.GitLocal); err != nil {
-							cli.Warning(w, "failed to clean untracked files in source: %v\n%s", err, output)
+							cli.Warning(stderr, "failed to clean untracked files in source: %v\n%s", err, output)
 						}
-						cli.Success(w, "Moved uncommitted changes to fork")
+						if !forkJSON {
+							cli.Success(w, "Moved uncommitted changes to fork")
+						}
 					}
 				}
 			}
@@ -238,8 +244,8 @@ Examples:
 			ParentWorktree: parentName,
 		}
 		if err := ctx.State.AddWorktree(name, wsState); err != nil {
-			cli.Warning(w, "worktree created but state tracking failed: %v", err)
-			cli.Info(w, "run 'grove repair' to fix")
+			cli.Warning(stderr, "worktree created but state tracking failed: %v", err)
+			cli.Info(stderr, "run 'grove repair' to fix")
 		}
 
 		runFileSetup(ctx.Config, newTree.Path, ctx.ProjectRoot, w, forkJSON)
@@ -252,7 +258,7 @@ Examples:
 			MainPath:     ctx.ProjectRoot,
 		}
 		if err := hooks.Fire(hooks.EventPostCreate, hookCtx); err != nil {
-			cli.Warning(w, "Post-create hook failed: %v", err)
+			cli.Warning(stderr, "Post-create hook failed: %v", err)
 		}
 
 		projectName := mgr.GetProjectName()
@@ -261,8 +267,8 @@ Examples:
 		if tmux.IsTmuxAvailable() {
 			sessionName := worktree.TmuxSessionName(projectName, name)
 			if err := tmux.CreateSession(sessionName, newTree.Path); err != nil {
-				cli.Warning(w, "Failed to create tmux session: %v", err)
-			} else {
+				cli.Warning(stderr, "Failed to create tmux session: %v", err)
+			} else if !forkJSON {
 				cli.Success(w, "Created tmux session '%s'", sessionName)
 			}
 		}
@@ -297,16 +303,6 @@ Examples:
 
 		return nil
 	}),
-}
-
-// isInteractive checks if we're running interactively.
-func isInteractive() bool {
-	// Check if stdin is a terminal
-	fileInfo, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return (fileInfo.Mode() & os.ModeCharDevice) != 0
 }
 
 func init() {

--- a/cmd/grove/commands/fork.go
+++ b/cmd/grove/commands/fork.go
@@ -135,13 +135,13 @@ Examples:
 				}
 
 				files, _ := wipHandler.ListWIPFiles()
-				cli.Warning(w, "Uncommitted changes detected (%d files):", len(files))
+				cli.Warning(stderr, "Uncommitted changes detected (%d files):", len(files))
 				for i, f := range files {
 					if i >= 5 {
-						cli.Faint(w, "  ... and %d more", len(files)-5)
+						cli.Faint(stderr, "  ... and %d more", len(files)-5)
 						break
 					}
-					cli.Faint(w, "  %s", f)
+					cli.Faint(stderr, "  %s", f)
 				}
 
 				choice, err := cli.Choose("How do you want to handle uncommitted changes?", []string{

--- a/cmd/grove/commands/fork.go
+++ b/cmd/grove/commands/fork.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/grove"
 	"github.com/lost-in-the/grove/internal/hooks"
-	"github.com/lost-in-the/grove/internal/log"
 	"github.com/lost-in-the/grove/internal/output"
 	"github.com/lost-in-the/grove/internal/state"
 	"github.com/lost-in-the/grove/internal/tmux"
@@ -283,55 +282,14 @@ Examples:
 			return output.PrintJSON(result)
 		}
 
-		// Switch to new worktree unless --no-switch.
-		// Batch the SetLastWorktree + TouchWorktree pair into a single state save.
+		// Switch to new worktree unless --no-switch. Agent mode and tmux mode
+		// "off" suppress the client switch (terminal takeover) — same policy
+		// as `grove new` and `grove to`.
 		if !forkNoSwitch {
-			var tmuxSwitched bool
-			batchErr := ctx.State.Batch(func() error {
-				if err := ctx.State.SetLastWorktree(parentName); err != nil {
-					log.Printf("failed to set last worktree %q: %v", parentName, err)
-				}
-
-				// Store current session as last if inside tmux
-				if tmux.IsInsideTmux() {
-					currentSession, err := tmux.GetCurrentSession()
-					if err == nil {
-						if err := tmux.StoreLastSession(currentSession); err != nil {
-							log.Printf("failed to store last session %q: %v", currentSession, err)
-						}
-					}
-				}
-
-				// Switch tmux session
-				if tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
-					sessionName := worktree.TmuxSessionName(projectName, name)
-					if err := tmux.SwitchSession(sessionName); err != nil {
-						cli.Warning(w, "Failed to switch session: %v", err)
-					} else {
-						tmuxSwitched = true
-					}
-				}
-
-				// Update last_accessed_at for target worktree
-				if err := ctx.State.TouchWorktree(name); err != nil {
-					log.Printf("failed to touch worktree %q: %v", name, err)
-				}
-				return nil
-			})
-			if batchErr != nil {
-				log.Printf("state save failed: %v", batchErr)
-			}
-
-			// Skip cd directive when tmux switch already moved the user
-			if !tmuxSwitched {
-				hasShellIntegration := os.Getenv("GROVE_SHELL") == "1"
-				if hasShellIntegration {
-					cli.Directive("cd", newTree.Path)
-				} else {
-					cli.Info(stderr, "Directory switching requires shell integration.")
-					cli.Faint(stderr, "To change directory manually:")
-					cli.Faint(stderr, "  cd %s", newTree.Path)
-				}
+			suppressTmux := effectiveTmuxMode(ctx.Config.Tmux.Mode, ctx.Config.AgentMode, false, false) == tmuxModeOff
+			sessionName := worktree.TmuxSessionName(projectName, name)
+			if !switchToWorktree(ctx, stderr, parentName, name, sessionName, newTree.Path, suppressTmux) {
+				emitCdOrExplain(stderr, newTree.Path)
 			}
 		} else {
 			cli.Info(w, "To switch to the new worktree: grove to %s", name)

--- a/cmd/grove/commands/fork.go
+++ b/cmd/grove/commands/fork.go
@@ -76,9 +76,9 @@ Examples:
 			return fmt.Errorf("worktree name cannot be empty")
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Get current worktree

--- a/cmd/grove/commands/helpers.go
+++ b/cmd/grove/commands/helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -85,26 +84,6 @@ func updateGitignore(dir string) error {
 
 	_, err = f.WriteString(entry)
 	return err
-}
-
-func createWorktree(repoDir, projectName, name string) error {
-	parentDir := filepath.Dir(repoDir)
-	worktreeDir := filepath.Join(parentDir, fmt.Sprintf("%s-%s", projectName, name))
-
-	output, err := cmdexec.Output(context.TODO(), "git", []string{"rev-parse", "--abbrev-ref", "HEAD"}, repoDir, cmdexec.GitLocal)
-	if err != nil {
-		return fmt.Errorf("failed to get current branch: %w", err)
-	}
-	baseBranch := strings.TrimSpace(string(output))
-
-	branchName := name
-	// Worktree add streams progress to stdout/stderr — use exec.Command directly
-	cmd := exec.Command("git", "worktree", "add", "-b", branchName, worktreeDir, baseBranch)
-	cmd.Dir = repoDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
 }
 
 // emitCdOrExplain emits the cd: directive for the shell wrapper when shell

--- a/cmd/grove/commands/helpers.go
+++ b/cmd/grove/commands/helpers.go
@@ -11,6 +11,8 @@ import (
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/config"
+	"github.com/lost-in-the/grove/internal/log"
+	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/worktree"
 	"github.com/lost-in-the/grove/plugins/docker"
 )
@@ -102,6 +104,79 @@ func createWorktree(repoDir, projectName, name string) error {
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
+}
+
+// emitCdOrExplain emits the cd: directive for the shell wrapper when shell
+// integration is active; otherwise it explains how to set up shell
+// integration and change directory manually. Shared by every command that
+// lands the user in a different worktree without a tmux client switch.
+func emitCdOrExplain(stderr *cli.Writer, path string) {
+	if os.Getenv("GROVE_SHELL") == "1" {
+		cli.Directive("cd", path)
+		return
+	}
+	cli.Faint(stderr, "Note: Directory switching requires shell integration.")
+	cli.Faint(stderr, "Add this to your shell config (~/.zshrc or ~/.bashrc):")
+	_, _ = fmt.Fprintf(stderr, "\n")
+	cli.Faint(stderr, "  eval \"$(grove install zsh)\"   # for zsh")
+	cli.Faint(stderr, "  eval \"$(grove install bash)\"  # for bash")
+	_, _ = fmt.Fprintf(stderr, "\n")
+	cli.Faint(stderr, "To change directory manually:")
+	cli.Faint(stderr, "  cd %s", path)
+}
+
+// switchToWorktree runs the shared switch epilogue used by new/fork/last:
+// batches SetLastWorktree + TouchWorktree into a single state save, stores
+// the current tmux session as "last", and switches the tmux client to the
+// target session (creating it if missing). Returns whether the client was
+// actually switched; callers emit the cd-directive fallback when it wasn't.
+//
+// suppressTmux must be true when the client must not be relocated (agent
+// mode, --no-tmux, tmux mode "off") — compute it via effectiveTmuxMode.
+func switchToWorktree(ctx *GroveContext, stderr *cli.Writer, prevName, targetName, sessionName, targetPath string, suppressTmux bool) bool {
+	var tmuxSwitched bool
+	batchErr := ctx.State.Batch(func() error {
+		if prevName != "" {
+			if err := ctx.State.SetLastWorktree(prevName); err != nil {
+				log.Printf("failed to set last worktree %q: %v", prevName, err)
+			}
+		}
+
+		// Store current session as last if inside tmux
+		if tmux.IsInsideTmux() {
+			if currentSession, err := tmux.GetCurrentSession(); err == nil {
+				if err := tmux.StoreLastSession(currentSession); err != nil {
+					log.Printf("failed to store last session %q: %v", currentSession, err)
+				}
+			}
+		}
+
+		// Switch tmux session, creating it first when missing (e.g. killed
+		// by hand, or the worktree was entered with --no-tmux). Failures
+		// degrade to the cd-directive fallback instead of aborting.
+		if !suppressTmux && tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
+			if exists, err := tmux.SessionExists(sessionName); err == nil && !exists {
+				if createErr := tmux.CreateSession(sessionName, targetPath); createErr != nil {
+					cli.Warning(stderr, "Failed to create tmux session: %v", createErr)
+				}
+			}
+			if err := tmux.SwitchSession(sessionName); err != nil {
+				cli.Warning(stderr, "Failed to switch session: %v", err)
+			} else {
+				tmuxSwitched = true
+			}
+		}
+
+		// Update last_accessed_at for target worktree
+		if err := ctx.State.TouchWorktree(targetName); err != nil {
+			log.Printf("failed to touch worktree %q: %v", targetName, err)
+		}
+		return nil
+	})
+	if batchErr != nil {
+		log.Printf("state save failed: %v", batchErr)
+	}
+	return tmuxSwitched
 }
 
 // worktreeSetupOpts configures the post-create setup sequence.

--- a/cmd/grove/commands/helpers.go
+++ b/cmd/grove/commands/helpers.go
@@ -180,6 +180,23 @@ func switchToWorktree(ctx *GroveContext, stderr *cli.Writer, prevName, targetNam
 	return tmuxSwitched
 }
 
+// currentWorktreeRoot resolves the root directory of the worktree containing
+// the current working directory. Docker slot detection keys on the worktree
+// directory basename (docker.FindWorktreeSlot), so container commands must
+// pass the worktree root — a raw os.Getwd() from a subdirectory would miss
+// the isolated stack and silently operate on the shared one instead.
+func currentWorktreeRoot(ctx *GroveContext) (string, error) {
+	mgr, err := ctx.WorktreeManager()
+	if err != nil {
+		return "", err
+	}
+	root, err := mgr.CurrentPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve current worktree root: %w", err)
+	}
+	return root, nil
+}
+
 // removeWorktreeWithHooks runs the shared removal sequence used by `grove rm`
 // and `grove trim`: user pre-remove hooks (hooks.toml), the plugin pre-remove
 // hook (e.g. stop agent stacks), git worktree removal, state cleanup, and

--- a/cmd/grove/commands/helpers.go
+++ b/cmd/grove/commands/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/config"
+	"github.com/lost-in-the/grove/internal/hooks"
 	"github.com/lost-in-the/grove/internal/log"
 	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/worktree"
@@ -177,6 +178,99 @@ func switchToWorktree(ctx *GroveContext, stderr *cli.Writer, prevName, targetNam
 		log.Printf("state save failed: %v", batchErr)
 	}
 	return tmuxSwitched
+}
+
+// removeWorktreeWithHooks runs the shared removal sequence used by `grove rm`
+// and `grove trim`: user pre-remove hooks (hooks.toml), the plugin pre-remove
+// hook (e.g. stop agent stacks), git worktree removal, state cleanup, and
+// tmux session kill. Returns an error only when the git removal itself fails;
+// ancillary failures are warned and skipped.
+func removeWorktreeWithHooks(ctx *GroveContext, mgr *worktree.Manager, w *cli.Writer, projectName, name, wtPath, branchName string) error {
+	// Execute pre-remove hooks (user hooks from hooks.toml)
+	hookExecutor, hookErr := hooks.NewExecutor()
+	if hookErr == nil && hookExecutor.HasHooksForEvent(hooks.EventPreRemove) {
+		hookCtx := &hooks.ExecutionContext{
+			Event:        hooks.EventPreRemove,
+			Worktree:     name,
+			Branch:       branchName,
+			Project:      projectName,
+			MainPath:     ctx.ProjectRoot,
+			NewPath:      wtPath,
+			WorktreeFull: filepath.Base(wtPath),
+		}
+		cli.Step(w, "Running pre-remove hooks...")
+		if err := hookExecutor.Execute(hooks.EventPreRemove, hookCtx); err != nil {
+			cli.Warning(w, "Hook execution had errors: %v", err)
+		}
+	}
+
+	// Fire plugin pre-remove hook (e.g., stop agent stacks)
+	pluginHookCtx := &hooks.Context{
+		Worktree:     name,
+		Config:       ctx.Config,
+		WorktreePath: wtPath,
+		MainPath:     ctx.ProjectRoot,
+	}
+	if err := hooks.Fire(hooks.EventPreRemove, pluginHookCtx); err != nil {
+		cli.Warning(w, "Pre-remove plugin hook failed: %v", err)
+	}
+
+	// Remove worktree — the critical step, done before tmux kill
+	if err := mgr.Remove(name); err != nil {
+		return fmt.Errorf("failed to remove worktree: %w", err)
+	}
+
+	// Remove from state
+	if err := ctx.State.RemoveWorktree(name); err != nil {
+		cli.Warning(w, "worktree removed but state cleanup failed: %v", err)
+	}
+
+	cli.Success(w, "Removed worktree '%s'", name)
+
+	// Kill tmux session after worktree is confirmed gone
+	if tmux.IsTmuxAvailable() {
+		sessionName := worktree.TmuxSessionName(projectName, name)
+		if exists, err := tmux.SessionExists(sessionName); err == nil && exists {
+			if err := tmux.KillSession(sessionName); err != nil {
+				cli.Warning(w, "Failed to kill tmux session: %v", err)
+			} else {
+				cli.Success(w, "Killed tmux session '%s'", sessionName)
+			}
+		}
+	}
+
+	return nil
+}
+
+// firePostRemoveHooks fires user post-remove hooks (hooks.toml) and the
+// plugin post-remove hook for a worktree that was just removed. Kept separate
+// from removeWorktreeWithHooks so `grove rm` can interleave branch deletion
+// before the post-remove hooks, preserving its established ordering.
+func firePostRemoveHooks(ctx *GroveContext, w *cli.Writer, projectName, name, wtPath, branchName string) {
+	hookExecutor, hookErr := hooks.NewExecutor()
+	if hookErr == nil && hookExecutor.HasHooksForEvent(hooks.EventPostRemove) {
+		hookCtx := &hooks.ExecutionContext{
+			Event:    hooks.EventPostRemove,
+			Worktree: name,
+			Branch:   branchName,
+			Project:  projectName,
+			MainPath: ctx.ProjectRoot,
+		}
+		cli.Step(w, "Running post-remove hooks...")
+		if err := hookExecutor.Execute(hooks.EventPostRemove, hookCtx); err != nil {
+			cli.Warning(w, "Post-remove hook had errors: %v", err)
+		}
+	}
+
+	pluginHookCtx := &hooks.Context{
+		Worktree:     name,
+		Config:       ctx.Config,
+		WorktreePath: wtPath,
+		MainPath:     ctx.ProjectRoot,
+	}
+	if err := hooks.Fire(hooks.EventPostRemove, pluginHookCtx); err != nil {
+		cli.Warning(w, "Post-remove plugin hook failed: %v", err)
+	}
 }
 
 // worktreeSetupOpts configures the post-create setup sequence.

--- a/cmd/grove/commands/here.go
+++ b/cmd/grove/commands/here.go
@@ -70,9 +70,9 @@ var hereCmd = &cobra.Command{
 	Short:   "Show current worktree information",
 	Long:    `Display information about the current worktree including name, branch, and status.`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		tree, err := mgr.GetCurrent()

--- a/cmd/grove/commands/here.go
+++ b/cmd/grove/commands/here.go
@@ -75,6 +75,31 @@ var hereCmd = &cobra.Command{
 			return err
 		}
 
+		// Fast paths: --quiet and --check-mount only need the display name,
+		// so skip GetCurrent's commit-info and git-status enrichment (the
+		// same CurrentPath + DisplayNameForPath pattern new.go uses). -q is
+		// the variant scripts and prompts call in a loop.
+		if hereQuiet || hereCheckMount {
+			currentPath, err := mgr.CurrentPath()
+			if err != nil {
+				return fmt.Errorf("failed to get current worktree: %w", err)
+			}
+			displayName := mgr.DisplayNameForPath(currentPath)
+			if displayName == "" {
+				return fmt.Errorf("not in a grove worktree")
+			}
+
+			// --check-mount short-circuits the normal info flow. It's
+			// intended for scripting / pre-test guards: "did I forget to
+			// grove up after switching?" The exit code is the signal.
+			if hereCheckMount {
+				return runMountDriftCheck(ctx, displayName)
+			}
+
+			fmt.Println(displayName)
+			return nil
+		}
+
 		tree, err := mgr.GetCurrent()
 		if err != nil {
 			return fmt.Errorf("failed to get current worktree: %w", err)
@@ -85,21 +110,11 @@ var hereCmd = &cobra.Command{
 
 		displayName := tree.DisplayName()
 
-		// --check-mount short-circuits the normal info flow. It's intended
-		// for scripting / pre-test guards: "did I forget to grove up after
-		// switching?" The exit code is the user-facing signal.
-		if hereCheckMount {
-			return runMountDriftCheck(ctx, tree)
-		}
-
-		// Quiet mode: just print the name
-		if hereQuiet {
-			fmt.Println(displayName)
-			return nil
-		}
-
 		projectName := mgr.GetProjectName()
-		tmuxSessionName := worktree.TmuxSessionName(projectName, tree.ShortName)
+		// Canonical session name comes from DisplayName ("root" maps to the
+		// bare project name) — ShortName is the directory basename for the
+		// main worktree and would name a session that doesn't exist.
+		tmuxSessionName := worktree.TmuxSessionName(projectName, tree.DisplayName())
 		tmuxStatus := tmux.GetSessionStatus(tmuxSessionName)
 
 		// Fallback: check with directory basename

--- a/cmd/grove/commands/here_mount_drift.go
+++ b/cmd/grove/commands/here_mount_drift.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/exitcode"
-	"github.com/lost-in-the/grove/internal/worktree"
 	"github.com/lost-in-the/grove/plugins/docker"
 )
 
@@ -18,7 +17,7 @@ import (
 //
 // Reporter shape is deliberately scriptable: human-readable when running
 // interactively, exit code carries the parity verdict for automation.
-func runMountDriftCheck(ctx *GroveContext, tree *worktree.Worktree) error {
+func runMountDriftCheck(ctx *GroveContext, displayName string) error {
 	w := cli.NewStdout()
 	stderr := cli.NewStderr()
 
@@ -45,7 +44,7 @@ func runMountDriftCheck(ctx *GroveContext, tree *worktree.Worktree) error {
 		os.Exit(exitcode.ExternalCommandFailed)
 	}
 
-	cli.Header(w, "Mount drift — '%s'", tree.DisplayName())
+	cli.Header(w, "Mount drift — '%s'", displayName)
 	cli.Label(w, "Env file:        ", filepath.Join(composePath, driftCfg.EnvFileName))
 	cli.Label(w, "Configured src:  ", displayPath(reports))
 	cli.Label(w, "Mount dest:      ", driftCfg.MountDest)

--- a/cmd/grove/commands/init.go
+++ b/cmd/grove/commands/init.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/grove"
 	"github.com/lost-in-the/grove/internal/state"
+	"github.com/lost-in-the/grove/internal/worktree"
 )
 
 var (
@@ -116,7 +117,7 @@ func runInit() error {
 		generateAndWriteHooks(groveDir, cwd, cli.StdPrompter{})
 	}
 
-	createInitialWorktrees(cwd, projectName)
+	createInitialWorktrees(groveDir, cwd, projectName)
 
 	fmt.Println("")
 	fmt.Println("Next steps:")
@@ -468,7 +469,14 @@ func printHooksSummary(profile *detect.ProjectProfile) {
 	fmt.Printf("\n  Edit hooks: grove config --hooks -e\n")
 }
 
-func createInitialWorktrees(cwd, projectName string) {
+// createInitialWorktrees creates the --with-testing/--with-scratch/--full
+// worktrees through the same path as `grove new`: worktree.Manager.Create
+// (which honors the [naming] pattern instead of hardcoding {project}-{name})
+// followed by setupCreatedWorktree (state registration, config symlink,
+// hooks.toml post_create hooks, docker auto-start). Without this, worktrees
+// grove itself just created weren't registered in state, so entering one and
+// running any grove command reported it as an unrecognized drifted worktree.
+func createInitialWorktrees(groveDir, cwd, projectName string) {
 	if initFull {
 		initWithTesting = true
 		initWithScratch = true
@@ -484,13 +492,38 @@ func createInitialWorktrees(cwd, projectName string) {
 	if initFull {
 		names = append(names, "hotfix")
 	}
+	if len(names) == 0 {
+		return
+	}
+
+	mgr, err := worktree.NewManager(cwd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to initialize worktree manager: %v\n", err)
+		return
+	}
+	stateMgr, err := state.NewManager(groveDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to open state for initial worktrees: %v\n", err)
+		return
+	}
+	cfg, err := config.LoadFromGroveDir(groveDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load config for initial worktrees: %v\n", err)
+		return
+	}
+	ctx := &GroveContext{GroveDir: groveDir, ProjectRoot: cwd, State: stateMgr, Config: cfg}
+	w := cli.NewStdout()
 
 	for _, name := range names {
-		if err := createWorktree(cwd, projectName, name); err != nil {
+		if err := mgr.Create(name, name); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to create %s worktree: %v\n", name, err)
-		} else {
-			fmt.Printf("✓ Created '%s' worktree\n", name)
+			continue
 		}
+		if _, err := setupCreatedWorktree(ctx, mgr, name, name, worktreeSetupOpts{}, w); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to set up %s worktree: %v\n", name, err)
+			continue
+		}
+		fmt.Printf("✓ Created '%s' worktree\n", name)
 	}
 }
 

--- a/cmd/grove/commands/init_test.go
+++ b/cmd/grove/commands/init_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +12,7 @@ import (
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/config"
 	"github.com/lost-in-the/grove/internal/detect"
+	"github.com/lost-in-the/grove/internal/state"
 )
 
 // fakePrompter is a scripted cli.Prompter used by tests that need to drive
@@ -564,3 +567,53 @@ func TestWalkthroughProfile(t *testing.T) {
 
 // Compile-time check that fakePrompter satisfies the cli.Prompter interface.
 var _ cli.Prompter = (*fakePrompter)(nil)
+
+// TestCreateInitialWorktrees_RegistersState verifies that --with-testing
+// worktrees are registered in state (and use the project's naming pattern)
+// instead of being created via a raw `git worktree add` that state never
+// learns about. Previously, entering a grove-init-created worktree and
+// running any grove command reported it as an unrecognized drifted worktree.
+func TestCreateInitialWorktrees_RegistersState(t *testing.T) {
+	dir := t.TempDir()
+	runAdoptGit(t, dir, "init", "-b", "main")
+	runAdoptGit(t, dir, "commit", "--allow-empty", "-m", "init")
+
+	groveDir := filepath.Join(dir, ".grove")
+	if err := os.MkdirAll(groveDir, 0755); err != nil {
+		t.Fatalf("mkdir .grove: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(groveDir, "config.toml"), []byte("project_name = \"proj\"\n"), 0644); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+
+	stateMgr, err := state.NewManager(groveDir)
+	if err != nil {
+		t.Fatalf("state.NewManager: %v", err)
+	}
+	if err := stateMgr.AddWorktree("main", &state.WorktreeState{Path: dir, Branch: "main", Root: true}); err != nil {
+		t.Fatalf("AddWorktree(main): %v", err)
+	}
+
+	origTesting, origScratch, origFull := initWithTesting, initWithScratch, initFull
+	defer func() { initWithTesting, initWithScratch, initFull = origTesting, origScratch, origFull }()
+	initWithTesting, initWithScratch, initFull = true, false, false
+
+	createInitialWorktrees(groveDir, dir, "proj")
+
+	wtPath := filepath.Join(filepath.Dir(dir), "proj-testing")
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected worktree dir %s to exist: %v", wtPath, err)
+	}
+
+	reopened, err := state.NewManager(groveDir)
+	if err != nil {
+		t.Fatalf("reopen state: %v", err)
+	}
+	ws, _ := reopened.GetWorktree("testing")
+	if ws == nil {
+		t.Fatal("expected 'testing' worktree to be registered in state after createInitialWorktrees")
+	}
+	if ws.Branch != "testing" {
+		t.Errorf("branch = %q, want %q", ws.Branch, "testing")
+	}
+}

--- a/cmd/grove/commands/last.go
+++ b/cmd/grove/commands/last.go
@@ -24,9 +24,9 @@ var lastCmd = &cobra.Command{
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		stderr := cli.NewStderr()
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Try to get last worktree from state first (V2 approach)

--- a/cmd/grove/commands/last.go
+++ b/cmd/grove/commands/last.go
@@ -2,13 +2,11 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/lost-in-the/grove/internal/cli"
-	"github.com/lost-in-the/grove/internal/log"
 	"github.com/lost-in-the/grove/internal/output"
 	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/worktree"
@@ -56,47 +54,17 @@ var lastCmd = &cobra.Command{
 			return fmt.Errorf("last worktree '%s' not found", lastWorktree)
 		}
 
-		// Batch the SetLastWorktree + TouchWorktree pair so the state file
-		// is written once instead of twice.
+		// Shared switch epilogue: single batched state save, tmux client
+		// switch (creating the session if it's missing instead of failing
+		// hard), suppressed in agent mode / tmux mode "off".
 		projectName := mgr.GetProjectName()
-		var tmuxSwitched bool
-		if batchErr := ctx.State.Batch(func() error {
-			if currentPath, err := mgr.CurrentPath(); err == nil {
-				prevName := mgr.DisplayNameForPath(currentPath)
-				if prevName != "" {
-					if err := ctx.State.SetLastWorktree(prevName); err != nil {
-						log.Printf("failed to set last worktree %q: %v", prevName, err)
-					}
-				}
-			}
-
-			// Store current session as last if inside tmux
-			if tmux.IsInsideTmux() {
-				currentSession, err := tmux.GetCurrentSession()
-				if err == nil {
-					if err := tmux.StoreLastSession(currentSession); err != nil {
-						log.Printf("failed to store last session %q: %v", currentSession, err)
-					}
-				}
-			}
-
-			// Switch to session
-			if tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
-				sessionName := worktree.TmuxSessionName(projectName, lastWorktree)
-				if err := tmux.SwitchSession(sessionName); err != nil {
-					return fmt.Errorf("failed to switch session: %w", err)
-				}
-				tmuxSwitched = true
-			}
-
-			// Update last_accessed_at for target worktree
-			if err := ctx.State.TouchWorktree(targetTree.DisplayName()); err != nil {
-				log.Printf("failed to touch worktree %q: %v", targetTree.DisplayName(), err)
-			}
-			return nil
-		}); batchErr != nil {
-			return batchErr
+		prevName := ""
+		if currentPath, err := mgr.CurrentPath(); err == nil {
+			prevName = mgr.DisplayNameForPath(currentPath)
 		}
+		suppressTmux := effectiveTmuxMode(ctx.Config.Tmux.Mode, ctx.Config.AgentMode, false, false) == tmuxModeOff
+		sessionName := worktree.TmuxSessionName(projectName, targetTree.DisplayName())
+		tmuxSwitched := switchToWorktree(ctx, stderr, prevName, targetTree.DisplayName(), sessionName, targetTree.Path, suppressTmux)
 
 		// JSON output mode
 		if lastJSON {
@@ -111,20 +79,7 @@ var lastCmd = &cobra.Command{
 
 		// Skip cd directive when tmux switch already moved the user
 		if !tmuxSwitched {
-			hasShellIntegration := os.Getenv("GROVE_SHELL") == "1"
-
-			if hasShellIntegration {
-				cli.Directive("cd", targetTree.Path)
-			} else {
-				cli.Faint(stderr, "Note: Directory switching requires shell integration.")
-				cli.Faint(stderr, "Add this to your shell config (~/.zshrc or ~/.bashrc):")
-				_, _ = fmt.Fprintf(stderr, "\n")
-				cli.Faint(stderr, "  eval \"$(grove install zsh)\"   # for zsh")
-				cli.Faint(stderr, "  eval \"$(grove install bash)\"  # for bash")
-				_, _ = fmt.Fprintf(stderr, "\n")
-				cli.Faint(stderr, "To change directory manually:")
-				cli.Faint(stderr, "  cd %s", targetTree.Path)
-			}
+			emitCdOrExplain(stderr, targetTree.Path)
 		}
 
 		return nil

--- a/cmd/grove/commands/logs.go
+++ b/cmd/grove/commands/logs.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -36,10 +35,12 @@ Examples:
   grove logs -f=false  # Show logs without following
   w logs db            # Using alias`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
-		// Get current directory (docker-compose works in cwd)
-		cwd, err := os.Getwd()
+		// Resolve the worktree root — slot detection keys on the worktree
+		// directory basename, so cwd must be normalized (running from a
+		// subdirectory would otherwise tail the shared stack).
+		root, err := currentWorktreeRoot(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get current directory: %w", err)
+			return err
 		}
 
 		// Get service name if provided
@@ -50,7 +51,7 @@ Examples:
 
 		// Create docker plugin — auto-detect isolated stacks
 		plugin := docker.New()
-		if docker.HasActiveAgentSlot(ctx.Config, cwd) {
+		if docker.HasActiveAgentSlot(ctx.Config, root) {
 			plugin.SetIsolated(true)
 		}
 		if err := plugin.Init(ctx.Config); err != nil {
@@ -58,7 +59,7 @@ Examples:
 		}
 
 		// Show logs
-		if err := plugin.Logs(cwd, service, logsFollow); err != nil {
+		if err := plugin.Logs(root, service, logsFollow); err != nil {
 			return fmt.Errorf("failed to show logs: %w", err)
 		}
 

--- a/cmd/grove/commands/ls.go
+++ b/cmd/grove/commands/ls.go
@@ -59,7 +59,9 @@ var lsCmd = &cobra.Command{
 			return err
 		}
 
-		// Fast paths: quiet and paths modes skip dirty checks entirely
+		// Fast path: quiet mode skips dirty checks entirely. (--paths still
+		// pays for List()'s per-worktree git status; hoisting it needs a
+		// light path listing in internal/worktree.)
 		if lsQuiet {
 			names, err := mgr.ListNames()
 			if err != nil {
@@ -152,21 +154,8 @@ var lsCmd = &cobra.Command{
 				}
 
 				tmuxStatus := tmuxStatusNone
-				if tmuxAvailable && sessions != nil {
-					sessionName := worktree.TmuxSessionName(projectName, tree.DisplayName())
-					if session, ok := sessions[sessionName]; ok {
-						if session.Attached {
-							tmuxStatus = tmuxStatusAttached
-						} else {
-							tmuxStatus = tmuxStatusDetached
-						}
-					} else if session, ok := sessions[tree.Name]; ok {
-						if session.Attached {
-							tmuxStatus = tmuxStatusAttached
-						} else {
-							tmuxStatus = tmuxStatusDetached
-						}
-					}
+				if tmuxAvailable {
+					tmuxStatus = tmuxStatusFor(tree, projectName, sessions)
 				}
 
 				isEnv, _ := ctx.State.IsEnvironment(tree.ShortName)
@@ -184,8 +173,8 @@ var lsCmd = &cobra.Command{
 				}
 
 				if entries, ok := pluginStatuses[tree.Path]; ok {
+					wo.Containers = containersSummary(entries)
 					for _, e := range entries {
-						wo.Containers = e.Short
 						wo.Services = append(wo.Services, lsServiceStatus{
 							Provider: e.ProviderName,
 							Status:   e.Short,
@@ -267,16 +256,7 @@ var lsCmd = &cobra.Command{
 				tmuxStatus = tmuxStatusFor(tree, projectName, sessions)
 			}
 
-			containers := ""
-			if entries, ok := pluginStatuses[tree.Path]; ok {
-				var parts []string
-				for _, e := range entries {
-					if e.Short != "" {
-						parts = append(parts, e.Short)
-					}
-				}
-				containers = strings.Join(parts, ",")
-			}
+			containers := containersSummary(pluginStatuses[tree.Path])
 
 			pathStr := tree.Path
 			if isEnv, _ := ctx.State.IsEnvironment(tree.ShortName); isEnv {
@@ -294,6 +274,19 @@ var lsCmd = &cobra.Command{
 
 		return nil
 	}),
+}
+
+// containersSummary joins each plugin status entry's short status with ","
+// so JSON and table output agree when multiple providers report. Empty
+// shorts are skipped.
+func containersSummary(entries []plugins.StatusEntry) string {
+	var parts []string
+	for _, e := range entries {
+		if e.Short != "" {
+			parts = append(parts, e.Short)
+		}
+	}
+	return strings.Join(parts, ",")
 }
 
 // tmuxStatusFor returns "attached", "detached", or "none" for a worktree.

--- a/cmd/grove/commands/ls.go
+++ b/cmd/grove/commands/ls.go
@@ -54,9 +54,9 @@ var lsCmd = &cobra.Command{
 	Short:   "List all worktrees",
 	Long:    `List all git worktrees with their status (clean/dirty) and branch information.`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Fast paths: quiet and paths modes skip dirty checks entirely

--- a/cmd/grove/commands/ls_test.go
+++ b/cmd/grove/commands/ls_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/plugins"
+)
+
+func TestContainersSummary(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []plugins.StatusEntry
+		want    string
+	}{
+		{
+			name:    "nil entries",
+			entries: nil,
+			want:    "",
+		},
+		{
+			name:    "single entry",
+			entries: []plugins.StatusEntry{{Short: "3 up"}},
+			want:    "3 up",
+		},
+		{
+			name: "multiple entries joined, not overwritten",
+			entries: []plugins.StatusEntry{
+				{Short: "3 up"},
+				{Short: "1 stale"},
+			},
+			want: "3 up,1 stale",
+		},
+		{
+			name: "empty shorts skipped",
+			entries: []plugins.StatusEntry{
+				{Short: "3 up"},
+				{Short: ""},
+			},
+			want: "3 up",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containersSummary(tt.entries); got != tt.want {
+				t.Errorf("containersSummary() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -113,9 +113,9 @@ Examples:
 			dirtyPatch = out
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Quick path-based existence check — avoids List() with N parallel

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/cmdexec"
 	"github.com/lost-in-the/grove/internal/exitcode"
-	"github.com/lost-in-the/grove/internal/log"
 	"github.com/lost-in-the/grove/internal/output"
 	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/worktree"
@@ -267,58 +266,13 @@ Examples:
 			currentWorktreeName = mgr.DisplayNameForPath(currentPath)
 		}
 
-		// Switch to new worktree unless --no-switch.
-		// Batch the SetLastWorktree + TouchWorktree pair so the state file is
-		// flock-merged-renamed once instead of twice.
+		// Switch to new worktree unless --no-switch. Agent mode, --no-tmux,
+		// and tmux mode "off" suppress the client switch (terminal takeover).
 		if !newNoSwitch {
-			var tmuxSwitched bool
-			batchErr := ctx.State.Batch(func() error {
-				if currentWorktreeName != "" {
-					if err := ctx.State.SetLastWorktree(currentWorktreeName); err != nil {
-						log.Printf("failed to set last worktree %q: %v", currentWorktreeName, err)
-					}
-				}
-
-				// Store current session as last if inside tmux
-				if tmux.IsInsideTmux() {
-					currentSession, err := tmux.GetCurrentSession()
-					if err == nil {
-						if err := tmux.StoreLastSession(currentSession); err != nil {
-							log.Printf("failed to store last session %q: %v", currentSession, err)
-						}
-					}
-				}
-
-				// Switch tmux session if inside tmux (skip in agent mode or --no-tmux)
-				if !ctx.Config.AgentMode && !newNoTmux && tmux.IsTmuxAvailable() && tmux.IsInsideTmux() {
-					sessionName := worktree.TmuxSessionName(projectName, name)
-					if err := tmux.SwitchSession(sessionName); err != nil {
-						cli.Warning(w, "Failed to switch session: %v", err)
-					} else {
-						tmuxSwitched = true
-					}
-				}
-
-				// Update last_accessed_at for target worktree
-				if err := ctx.State.TouchWorktree(name); err != nil {
-					log.Printf("failed to touch worktree %q: %v", name, err)
-				}
-				return nil
-			})
-			if batchErr != nil {
-				log.Printf("state save failed: %v", batchErr)
-			}
-
-			// Skip cd directive when tmux switch already moved the user
-			if !tmuxSwitched {
-				hasShellIntegration := os.Getenv("GROVE_SHELL") == "1"
-				if hasShellIntegration {
-					cli.Directive("cd", wt.Path)
-				} else {
-					cli.Info(stderr, "Directory switching requires shell integration.")
-					cli.Faint(stderr, "To change directory manually:")
-					cli.Faint(stderr, "  cd %s", wt.Path)
-				}
+			suppressTmux := effectiveTmuxMode(ctx.Config.Tmux.Mode, ctx.Config.AgentMode, newNoTmux, false) == tmuxModeOff
+			sessionName := worktree.TmuxSessionName(projectName, name)
+			if !switchToWorktree(ctx, stderr, currentWorktreeName, name, sessionName, wt.Path, suppressTmux) {
+				emitCdOrExplain(stderr, wt.Path)
 			}
 		} else {
 			cli.Info(w, "To switch to the new worktree: grove to %s", name)

--- a/cmd/grove/commands/new.go
+++ b/cmd/grove/commands/new.go
@@ -149,11 +149,15 @@ Examples:
 				os.Exit(exitcode.ResourceNotFound)
 			}
 
-			// Use env/{name} as local branch for environment worktrees
+			// Use env/{name} as local branch for environment worktrees. Must
+			// actually create that branch (git worktree add -b) rather than
+			// checking out the remote ref directly — the latter leaves the
+			// worktree on a detached HEAD while state/JSON output/hooks still
+			// report "env/{name}" as the branch, a branch that doesn't exist.
 			branchName = "env/" + name
 
-			// Create worktree from the remote branch
-			if err := mgr.CreateFromBranch(name, mirror); err != nil {
+			// Create worktree with a new local branch tracking the remote ref
+			if err := mgr.CreateFromRef(name, branchName, mirror); err != nil {
 				return fmt.Errorf("failed to create environment worktree: %w", err)
 			}
 

--- a/cmd/grove/commands/open.go
+++ b/cmd/grove/commands/open.go
@@ -119,7 +119,9 @@ Examples:
 				return printOpenJSON(wt, name, created)
 			}
 			cli.Faint(stderr, "tmux not available, skipping session management")
-			cli.Directive("cd", wt.Path)
+			// Only emit the raw cd: protocol line when the shell wrapper is
+			// listening; otherwise explain how to switch manually.
+			emitCdOrExplain(stderr, wt.Path)
 			return nil
 		}
 

--- a/cmd/grove/commands/open.go
+++ b/cmd/grove/commands/open.go
@@ -73,9 +73,9 @@ Examples:
 			return fmt.Errorf("worktree name cannot be empty")
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		projectName := mgr.GetProjectName()

--- a/cmd/grove/commands/rename.go
+++ b/cmd/grove/commands/rename.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/tmux"
+	"github.com/lost-in-the/grove/internal/tui"
 	"github.com/lost-in-the/grove/internal/worktree"
 )
 
@@ -89,7 +90,7 @@ Examples:
 		if currentPath, err := mgr.CurrentPath(); err == nil {
 			currentTree = &worktree.Worktree{Path: currentPath}
 		}
-		if err := validateRename(wt, existing, currentTree, ctx.Config, oldName); err != nil {
+		if err := validateRename(wt, existing, currentTree, ctx.Config, oldName, newName); err != nil {
 			cli.Error(stderr, "%s", err)
 			if err == errCurrentWorktree {
 				cli.Info(stderr, "Switch to another worktree first: grove to <name>")
@@ -154,8 +155,13 @@ var (
 )
 
 // validateRename checks rename preconditions: not main, not protected,
-// not a name collision, and not the current worktree.
-func validateRename(wt, existing, current *worktree.Worktree, cfg interface{ IsProtected(string) bool }, oldName string) error {
+// not a name collision, not the current worktree, and that the new name is
+// a valid worktree name — the same character/prefix check create/fork's TUI
+// overlays enforce (internal/tui.ValidateWorktreeName), which the CLI rename
+// path skipped entirely. Without it, `grove rename x ../escape` or
+// `grove rename x -flag` would reach mgr.Move with an unvalidated path
+// component.
+func validateRename(wt, existing, current *worktree.Worktree, cfg interface{ IsProtected(string) bool }, oldName, newName string) error {
 	if wt.IsMain {
 		return errMainWorktree
 	}
@@ -167,6 +173,9 @@ func validateRename(wt, existing, current *worktree.Worktree, cfg interface{ IsP
 	}
 	if current != nil && current.Path == wt.Path {
 		return errCurrentWorktree
+	}
+	if errMsg := tui.ValidateWorktreeName(newName); errMsg != "" {
+		return fmt.Errorf("invalid new name '%s': %s", newName, errMsg)
 	}
 	return nil
 }

--- a/cmd/grove/commands/rename.go
+++ b/cmd/grove/commands/rename.go
@@ -62,9 +62,9 @@ Examples:
 			return fmt.Errorf("both old and new names are required")
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Find the worktree by old name

--- a/cmd/grove/commands/rename_test.go
+++ b/cmd/grove/commands/rename_test.go
@@ -110,6 +110,7 @@ func TestValidateRename(t *testing.T) {
 		current   *worktree.Worktree
 		cfg       *mockProtection
 		oldName   string
+		newName   string
 		wantErr   bool
 		errSubstr string
 	}{
@@ -119,6 +120,7 @@ func TestValidateRename(t *testing.T) {
 			current: otherWT,
 			cfg:     noCfg,
 			oldName: "feature",
+			newName: "feature-v2",
 			wantErr: false,
 		},
 		{
@@ -127,6 +129,7 @@ func TestValidateRename(t *testing.T) {
 			current:   otherWT,
 			cfg:       noCfg,
 			oldName:   "root",
+			newName:   "renamed",
 			wantErr:   true,
 			errSubstr: "cannot rename the main worktree",
 		},
@@ -136,6 +139,7 @@ func TestValidateRename(t *testing.T) {
 			current:   otherWT,
 			cfg:       &mockProtection{protected: map[string]bool{"feature": true}},
 			oldName:   "feature",
+			newName:   "renamed",
 			wantErr:   true,
 			errSubstr: "protected",
 		},
@@ -146,6 +150,7 @@ func TestValidateRename(t *testing.T) {
 			current:   nil,
 			cfg:       noCfg,
 			oldName:   "feature",
+			newName:   "other",
 			wantErr:   true,
 			errSubstr: "already exists",
 		},
@@ -155,6 +160,7 @@ func TestValidateRename(t *testing.T) {
 			current:   normalWT, // same path = current
 			cfg:       noCfg,
 			oldName:   "feature",
+			newName:   "renamed",
 			wantErr:   true,
 			errSubstr: "cannot rename current worktree",
 		},
@@ -164,6 +170,7 @@ func TestValidateRename(t *testing.T) {
 			current: nil,
 			cfg:     noCfg,
 			oldName: "feature",
+			newName: "renamed",
 			wantErr: false,
 		},
 		{
@@ -172,7 +179,38 @@ func TestValidateRename(t *testing.T) {
 			current: otherWT,
 			cfg:     nil,
 			oldName: "feature",
+			newName: "renamed",
 			wantErr: false,
+		},
+		{
+			name:      "new name with path separator is rejected",
+			wt:        normalWT,
+			current:   otherWT,
+			cfg:       noCfg,
+			oldName:   "feature",
+			newName:   "../escape",
+			wantErr:   true,
+			errSubstr: "invalid new name",
+		},
+		{
+			name:      "new name starting with dash is rejected",
+			wt:        normalWT,
+			current:   otherWT,
+			cfg:       noCfg,
+			oldName:   "feature",
+			newName:   "-flag",
+			wantErr:   true,
+			errSubstr: "invalid new name",
+		},
+		{
+			name:      "new name starting with dot is rejected",
+			wt:        normalWT,
+			current:   otherWT,
+			cfg:       noCfg,
+			oldName:   "feature",
+			newName:   ".hidden",
+			wantErr:   true,
+			errSubstr: "invalid new name",
 		},
 	}
 
@@ -182,7 +220,7 @@ func TestValidateRename(t *testing.T) {
 			if tt.cfg != nil {
 				cfg = tt.cfg
 			}
-			err := validateRename(tt.wt, tt.existing, tt.current, cfg, tt.oldName)
+			err := validateRename(tt.wt, tt.existing, tt.current, cfg, tt.oldName, tt.newName)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error, got nil")

--- a/cmd/grove/commands/repair.go
+++ b/cmd/grove/commands/repair.go
@@ -43,9 +43,9 @@ Examples:
   grove repair           # Detect and fix issues
   grove repair --dry-run # Show what would be fixed without making changes`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		projectName := mgr.GetProjectName()

--- a/cmd/grove/commands/repair.go
+++ b/cmd/grove/commands/repair.go
@@ -146,23 +146,43 @@ Examples:
 			return nil
 		}
 
-		confirmed, err := cli.Confirm("Proceed with repairs?", false)
-		if err != nil || !confirmed {
+		// State repairs (orphan_state/missing_state) are confirmed together — they're
+		// derived from this project's own git worktree list, so low-risk. orphan_tmux
+		// is confirmed per-session below instead: tmux.ListSessions() returns every
+		// session on the server, and the "starts with {project}-" prefix match can't
+		// tell this project's sessions apart from a sibling project whose name shares
+		// the prefix (e.g. "grove" vs "grove-web-checkout"). A single blanket "yes"
+		// must not be enough to kill a live session that may belong to someone else.
+		hasStateIssues := false
+		for _, issue := range issues {
+			if issue.Type == "orphan_state" || issue.Type == "missing_state" {
+				hasStateIssues = true
+				break
+			}
+		}
+
+		confirmedState := false
+		if hasStateIssues {
+			confirmed, err := cli.Confirm("Proceed with state repairs?", false)
 			if err != nil && !errors.Is(err, cli.ErrPromptCanceled) {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 			}
-			fmt.Fprintln(os.Stderr, "Canceled")
-			os.Exit(exitcode.UserCancelled)
+			confirmedState = confirmed
 		}
 
 		// Perform repairs
 		repaired := 0
 		failed := 0
+		skipped := 0
 
 		for i := range issues {
 			issue := &issues[i]
 			switch issue.Type {
 			case "orphan_state":
+				if !confirmedState {
+					skipped++
+					continue
+				}
 				// Extract name from description (hacky but works)
 				name := extractQuotedName(issue.Description)
 				if err := ctx.State.RemoveWorktree(name); err != nil {
@@ -175,6 +195,10 @@ Examples:
 				}
 
 			case "missing_state":
+				if !confirmedState {
+					skipped++
+					continue
+				}
 				// Find the worktree and add it to state
 				name := extractQuotedName(issue.Description)
 				if wt, exists := gitWorktreeByName[name]; exists {
@@ -198,17 +222,37 @@ Examples:
 			case "orphan_tmux":
 				// Extract session name
 				sessionName := extractQuotedName(issue.Description)
-				if sessionName != "" {
-					if err := tmux.KillSession(sessionName); err != nil {
-						fmt.Fprintf(os.Stderr, "  Failed to kill session '%s': %v\n", sessionName, err)
-						failed++
-					} else {
-						fmt.Fprintf(os.Stderr, "  Killed tmux session '%s'\n", sessionName)
-						issue.Resolved = true
-						repaired++
-					}
+				if sessionName == "" {
+					continue
+				}
+				confirmed, err := cli.Confirm(
+					fmt.Sprintf("Kill tmux session '%s'? (may belong to a different project sharing this name prefix)", sessionName),
+					false,
+				)
+				if err != nil && !errors.Is(err, cli.ErrPromptCanceled) {
+					fmt.Fprintf(os.Stderr, "%v\n", err)
+				}
+				if !confirmed {
+					skipped++
+					continue
+				}
+				if err := tmux.KillSession(sessionName); err != nil {
+					fmt.Fprintf(os.Stderr, "  Failed to kill session '%s': %v\n", sessionName, err)
+					failed++
+				} else {
+					fmt.Fprintf(os.Stderr, "  Killed tmux session '%s'\n", sessionName)
+					issue.Resolved = true
+					repaired++
 				}
 			}
+		}
+
+		if repaired == 0 && failed == 0 {
+			fmt.Fprintln(os.Stderr, "Canceled")
+			os.Exit(exitcode.UserCancelled)
+		}
+		if skipped > 0 {
+			fmt.Fprintf(os.Stderr, "%d issue(s) skipped (not confirmed)\n", skipped)
 		}
 
 		fmt.Fprintf(os.Stderr, "\nRepairs complete: %d fixed, %d failed\n", repaired, failed)

--- a/cmd/grove/commands/repair.go
+++ b/cmd/grove/commands/repair.go
@@ -141,7 +141,7 @@ Examples:
 		}
 
 		// Prompt for confirmation
-		if !isInteractive() {
+		if !cli.IsInteractive() {
 			fmt.Fprintln(os.Stderr, "Non-interactive mode: use --dry-run to preview or run interactively to repair")
 			return nil
 		}

--- a/cmd/grove/commands/repair_test.go
+++ b/cmd/grove/commands/repair_test.go
@@ -1,0 +1,24 @@
+package commands
+
+import "testing"
+
+func TestExtractQuotedName(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want string
+	}{
+		{name: "state entry", desc: "State entry 'feature-x' points to missing directory: /tmp/x", want: "feature-x"},
+		{name: "tmux session", desc: "Tmux session 'grove-web-checkout' has no corresponding worktree", want: "grove-web-checkout"},
+		{name: "no quotes", desc: "no quoted name here", want: ""},
+		{name: "single quote only", desc: "only one 'quote here", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractQuotedName(tt.desc); got != tt.want {
+				t.Errorf("extractQuotedName(%q) = %q, want %q", tt.desc, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/grove/commands/restart.go
+++ b/cmd/grove/commands/restart.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -32,10 +31,12 @@ Examples:
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
 		w := cli.NewStdout()
 
-		// Get current directory (docker-compose works in cwd)
-		cwd, err := os.Getwd()
+		// Resolve the worktree root — slot detection keys on the worktree
+		// directory basename, so cwd must be normalized (running from a
+		// subdirectory would otherwise restart the shared stack).
+		root, err := currentWorktreeRoot(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get current directory: %w", err)
+			return err
 		}
 
 		// Get service name if provided
@@ -46,7 +47,7 @@ Examples:
 
 		// Create docker plugin — auto-detect isolated stacks
 		plugin := docker.New()
-		if docker.HasActiveAgentSlot(ctx.Config, cwd) {
+		if docker.HasActiveAgentSlot(ctx.Config, root) {
 			plugin.SetIsolated(true)
 		}
 		if err := plugin.Init(ctx.Config); err != nil {
@@ -60,7 +61,7 @@ Examples:
 		} else {
 			cli.Step(stderr, "Restarting containers...")
 		}
-		if err := plugin.Restart(cwd, service); err != nil {
+		if err := plugin.Restart(root, service); err != nil {
 			return fmt.Errorf("failed to restart: %w", err)
 		}
 

--- a/cmd/grove/commands/rm.go
+++ b/cmd/grove/commands/rm.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -11,7 +10,6 @@ import (
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/git"
-	"github.com/lost-in-the/grove/internal/hooks"
 	"github.com/lost-in-the/grove/internal/tmux"
 	"github.com/lost-in-the/grove/internal/worktree"
 )
@@ -187,58 +185,10 @@ Examples:
 			branchName = wt.Branch
 		}
 
-		// Execute pre-remove hooks (user hooks from hooks.toml)
-		hookExecutor, hookErr := hooks.NewExecutor()
-		if hookErr == nil && hookExecutor.HasHooksForEvent(hooks.EventPreRemove) {
-			hookCtx := &hooks.ExecutionContext{
-				Event:        hooks.EventPreRemove,
-				Worktree:     name,
-				Branch:       branchName,
-				Project:      projectName,
-				MainPath:     ctx.ProjectRoot,
-				NewPath:      wt.Path,
-				WorktreeFull: filepath.Base(wt.Path),
-			}
-			cli.Step(w, "Running pre-remove hooks...")
-			if err := hookExecutor.Execute(hooks.EventPreRemove, hookCtx); err != nil {
-				cli.Warning(w, "Hook execution had errors: %v", err)
-			}
-		}
-
-		// Fire plugin pre-remove hook (e.g., stop agent stacks)
-		pluginHookCtx := &hooks.Context{
-			Worktree:     name,
-			Config:       cfg,
-			WorktreePath: wt.Path,
-			MainPath:     ctx.ProjectRoot,
-		}
-		if err := hooks.Fire(hooks.EventPreRemove, pluginHookCtx); err != nil {
-			cli.Warning(w, "Pre-remove plugin hook failed: %v", err)
-		}
-
-		// Remove worktree — the critical step, done before tmux kill
-		if err := mgr.Remove(name); err != nil {
-			return fmt.Errorf("failed to remove worktree: %w", err)
-		}
-
-		// Remove from state
-		if err := ctx.State.RemoveWorktree(name); err != nil {
-			cli.Warning(w, "worktree removed but state cleanup failed: %v", err)
-		}
-
-		cli.Success(w, "Removed worktree '%s'", name)
-
-		// Kill tmux session after worktree is confirmed gone
-		if tmux.IsTmuxAvailable() {
-			sessionName := worktree.TmuxSessionName(projectName, name)
-			exists, err := tmux.SessionExists(sessionName)
-			if err == nil && exists {
-				if err := tmux.KillSession(sessionName); err != nil {
-					cli.Warning(w, "Failed to kill tmux session: %v", err)
-				} else {
-					cli.Success(w, "Killed tmux session '%s'", sessionName)
-				}
-			}
+		// Shared removal sequence: pre-remove hooks, git removal, state
+		// cleanup, tmux session kill (also used by `grove trim`).
+		if err := removeWorktreeWithHooks(ctx, mgr, w, projectName, name, wt.Path, branchName); err != nil {
+			return err
 		}
 
 		// Handle branch deletion
@@ -248,25 +198,8 @@ Examples:
 			}
 		}
 
-		// Execute post-remove hooks (user hooks from hooks.toml)
-		if hookErr == nil && hookExecutor.HasHooksForEvent(hooks.EventPostRemove) {
-			hookCtx := &hooks.ExecutionContext{
-				Event:    hooks.EventPostRemove,
-				Worktree: name,
-				Branch:   branchName,
-				Project:  projectName,
-				MainPath: ctx.ProjectRoot,
-			}
-			cli.Step(w, "Running post-remove hooks...")
-			if err := hookExecutor.Execute(hooks.EventPostRemove, hookCtx); err != nil {
-				cli.Warning(w, "Post-remove hook had errors: %v", err)
-			}
-		}
-
-		// Fire plugin post-remove hook
-		if err := hooks.Fire(hooks.EventPostRemove, pluginHookCtx); err != nil {
-			cli.Warning(w, "Post-remove plugin hook failed: %v", err)
-		}
+		// User + plugin post-remove hooks
+		firePostRemoveHooks(ctx, w, projectName, name, wt.Path, branchName)
 
 		return nil
 	}),

--- a/cmd/grove/commands/rm.go
+++ b/cmd/grove/commands/rm.go
@@ -62,9 +62,9 @@ Examples:
 			return fmt.Errorf("worktree name cannot be empty")
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Find worktree early — all checks reuse this

--- a/cmd/grove/commands/rm.go
+++ b/cmd/grove/commands/rm.go
@@ -75,6 +75,14 @@ Examples:
 			os.Exit(exitcode.ResourceNotFound)
 		}
 
+		// Find matches by short name, display name, branch, or path basename,
+		// so the argument the user typed (e.g. a branch name that differs
+		// from the worktree's directory name) isn't necessarily the name
+		// state and tmux sessions are keyed under. Use the resolved short
+		// name for state/tmux operations from here on; user-facing messages
+		// keep echoing the argument as typed.
+		resolvedName := wt.ShortName
+
 		// When selected interactively, confirm before proceeding
 		if len(args) == 0 {
 			details := []string{
@@ -105,7 +113,7 @@ Examples:
 		cfg := ctx.Config
 		isProtectedByConfig := cfg != nil && cfg.IsProtected(name)
 		isEnvironment := false
-		ws, _ := ctx.State.GetWorktree(name)
+		ws, _ := ctx.State.GetWorktree(resolvedName)
 		if ws != nil {
 			isEnvironment = ws.Environment
 		}
@@ -168,7 +176,7 @@ Examples:
 				}
 			}
 			if tmux.IsTmuxAvailable() {
-				sessionName := worktree.TmuxSessionName(mgr.GetProjectName(), name)
+				sessionName := worktree.TmuxSessionName(mgr.GetProjectName(), resolvedName)
 				exists, _ := tmux.SessionExists(sessionName)
 				if exists {
 					cli.Faint(w, "  Would kill tmux session: %s", sessionName)
@@ -187,7 +195,7 @@ Examples:
 
 		// Shared removal sequence: pre-remove hooks, git removal, state
 		// cleanup, tmux session kill (also used by `grove trim`).
-		if err := removeWorktreeWithHooks(ctx, mgr, w, projectName, name, wt.Path, branchName); err != nil {
+		if err := removeWorktreeWithHooks(ctx, mgr, w, projectName, resolvedName, wt.Path, branchName); err != nil {
 			return err
 		}
 
@@ -199,7 +207,7 @@ Examples:
 		}
 
 		// User + plugin post-remove hooks
-		firePostRemoveHooks(ctx, w, projectName, name, wt.Path, branchName)
+		firePostRemoveHooks(ctx, w, projectName, resolvedName, wt.Path, branchName)
 
 		return nil
 	}),

--- a/cmd/grove/commands/rm.go
+++ b/cmd/grove/commands/rm.go
@@ -111,7 +111,7 @@ Examples:
 
 		// Check protection status
 		cfg := ctx.Config
-		isProtectedByConfig := cfg != nil && cfg.IsProtected(name)
+		isProtectedByConfig := cfg != nil && (cfg.IsProtected(resolvedName) || cfg.IsProtected(name))
 		isEnvironment := false
 		ws, _ := ctx.State.GetWorktree(resolvedName)
 		if ws != nil {

--- a/cmd/grove/commands/select_worktree.go
+++ b/cmd/grove/commands/select_worktree.go
@@ -12,9 +12,9 @@ import (
 // In interactive mode, shows a formatted numbered list and prompts for selection.
 // In non-interactive mode, returns an error listing available worktrees.
 func selectWorktree(ctx *GroveContext, prompt string) (string, error) {
-	mgr, err := worktree.NewManager(ctx.ProjectRoot)
+	mgr, err := ctx.WorktreeManager()
 	if err != nil {
-		return "", fmt.Errorf("failed to initialize worktree manager: %w", err)
+		return "", err
 	}
 
 	trees, err := mgr.List()

--- a/cmd/grove/commands/sync.go
+++ b/cmd/grove/commands/sync.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lost-in-the/grove/internal/exitcode"
 	"github.com/lost-in-the/grove/internal/log"
 	"github.com/lost-in-the/grove/internal/output"
-	"github.com/lost-in-the/grove/internal/worktree"
 )
 
 var (
@@ -64,9 +63,9 @@ Examples:
 		w := cli.NewStdout()
 		stderr := cli.NewStderr()
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		var targets []string

--- a/cmd/grove/commands/test.go
+++ b/cmd/grove/commands/test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lost-in-the/grove/internal/config"
-	"github.com/lost-in-the/grove/internal/worktree"
 	"github.com/lost-in-the/grove/plugins/docker"
 )
 
@@ -55,9 +54,9 @@ Extra arguments are appended to the configured command:
 			return fmt.Errorf("no test command configured\n\nAdd a [test] section to .grove/config.toml:\n\n  [test]\n  command = \"bin/rails test\"")
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		targetTree, err := mgr.Find(name)

--- a/cmd/grove/commands/to.go
+++ b/cmd/grove/commands/to.go
@@ -317,7 +317,7 @@ func handleDirectoryDrift(sessionName, worktreePath, onSwitch string, stderr *cl
 }
 
 // shellSingleQuote wraps s in single quotes for safe interpolation into a
-// POSIX shell command line, escaping embedded single quotes with '\''.
+// POSIX shell command line, escaping embedded single quotes with '\”.
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/cmd/grove/commands/to.go
+++ b/cmd/grove/commands/to.go
@@ -57,9 +57,9 @@ When using shell integration, this will also change your current directory.`,
 			return fmt.Errorf("worktree name cannot be empty")
 		}
 
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		// Find worktree by short name or full name

--- a/cmd/grove/commands/to.go
+++ b/cmd/grove/commands/to.go
@@ -306,12 +306,20 @@ func handleDirectoryDrift(sessionName, worktreePath, onSwitch string, stderr *cl
 	case "ignore":
 		// Do nothing
 	default: // "reset" or ""
-		// Use single quotes for shell safety — path cannot contain single quotes
-		// (git worktree paths are derived from branch names which disallow them)
-		if err := tmux.SendKeys(sessionName, "cd '"+worktreePath+"'"); err != nil {
+		// Single-quote for shell safety. The path derives from the repo's
+		// parent directory plus the naming pattern (and externally created
+		// worktrees can live anywhere), so it may legally contain single
+		// quotes — escape them with the standard '\'' idiom.
+		if err := tmux.SendKeys(sessionName, "cd "+shellSingleQuote(worktreePath)); err != nil {
 			log.Printf("failed to reset directory in session %q: %v", sessionName, err)
 		}
 	}
+}
+
+// shellSingleQuote wraps s in single quotes for safe interpolation into a
+// POSIX shell command line, escaping embedded single quotes with '\''.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func init() {

--- a/cmd/grove/commands/to.go
+++ b/cmd/grove/commands/to.go
@@ -248,24 +248,13 @@ When using shell integration, this will also change your current directory.`,
 		// target session — emitting cd: here would change the OLD session's
 		// directory, not the one the user is now viewing.
 		if !tmuxSwitched {
-			if hasShellIntegration {
-				// Shell wrapper will parse this and execute cd
-				cli.Directive("cd", targetTree.Path)
-				// In auto mode outside tmux, emit tmux-attach directive for shell wrapper
-				if tmuxMode == tmuxModeAuto && sessionName != "" {
+			emitCdOrExplain(stderr, targetTree.Path)
+			// In auto mode outside tmux: emit the tmux-attach directive for
+			// the shell wrapper, or attach directly without it.
+			if tmuxMode == tmuxModeAuto && sessionName != "" {
+				if hasShellIntegration {
 					cli.TmuxAttachDirective(sessionName, useCC)
-				}
-			} else {
-				cli.Faint(stderr, "Note: Directory switching requires shell integration.")
-				cli.Faint(stderr, "Add this to your shell config (~/.zshrc or ~/.bashrc):")
-				_, _ = fmt.Fprintf(stderr, "\n")
-				cli.Faint(stderr, "  eval \"$(grove install zsh)\"   # for zsh")
-				cli.Faint(stderr, "  eval \"$(grove install bash)\"  # for bash")
-				_, _ = fmt.Fprintf(stderr, "\n")
-				cli.Faint(stderr, "To change directory manually:")
-				cli.Faint(stderr, "  cd %s", targetTree.Path)
-				// In auto mode outside tmux without shell wrapper, attach directly
-				if tmuxMode == tmuxModeAuto && sessionName != "" {
+				} else {
 					var attachErr error
 					if useCC {
 						attachErr = tmux.AttachSessionControlMode(sessionName)

--- a/cmd/grove/commands/to_test.go
+++ b/cmd/grove/commands/to_test.go
@@ -31,3 +31,23 @@ func TestEffectiveTmuxMode(t *testing.T) {
 		})
 	}
 }
+
+func TestShellSingleQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain path", in: "/Users/dev/proj-fix", want: "'/Users/dev/proj-fix'"},
+		{name: "embedded single quote", in: "/Users/leah/Leah's Projects/app-fix", want: `'/Users/leah/Leah'\''s Projects/app-fix'`},
+		{name: "empty string", in: "", want: "''"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shellSingleQuote(tt.in); got != tt.want {
+				t.Errorf("shellSingleQuote(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/grove/commands/to_test.go
+++ b/cmd/grove/commands/to_test.go
@@ -39,7 +39,7 @@ func TestShellSingleQuote(t *testing.T) {
 		want string
 	}{
 		{name: "plain path", in: "/Users/dev/proj-fix", want: "'/Users/dev/proj-fix'"},
-		{name: "embedded single quote", in: "/Users/leah/Leah's Projects/app-fix", want: `'/Users/leah/Leah'\''s Projects/app-fix'`},
+		{name: "embedded single quote", in: "/Users/dev/Dev's Projects/app-fix", want: `'/Users/dev/Dev'\''s Projects/app-fix'`},
 		{name: "empty string", in: "", want: "''"},
 	}
 

--- a/cmd/grove/commands/up.go
+++ b/cmd/grove/commands/up.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -43,10 +42,13 @@ Examples:
 		w := cli.NewStdout()
 		stderr := cli.NewStderr()
 
-		// Get current directory (docker-compose works in cwd)
-		cwd, err := os.Getwd()
+		// Resolve the worktree root — isolated slot allocation keys on the
+		// worktree directory basename, so cwd must be normalized (running
+		// from a subdirectory would otherwise register a slot under the
+		// subdirectory's name, which later lookups would never match).
+		root, err := currentWorktreeRoot(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get current directory: %w", err)
+			return err
 		}
 
 		// Create docker plugin
@@ -65,7 +67,7 @@ Examples:
 		// Start containers — no spinner here: docker compose writes its own
 		// progress to stderr, and wrapping it in Bubbletea causes flashing.
 		cli.Step(stderr, "Starting containers...")
-		if err := plugin.Up(cwd, upDetach); err != nil {
+		if err := plugin.Up(root, upDetach); err != nil {
 			return fmt.Errorf("failed to start containers: %w", err)
 		}
 		if upDetach && !upIsolated {

--- a/cmd/grove/commands/which.go
+++ b/cmd/grove/commands/which.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/lost-in-the/grove/internal/cli"
 	"github.com/lost-in-the/grove/internal/output"
-	"github.com/lost-in-the/grove/internal/worktree"
 	"github.com/lost-in-the/grove/plugins/docker"
 )
 
@@ -37,9 +36,9 @@ Examples:
   grove which -j     # JSON output for scripts
   grove status       # Alias`,
 	RunE: RequireGroveContext(func(cmd *cobra.Command, args []string, ctx *GroveContext) error {
-		mgr, err := worktree.NewManager(ctx.ProjectRoot)
+		mgr, err := ctx.WorktreeManager()
 		if err != nil {
-			return fmt.Errorf("failed to initialize worktree manager: %w", err)
+			return err
 		}
 
 		tree, err := mgr.GetCurrent()

--- a/tests/integration/fork_json_test.go
+++ b/tests/integration/fork_json_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+// End-to-end coverage for `grove fork --json` keeping its stdout limited to
+// a single parseable JSON object (see commit 12d6574, "fix(fork): keep
+// --json output parseable").
+package integration_test
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/testhelper"
+)
+
+// TestForkJSON_ValidJSONOutput verifies that `grove fork <name> --json`
+// against a clean worktree produces stdout that is exactly one JSON object
+// (no human-readable success/info lines mixed in before it).
+func TestForkJSON_ValidJSONOutput(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	repo := testhelper.SetupRailsFixture(t)
+
+	cmd := exec.Command(binary, "fork", "json-fork", "--json", "--no-switch")
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("grove fork --json failed: %v\nstderr: %s\nstdout: %s", err, ee.Stderr, out)
+		}
+		t.Fatalf("grove fork --json failed: %v\nstdout: %s", err, out)
+	}
+
+	var result struct {
+		Name    string `json:"name"`
+		Branch  string `json:"branch"`
+		Path    string `json:"path"`
+		Parent  string `json:"parent"`
+		Created bool   `json:"created"`
+	}
+
+	// Decode exactly one JSON value, then confirm nothing but whitespace
+	// follows — this is what would fail if a human-readable warning/success
+	// line leaked onto stdout ahead of (or after) the JSON object.
+	dec := json.NewDecoder(strings.NewReader(string(out)))
+	if err := dec.Decode(&result); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout: %s", err, out)
+	}
+	if dec.More() {
+		t.Fatalf("stdout contains extra content after the JSON object:\nstdout: %s", out)
+	}
+
+	if result.Name != "json-fork" {
+		t.Errorf("result.Name = %q, want %q", result.Name, "json-fork")
+	}
+	if !result.Created {
+		t.Error("result.Created = false, want true")
+	}
+	if !filepath.IsAbs(result.Path) {
+		t.Errorf("result.Path %q is not absolute", result.Path)
+	}
+}

--- a/tests/integration/rm_protection_test.go
+++ b/tests/integration/rm_protection_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+// End-to-end coverage for `grove rm` protection when the worktree is
+// removed by a name that differs from the one listed in
+// [protection].protected.
+//
+// mgr.Find resolves a worktree by short name, display name, branch name, or
+// path basename — so a worktree whose directory is named "foo" but whose
+// branch is "bar" can be targeted as either `grove rm foo` or `grove rm bar`.
+// [protection].protected is configured against the worktree's short name
+// ("foo"); removal must be blocked regardless of which name the user types.
+package integration_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lost-in-the/grove/internal/testhelper"
+)
+
+func TestRmProtection_BlocksRemovalByBranchName(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	repo := testhelper.SetupRailsFixture(t)
+
+	// Worktree short name "foo", branch "bar" — deliberately divergent so
+	// `grove rm bar` exercises the Find-resolved-name path.
+	wtPath := filepath.Join(filepath.Dir(repo), "rails-app-foo")
+	testhelper.RunGit(t, repo, "worktree", "add", "-b", "bar", wtPath)
+
+	// Protect the worktree under its short name ("foo"), not its branch name.
+	testhelper.WriteFile(t, filepath.Join(repo, ".grove", "config.toml"), `project_name = "rails-app"
+
+[plugins.docker]
+enabled = true
+auto_start = false
+auto_stop = false
+
+[protection]
+protected = ["foo"]
+`)
+
+	// Attempt removal by branch name, without --force/--unprotect.
+	cmd := exec.Command(binary, "rm", "bar")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Fatalf("expected `grove rm bar` to fail for a config-protected worktree, but it succeeded: %s", out)
+	}
+
+	if !strings.Contains(string(out), "protected") {
+		t.Errorf("expected output to mention protection, got: %s", out)
+	}
+
+	if _, statErr := exec.Command("git", "-C", repo, "worktree", "list").CombinedOutput(); statErr != nil {
+		t.Fatalf("git worktree list failed: %v", statErr)
+	}
+	listOut, _ := exec.Command("git", "-C", repo, "worktree", "list").CombinedOutput()
+	if !strings.Contains(string(listOut), wtPath) {
+		t.Errorf("worktree %s should not have been removed:\n%s", wtPath, listOut)
+	}
+}
+
+// TestRmProtection_AllowsRemovalByBranchNameWithForceUnprotect verifies the
+// escape hatch still works when targeting the worktree by branch name.
+func TestRmProtection_AllowsRemovalByBranchNameWithForceUnprotect(t *testing.T) {
+	binary := buildGroveBinary(t)
+
+	repo := testhelper.SetupRailsFixture(t)
+
+	wtPath := filepath.Join(filepath.Dir(repo), "rails-app-foo")
+	testhelper.RunGit(t, repo, "worktree", "add", "-b", "bar", wtPath)
+
+	testhelper.WriteFile(t, filepath.Join(repo, ".grove", "config.toml"), `project_name = "rails-app"
+
+[plugins.docker]
+enabled = true
+auto_start = false
+auto_stop = false
+
+[protection]
+protected = ["foo"]
+`)
+
+	cmd := exec.Command(binary, "rm", "bar", "--force", "--unprotect", "--keep-branch")
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("grove rm bar --force --unprotect failed: %v\noutput: %s", err, out)
+	}
+
+	listOut, _ := exec.Command("git", "-C", repo, "worktree", "list").CombinedOutput()
+	if strings.Contains(string(listOut), wtPath) {
+		t.Errorf("worktree %s should have been removed:\n%s", wtPath, listOut)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the verified command-layer findings from the repo audit (#112, #113, #114) plus the command-side parts of #116 and #120. 19 commits, each scoped to one fix. Highlights:

- **fetch bootstrap** (#112): worktrees created via `grove fetch` (and the `prs`/`issues` CLI path) now run the full bootstrap — config symlink, state registration, hooks, docker — instead of a bare `git worktree add`.
- **Command bugs** (#113): `grove last` no longer hard-fails when the target's tmux session is gone (creates/switches instead); `down`/`logs`/`restart`/`up` resolve the worktree root via git instead of guessing from cwd basename; `config --global` shows actual global values instead of mislabeled merged config; `adopt` rejects repos that aren't worktrees of the current project; `here` uses the canonical root session name and gets fast paths for `-q`/`--check-mount`; `ls --json` aggregates multi-provider container statuses instead of keeping the last; `new --mirror` actually creates the documented `env/{name}` branch; `open` no longer leaks a raw `cd:` directive without shell integration; `to`'s drift-reset cd escapes single-quoted paths.
- **DRY drift** (#114): the triplicated 50-line switch-to-worktree epilogue in `new`/`fork`/`last` is unified (agent-mode guard now consistent); `fork --json` output is parseable (human chatter moved off stdout, WIP warning to stderr); `fork`'s weaker private `isInteractive` replaced with the shared TTY check; `trim` now fires the same pre/post-remove hooks as `rm` (docker teardown included); `init` routes `--with-testing`/`--with-scratch`/`--full` through the shared creation path so the naming pattern, state, and hooks apply; `worktree.Manager` construction centralized on GroveContext.
- **Inherited from other branches' reviews** (#116): `rm` resolves the worktree via `Find` before state/tmux cleanup and checks `[protection]` against the resolved name too — previously a config-protected worktree could dodge protection when addressed by branch name; `rename` now validates the new name with the same rules as create/fork; `repair` confirms each orphan tmux session kill individually instead of killing prefix-matched sessions in bulk.

Closes #112. Closes #113. Closes #114. Refs #116, #120.

Known gaps left deliberately (from review, all pre-existing or judgment calls): `adopt` still accepts a subdirectory of a legitimate worktree; recreating an env worktree after `grove rm` (without `--delete-branch`) errors because the `env/{name}` branch survives; `repair`'s exit code can read as user-cancel when a missing-state entry matches nothing; fork's WIP-prompt TTY path has no pty test harness. The optional `clean` exec-batching perf item was not taken (needs the internal/git batch API threaded through).

## Type of Change

- [x] Bug fix
- [x] Refactoring (no functional change)

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter is clean (`make lint`)
- [x] Documentation updated (if applicable — see CONTRIBUTING.md)
- [x] Commit messages follow conventional commits (`type(scope): description`)
