### PR TITLE
fix: release-pipeline robustness (flaky tui test + re-runnable Homebrew job)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Homebrew tap update runs as its own job so it can be re-run in isolation
+  # (e.g. after rotating TAP_GITHUB_TOKEN) without re-running GoReleaser, which
+  # fails with "asset already_exists" once a tag has been released. It depends
+  # only on the release existing and the source tarball (not GoReleaser's
+  # artifacts), so `needs: goreleaser` is purely an ordering/success gate.
+  homebrew:
+    name: Update Homebrew formula
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Update Homebrew formula
         env:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/internal/tui/overlay_create_v2_test.go
+++ b/internal/tui/overlay_create_v2_test.go
@@ -337,6 +337,20 @@ func TestCreateWorktreeCmd_RemoteBranch_UsesCreateFromBranch(t *testing.T) {
 	default:
 		t.Fatalf("unexpected message type %T: %v", msg, msg)
 	}
+
+	// streamingCreateCmd runs createFn (the actual `git worktree add`) in a
+	// background goroutine and returns after the first log line. Drain the
+	// remaining events until the done message so that goroutine's git writes
+	// complete before t.TempDir() cleanup runs — otherwise an in-flight
+	// worktree add races RemoveAll on .git and CI flakes with
+	// "directory not empty".
+	for {
+		lm, ok := msg.(creationLogMsg)
+		if !ok {
+			break // creationDoneMsg — the creation goroutine has finished
+		}
+		msg = readCreationLog(lm.ch, "create")()
+	}
 }
 
 // createStateWithName creates a CreateState at the name step with a pre-set name.


### PR DESCRIPTION
## Summary

Release-pipeline robustness follow-ups — both issues bit the v0.8.0 release.

### 1. Fix flaky `internal/tui` test (`test(tui)`)
`TestCreateWorktreeCmd_RemoteBranch_UsesCreateFromBranch` read only the **first** message from `streamingCreateCmd`, which runs `createFn` (the real `git worktree add`) in a **background goroutine**. The test returned while that goroutine was still writing to `.git`, racing `t.TempDir()` cleanup — intermittently failing CI with:

```
testing.go:1369: TempDir RemoveAll cleanup: unlinkat .../001/.git: directory not empty
```

This failed the PR CI and the release run (needing manual re-runs both times). Fix: drain the creation events to the done message so the goroutine's git work completes before cleanup. Verified with `go test -race -count=1` ×5.

### 2. Make the Homebrew tap update re-runnable (`ci(release)`)
The formula update ran as the last **step** of the `goreleaser` job. When it failed (v0.8.0 hit an expired `TAP_GITHUB_TOKEN` → HTTP 401), the only retry was re-running goreleaser — which then failed with `asset already_exists` on the already-published tag, so the tap step was never reachable (I had to update the tap by hand).

Split it into a separate `homebrew` job (`needs: goreleaser`) that depends only on the release + source tarball. Now the tap update can be re-run in isolation after rotating the token, without re-running goreleaser.

## Testing
- `gofmt -s` clean, `make lint` 0 issues, `go vet`, full `go test ./...` (21 pkgs) pass.
- Flaky test passes 5× under `-race -count=1`.
- `release.yml` YAML validated; jobs = `goreleaser` → `homebrew (needs: goreleaser)`.

## Note
The `homebrew` job's script is unchanged and injection-safe (uses the `$GITHUB_REF_NAME` shell env and `TAP_GITHUB_TOKEN` via `env:`, no untrusted `${{ }}` interpolation in `run:`).
